### PR TITLE
Update/25 request history UI api

### DIFF
--- a/app/src/main/java/com/example/rentit/feature/product/ProductViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/product/ProductViewModel.kt
@@ -45,18 +45,18 @@ class ProductViewModel @Inject constructor(
         RequestInfoDto(
             reservationId = 1002,
             renterNickName = "눈송",
-            startDate = "2025-07-01",
+            startDate = "2025-07-04",
             endDate = "2025-07-05",
             status = "PENDING",
             requestedAt = LocalDateTime.of(2025, 4, 10, 10, 30, 0).format(formatter)
         ),
         RequestInfoDto(
-            reservationId = 1003,
+            reservationId = 21,
             renterNickName = "눈송",
-            startDate = "2025-06-10",
-            endDate = "2025-06-12",
+            startDate = "2025-06-27",
+            endDate = "2025-07-03",
             status = "PENDING",
-            requestedAt = LocalDateTime.of(2025, 4, 25, 16, 15, 0).format(formatter)
+            requestedAt = LocalDateTime.of(2025, 6, 25, 16, 15, 0).format(formatter)
         ),
     )
 

--- a/app/src/main/java/com/example/rentit/feature/user/RequestHistoryScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/RequestHistoryScreen.kt
@@ -2,16 +2,21 @@ package com.example.rentit.feature.user
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.data.product.dto.RequestPeriodDto
 import com.example.rentit.feature.product.ProductViewModel
@@ -35,10 +40,12 @@ fun RequestHistoryScreen(navHostController: NavHostController, productViewModel:
             modifier = Modifier.padding(it)
         ) {
             RequestCheckCalendar(requestPeriodList)
-            LazyColumn {
+            LazyColumn(modifier = Modifier.screenHorizontalPadding(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                item { Spacer(Modifier.size(2.dp)) }
                 items(sampleRequestHistory) { info ->
-                    RequestHistoryListItem(requestInfo = info)
+                    RequestHistoryListItem(requestInfo = info) {}
                 }
+                item { Spacer(Modifier.size(50.dp)) }
             }
         }
     }

--- a/app/src/main/java/com/example/rentit/feature/user/RequestHistoryScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/RequestHistoryScreen.kt
@@ -11,27 +11,42 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.example.rentit.common.component.CommonTopAppBar
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.data.product.dto.RequestInfoDto
 import com.example.rentit.data.product.dto.RequestPeriodDto
 import com.example.rentit.feature.product.ProductViewModel
 import com.example.rentit.feature.user.component.RequestCheckCalendar
 import com.example.rentit.feature.user.component.RequestHistoryListItem
 import java.time.LocalDate
+import java.time.YearMonth
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun RequestHistoryScreen(navHostController: NavHostController, productViewModel: ProductViewModel) {
     //val requestHistory by productViewModel.requestList.collectAsStateWithLifecycle()
+    var yearMonth by remember { mutableStateOf(YearMonth.now()) }
     val sampleRequestHistory = productViewModel.sampleReservationsList
 
-    val requestPeriodList: List<RequestPeriodDto> = sampleRequestHistory.map { RequestPeriodDto(
-        LocalDate.parse(it.startDate), LocalDate.parse(it.endDate)) }
+    val requestPeriodList: List<RequestPeriodDto> = sampleRequestHistory.map {
+        RequestPeriodDto(
+            LocalDate.parse(it.startDate), LocalDate.parse(it.endDate)
+        )
+    }
+
+    val groupedByMonth: Map<YearMonth, List<RequestInfoDto>> = sampleRequestHistory.groupBy {
+        YearMonth.from(LocalDate.parse(it.startDate))
+    }
 
     Scaffold(
         topBar = { CommonTopAppBar(title = "요청 내역", onClick = {}) }
@@ -39,10 +54,13 @@ fun RequestHistoryScreen(navHostController: NavHostController, productViewModel:
         Column(
             modifier = Modifier.padding(it)
         ) {
-            RequestCheckCalendar(requestPeriodList)
-            LazyColumn(modifier = Modifier.screenHorizontalPadding(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            RequestCheckCalendar(requestPeriodList) { month -> yearMonth = month }
+            LazyColumn(
+                modifier = Modifier.screenHorizontalPadding(),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
                 item { Spacer(Modifier.size(2.dp)) }
-                items(sampleRequestHistory) { info ->
+                items(groupedByMonth[yearMonth] ?: emptyList()) { info ->
                     RequestHistoryListItem(requestInfo = info) {}
                 }
                 item { Spacer(Modifier.size(50.dp)) }

--- a/app/src/main/java/com/example/rentit/feature/user/component/RequestCheckCalendar.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/component/RequestCheckCalendar.kt
@@ -26,7 +26,7 @@ fun RequestCheckCalendar(requestPeriodList: List<RequestPeriodDto>) {
 
     fun changeMonth(monthsToAdd: Long) { yearMonth.value = yearMonth.value.plusMonths(monthsToAdd) }
 
-    Column(modifier = Modifier.padding(bottom = 32.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
         CalendarHeader(yearMonth.value, { changeMonth(-1) }, { changeMonth(1) })
         DayOfWeek(cellWidth)
         CalendarDate(

--- a/app/src/main/java/com/example/rentit/feature/user/component/RequestCheckCalendar.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/component/RequestCheckCalendar.kt
@@ -3,12 +3,12 @@ package com.example.rentit.feature.user.component
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.rentit.common.component.calendar.CalendarDate
@@ -20,17 +20,20 @@ import java.time.YearMonth
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RequestCheckCalendar(requestPeriodList: List<RequestPeriodDto>) {
-    val yearMonth = remember { mutableStateOf(YearMonth.now()) }
+fun RequestCheckCalendar(requestPeriodList: List<RequestPeriodDto>, onChangeMonth: (month: YearMonth) -> Unit = {}) {
+    var yearMonth by remember { mutableStateOf(YearMonth.now()) }
     val cellWidth = 48.dp
 
-    fun changeMonth(monthsToAdd: Long) { yearMonth.value = yearMonth.value.plusMonths(monthsToAdd) }
+    fun changeMonth(monthsToAdd: Long) {
+        yearMonth = yearMonth.plusMonths(monthsToAdd)
+        onChangeMonth(yearMonth)
+    }
 
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        CalendarHeader(yearMonth.value, { changeMonth(-1) }, { changeMonth(1) })
+        CalendarHeader(yearMonth, { changeMonth(-1) }, { changeMonth(1) })
         DayOfWeek(cellWidth)
         CalendarDate(
-            yearMonth = yearMonth.value,
+            yearMonth = yearMonth,
             disabledDates = emptyList(),
             cellWidth = cellWidth,
             isPastDateDisabled = true,

--- a/app/src/main/java/com/example/rentit/feature/user/component/RequestHistoryListItem.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/component/RequestHistoryListItem.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.rentit.R
 import com.example.rentit.common.component.getKorDayOfWeek
+import com.example.rentit.common.theme.AppBlack
+import com.example.rentit.common.theme.Gray300
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
@@ -45,6 +47,9 @@ fun RequestHistoryListItem(requestInfo: RequestInfoDto, onStartChatClick: () -> 
     val endDate = LocalDate.parse(requestInfo.endDate)
     val period = ChronoUnit.DAYS.between(startDate, endDate).toInt() + 1
 
+    val isPast = startDate.isBefore(LocalDate.now())
+    val pastDateColor = Gray300
+
     Card(
         modifier = Modifier
             .fillMaxWidth(),
@@ -63,12 +68,13 @@ fun RequestHistoryListItem(requestInfo: RequestInfoDto, onStartChatClick: () -> 
                 Text(
                     modifier = Modifier.padding(end = 8.dp),
                     text = requestInfo.renterNickName,
-                    style = MaterialTheme.typography.labelMedium
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (isPast) pastDateColor else AppBlack
                 )
                 Text(
                     text = "${requestedAt.format(formatter)} ${getKorDayOfWeek(requestedAt.dayOfWeek.toString())}",
                     style = MaterialTheme.typography.labelMedium,
-                    color = Gray400
+                    color = if (isPast) pastDateColor else Gray400
                 )
             }
             Row(
@@ -85,9 +91,14 @@ fun RequestHistoryListItem(requestInfo: RequestInfoDto, onStartChatClick: () -> 
                         getKorDayOfWeek(endDate.dayOfWeek.toString()),
                         period
                     ),
-                    style = MaterialTheme.typography.labelLarge
+                    style = MaterialTheme.typography.labelLarge,
+                    color = if (isPast) pastDateColor else AppBlack
                 )
-                TextButton(modifier = Modifier.padding(start = 20.dp), onClick = onStartChatClick) {
+                TextButton(
+                    modifier = Modifier.padding(start = 20.dp),
+                    onClick = onStartChatClick,
+                    enabled = !isPast
+                ) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -95,14 +106,14 @@ fun RequestHistoryListItem(requestInfo: RequestInfoDto, onStartChatClick: () -> 
                             modifier = Modifier.padding(end = 4.dp),
                             text = stringResource(id = R.string.request_history_list_item_text_chat),
                             style = MaterialTheme.typography.labelLarge,
-                            color = PrimaryBlue500
+                            color = if (isPast) pastDateColor else PrimaryBlue500
                         )
                         Icon(
                             painter = painterResource(id = R.drawable.ic_chevron_right),
                             contentDescription = stringResource(
                                 id = R.string.content_description_for_ic_chevron_right
                             ),
-                            tint = PrimaryBlue500
+                            tint = if (isPast) pastDateColor else PrimaryBlue500
                         )
                     }
                 }

--- a/app/src/main/java/com/example/rentit/feature/user/component/RequestHistoryListItem.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/component/RequestHistoryListItem.kt
@@ -2,24 +2,28 @@ package com.example.rentit.feature.user.component
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.rentit.R
-import com.example.rentit.common.component.basicListItemTopDivider
 import com.example.rentit.common.component.getKorDayOfWeek
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.PrimaryBlue500
@@ -32,7 +36,8 @@ import java.time.temporal.ChronoUnit
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RequestHistoryListItem(requestInfo: RequestInfoDto) {
+fun RequestHistoryListItem(requestInfo: RequestInfoDto, onStartChatClick: () -> Unit) {
+
     val formatter = DateTimeFormatter.ofPattern("yy.MM.dd")
 
     val requestedAt = LocalDateTime.parse(requestInfo.requestedAt).toLocalDate()
@@ -40,67 +45,77 @@ fun RequestHistoryListItem(requestInfo: RequestInfoDto) {
     val endDate = LocalDate.parse(requestInfo.endDate)
     val period = ChronoUnit.DAYS.between(startDate, endDate).toInt() + 1
 
-    Column(
+    Card(
         modifier = Modifier
-            .fillMaxWidth()
-            .basicListItemTopDivider()
-            .padding(vertical = 26.dp, horizontal = 30.dp)
+            .fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 2.dp
+        ),
+        shape = RoundedCornerShape(25.dp)
     ) {
-        Row(modifier = Modifier.padding(bottom = 12.dp), verticalAlignment = Alignment.Bottom) {
-            Text(
-                modifier = Modifier.padding(end = 8.dp),
-                text = requestInfo.renterNickName,
-                style = MaterialTheme.typography.labelMedium
-            )
-            Text(
-                text = "${requestedAt.format(formatter)} ${getKorDayOfWeek(requestedAt.dayOfWeek.toString())}",
-                style = MaterialTheme.typography.labelMedium,
-                color = Gray400
-            )
-        }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(start = 30.dp, end = 18.dp, top = 26.dp, bottom = 10.dp)
         ) {
-            Text(
-                text = stringResource(
-                    id = R.string.request_history_list_item_period,
-                    startDate.format(formatter),
-                    getKorDayOfWeek(startDate.dayOfWeek.toString()),
-                    endDate.format(formatter),
-                    getKorDayOfWeek(endDate.dayOfWeek.toString()),
-                    period
-                ),
-                style = MaterialTheme.typography.bodyLarge
-            )
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(
+                    modifier = Modifier.padding(end = 8.dp),
+                    text = requestInfo.renterNickName,
+                    style = MaterialTheme.typography.labelMedium
+                )
+                Text(
+                    text = "${requestedAt.format(formatter)} ${getKorDayOfWeek(requestedAt.dayOfWeek.toString())}",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = Gray400
+                )
+            }
             Row(
-                modifier = Modifier.padding(start = 20.dp),
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    modifier = Modifier.padding(end = 4.dp),
-                    text = stringResource(id = R.string.request_history_list_item_text_chat),
-                    style = MaterialTheme.typography.labelLarge,
-                    color = PrimaryBlue500
-                )
-                Icon(
-                    modifier = Modifier.size(10.dp),
-                    painter = painterResource(id = R.drawable.ic_chevron_right),
-                    contentDescription = stringResource(
-                        id = R.string.content_description_for_ic_chevron_right
+                    text = stringResource(
+                        id = R.string.request_history_list_item_period,
+                        startDate.format(formatter),
+                        getKorDayOfWeek(startDate.dayOfWeek.toString()),
+                        endDate.format(formatter),
+                        getKorDayOfWeek(endDate.dayOfWeek.toString()),
+                        period
                     ),
-                    tint = PrimaryBlue500
+                    style = MaterialTheme.typography.labelLarge
                 )
+                TextButton(modifier = Modifier.padding(start = 20.dp), onClick = onStartChatClick) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            modifier = Modifier.padding(end = 4.dp),
+                            text = stringResource(id = R.string.request_history_list_item_text_chat),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = PrimaryBlue500
+                        )
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chevron_right),
+                            contentDescription = stringResource(
+                                id = R.string.content_description_for_ic_chevron_right
+                            ),
+                            tint = PrimaryBlue500
+                        )
+                    }
+                }
             }
         }
     }
 }
 
-@Preview(showBackground = true)
+@RequiresApi(Build.VERSION_CODES.O)
+@Preview
 @Composable
 fun PreviewRequestHistoryListItem() {
     RentItTheme {
-        // RequestHistoryListItem()
+        //RequestHistoryListItem() {}
     }
 }


### PR DESCRIPTION
# Pull Request

## Summary  
- 요청 내역 화면 UI 수정
- 요청 리스트 출력 개선

## Related Issue  
- Close: #25 

## Changes  
- `RequestHistoryListItem` 컴포넌트 UI 수정
- 요청 리스트에서 과거 요청 비활성화
- 요청 리스트 월별 그룹핑 및 출력

## Screenshots
<img src="https://github.com/user-attachments/assets/8e43ac25-d0de-43ab-8af6-0b242232eb5d" width="30%"/>


## Notes  
- 요청 리스트 조회에 관해 서버 수정이 필요하여 임시로 더미 데이터를 연결함
