### PR TITLE
Feature/32 chatroom prepare and load

### DIFF
--- a/app/src/main/java/com/example/rentit/common/di/ApiModule.kt
+++ b/app/src/main/java/com/example/rentit/common/di/ApiModule.kt
@@ -1,5 +1,6 @@
 package com.example.rentit.common.di
 
+import com.example.rentit.data.chat.remote.ChatApiService
 import com.example.rentit.data.product.remote.ProductApiService
 import com.example.rentit.data.user.remote.UserApiService
 import dagger.Module
@@ -11,6 +12,11 @@ import retrofit2.Retrofit
 @Module
 @InstallIn(SingletonComponent::class)
 object ApiModule {
+    @Provides
+    fun provideChatApiService(retrofit: Retrofit): ChatApiService {
+        return retrofit.create(ChatApiService::class.java)
+    }
+
     @Provides
     fun provideUserApiService(retrofit: Retrofit): UserApiService {
         return retrofit.create(UserApiService::class.java)

--- a/app/src/main/java/com/example/rentit/common/exception/ServerException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/ServerException.kt
@@ -1,3 +1,3 @@
-package com.example.rentit.common.exception.chat
+package com.example.rentit.common.exception
 
 class ServerException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/common/exception/chat/ChatRoomAlreadyExistsException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/chat/ChatRoomAlreadyExistsException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.common.exception.chat
+
+class ChatRoomAlreadyExistsException: Exception()

--- a/app/src/main/java/com/example/rentit/common/exception/chat/ForbiddenChatAccessException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/chat/ForbiddenChatAccessException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.common.exception.chat
+
+class ForbiddenChatAccessException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/common/exception/chat/ServerException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/chat/ServerException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.common.exception.chat
+
+class ServerException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/common/exception/product/ReservationByOwnerException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/product/ReservationByOwnerException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.common.exception.product
+
+class ReservationByOwnerException(): Exception()

--- a/app/src/main/java/com/example/rentit/data/chat/dto/ChatListResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/dto/ChatListResponseDto.kt
@@ -2,9 +2,9 @@ package com.example.rentit.data.chat.dto
 
 import com.google.gson.annotations.SerializedName
 
-data class ChatRoomListResponseDto(
+data class ChatListResponseDto(
     @SerializedName("chatrooms")
-    val chatrooms: List<ChatRoomDataDto>,
+    val chatRooms: List<ChatRoomSummaryDto>,
 
     @SerializedName("hasNext")
     val hasNext: Boolean,
@@ -13,9 +13,9 @@ data class ChatRoomListResponseDto(
     val totalPage: Int
 )
 
-data class ChatRoomDataDto(
+data class ChatRoomSummaryDto(
     @SerializedName("chatroomId")
-    val chatroomId: String,
+    val chatRoomId: String,
 
     @SerializedName("productTitle")
     val productTitle: String,
@@ -27,5 +27,5 @@ data class ChatRoomDataDto(
     val lastMessage: String,
 
     @SerializedName("lastMessageTime")
-    val lastMessageTime: String,
+    val lastMessageTime: String?,
 )

--- a/app/src/main/java/com/example/rentit/data/chat/dto/NewChatResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/dto/NewChatResponseDto.kt
@@ -1,0 +1,24 @@
+package com.example.rentit.data.chat.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class NewChatResponseDto(
+    @SerializedName("data")
+    val data: ChatRoomInfoDto,
+)
+
+data class ChatRoomInfoDto(
+    @SerializedName("chatroomId")
+    val chatRoomId: String,
+
+    @SerializedName("participants")
+    val participants: List<ChatParticipantInfoDto>
+)
+
+data class ChatParticipantInfoDto(
+    @SerializedName("userId")
+    val userId: Int,
+
+    @SerializedName("nickname")
+    val nickname: String
+)

--- a/app/src/main/java/com/example/rentit/data/chat/remote/ChatApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/remote/ChatApiService.kt
@@ -1,12 +1,18 @@
 package com.example.rentit.data.chat.remote
 
+import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Headers
+import retrofit2.http.Path
 
 interface ChatApiService {
     @GET("api/v1/chatrooms")
     @Headers("Content-Type: application/json")
     suspend fun getChatList(): Response<ChatListResponseDto>
+
+    @GET("api/v1/chatrooms/{chatroomId}/chats")
+    @Headers("Content-Type: application/json")
+    suspend fun getChatDetail(@Path("chatroomId") chatRoomId: String): Response<ChatDetailResponseDto>
 }

--- a/app/src/main/java/com/example/rentit/data/chat/remote/ChatApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/remote/ChatApiService.kt
@@ -8,6 +8,7 @@ import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface ChatApiService {
     @GET("api/v1/chatrooms")
@@ -16,7 +17,11 @@ interface ChatApiService {
 
     @GET("api/v1/chatrooms/{chatroomId}/chats")
     @Headers("Content-Type: application/json")
-    suspend fun getChatDetail(@Path("chatroomId") chatRoomId: String): Response<ChatDetailResponseDto>
+    suspend fun getChatDetail(
+        @Path("chatroomId") chatRoomId: String,
+        @Query("skip") skip: Int,
+        @Query("size") size: Int
+    ): Response<ChatDetailResponseDto>
 
     @POST("api/v1/products/{productId}/reservations/chatrooms")
     @Headers("Content-Type: application/json")

--- a/app/src/main/java/com/example/rentit/data/chat/remote/ChatApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/remote/ChatApiService.kt
@@ -1,0 +1,12 @@
+package com.example.rentit.data.chat.remote
+
+import com.example.rentit.data.chat.dto.ChatListResponseDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Headers
+
+interface ChatApiService {
+    @GET("api/v1/chatrooms")
+    @Headers("Content-Type: application/json")
+    suspend fun getChatList(): Response<ChatListResponseDto>
+}

--- a/app/src/main/java/com/example/rentit/data/chat/remote/ChatApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/remote/ChatApiService.kt
@@ -2,9 +2,11 @@ package com.example.rentit.data.chat.remote
 
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
+import com.example.rentit.data.chat.dto.NewChatResponseDto
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Headers
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface ChatApiService {
@@ -15,4 +17,8 @@ interface ChatApiService {
     @GET("api/v1/chatrooms/{chatroomId}/chats")
     @Headers("Content-Type: application/json")
     suspend fun getChatDetail(@Path("chatroomId") chatRoomId: String): Response<ChatDetailResponseDto>
+
+    @POST("api/v1/products/{productId}/reservations/chatrooms")
+    @Headers("Content-Type: application/json")
+    suspend fun postNewChat(@Path("productId") productId: Int): Response<NewChatResponseDto>
 }

--- a/app/src/main/java/com/example/rentit/data/chat/remote/ChatRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/remote/ChatRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package com.example.rentit.data.chat.remote
 
+import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
 import retrofit2.Response
 import javax.inject.Inject
@@ -9,5 +10,8 @@ class ChatRemoteDataSource @Inject constructor(
 ){
     suspend fun getChatList(): Response<ChatListResponseDto> {
         return chatApiService.getChatList()
+    }
+    suspend fun getChatDetail(chatRoomId: String): Response<ChatDetailResponseDto> {
+        return chatApiService.getChatDetail(chatRoomId)
     }
 }

--- a/app/src/main/java/com/example/rentit/data/chat/remote/ChatRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/remote/ChatRemoteDataSource.kt
@@ -1,0 +1,13 @@
+package com.example.rentit.data.chat.remote
+
+import com.example.rentit.data.chat.dto.ChatListResponseDto
+import retrofit2.Response
+import javax.inject.Inject
+
+class ChatRemoteDataSource @Inject constructor(
+    private val chatApiService: ChatApiService
+){
+    suspend fun getChatList(): Response<ChatListResponseDto> {
+        return chatApiService.getChatList()
+    }
+}

--- a/app/src/main/java/com/example/rentit/data/chat/remote/ChatRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/remote/ChatRemoteDataSource.kt
@@ -2,6 +2,7 @@ package com.example.rentit.data.chat.remote
 
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
+import com.example.rentit.data.chat.dto.NewChatResponseDto
 import retrofit2.Response
 import javax.inject.Inject
 
@@ -13,5 +14,8 @@ class ChatRemoteDataSource @Inject constructor(
     }
     suspend fun getChatDetail(chatRoomId: String): Response<ChatDetailResponseDto> {
         return chatApiService.getChatDetail(chatRoomId)
+    }
+    suspend fun postNewChat(productId: Int): Response<NewChatResponseDto> {
+        return chatApiService.postNewChat(productId)
     }
 }

--- a/app/src/main/java/com/example/rentit/data/chat/remote/ChatRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/remote/ChatRemoteDataSource.kt
@@ -12,8 +12,8 @@ class ChatRemoteDataSource @Inject constructor(
     suspend fun getChatList(): Response<ChatListResponseDto> {
         return chatApiService.getChatList()
     }
-    suspend fun getChatDetail(chatRoomId: String): Response<ChatDetailResponseDto> {
-        return chatApiService.getChatDetail(chatRoomId)
+    suspend fun getChatDetail(chatRoomId: String, skip: Int, size: Int): Response<ChatDetailResponseDto> {
+        return chatApiService.getChatDetail(chatRoomId, skip, size)
     }
     suspend fun postNewChat(productId: Int): Response<NewChatResponseDto> {
         return chatApiService.postNewChat(productId)

--- a/app/src/main/java/com/example/rentit/data/chat/repository/ChatRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/repository/ChatRepository.kt
@@ -1,0 +1,29 @@
+package com.example.rentit.data.chat.repository
+
+import android.util.Log
+import com.example.rentit.data.chat.dto.ChatListResponseDto
+import com.example.rentit.data.chat.remote.ChatRemoteDataSource
+import javax.inject.Inject
+
+private const val TAG = "ChatRepository"
+
+class ChatRepository @Inject constructor(
+    private val chatRemoteDataSource: ChatRemoteDataSource,
+) {
+    suspend fun getChatList(): Result<ChatListResponseDto> {
+        return runCatching {
+            val response = chatRemoteDataSource.getChatList()
+            when (response.code()) {
+                200 -> response.body() ?: throw Exception("Empty response body")
+                500 -> {
+                    Log.e(TAG, "Server error 500: ${response.errorBody()?.string()}")
+                    throw Exception("Server error")
+                }
+                else -> {
+                    Log.e(TAG, "Unexpected error: code=${response.code()}, ${response.errorBody()?.string()}")
+                    throw Exception("Unexpected error")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/data/chat/repository/ChatRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/repository/ChatRepository.kt
@@ -33,9 +33,9 @@ class ChatRepository @Inject constructor(
         }
     }
 
-    suspend fun getChatDetail(chatRoomMessageId: String): Result<ChatDetailResponseDto> {
+    suspend fun getChatDetail(chatRoomMessageId: String, skip: Int, size: Int): Result<ChatDetailResponseDto> {
         return runCatching {
-            val response = chatRemoteDataSource.getChatDetail(chatRoomMessageId)
+            val response = chatRemoteDataSource.getChatDetail(chatRoomMessageId, skip, size)
             when (response.code()) {
                 200 -> response.body() ?: throw Exception("Empty response body")
                 403 -> {

--- a/app/src/main/java/com/example/rentit/data/chat/repository/ChatRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/repository/ChatRepository.kt
@@ -2,9 +2,12 @@ package com.example.rentit.data.chat.repository
 
 import android.util.Log
 import com.example.rentit.common.exception.chat.ForbiddenChatAccessException
-import com.example.rentit.common.exception.chat.ServerException
+import com.example.rentit.common.exception.ServerException
+import com.example.rentit.common.exception.chat.ChatRoomAlreadyExistsException
+import com.example.rentit.common.exception.product.ReservationByOwnerException
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
+import com.example.rentit.data.chat.dto.NewChatResponseDto
 import com.example.rentit.data.chat.remote.ChatRemoteDataSource
 import javax.inject.Inject
 
@@ -37,7 +40,7 @@ class ChatRepository @Inject constructor(
                 200 -> response.body() ?: throw Exception("Empty response body")
                 403 -> {
                     Log.e(TAG, "Server error 403: ${response.errorBody()?.string()}")
-                    throw ForbiddenChatAccessException("Server error")
+                    throw ForbiddenChatAccessException()
                 }
                 500 -> {
                     Log.e(TAG, "Server error 500: ${response.errorBody()?.string()}")
@@ -51,5 +54,28 @@ class ChatRepository @Inject constructor(
         }
     }
 
-
+    suspend fun postNewChat(productId: Int): Result<NewChatResponseDto> {
+        return runCatching {
+            val response = chatRemoteDataSource.postNewChat(productId)
+            when (response.code()) {
+                200 -> response.body() ?: throw Exception("Empty response body")
+                403 -> {
+                    Log.e(TAG, "Server error 403: ${response.errorBody()?.string()}")
+                    throw ReservationByOwnerException()
+                }
+                409 -> {
+                    Log.e(TAG, "Server error 409: ${response.errorBody()?.string()}")
+                    throw ChatRoomAlreadyExistsException()
+                }
+                500 -> {
+                    Log.e(TAG, "Server error 500: ${response.errorBody()?.string()}")
+                    throw ServerException("Server error")
+                }
+                else -> {
+                    Log.e(TAG, "Unexpected error: code=${response.code()}, ${response.errorBody()?.string()}")
+                    throw Exception("Unexpected error")
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/rentit/data/chat/repository/ChatRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/repository/ChatRepository.kt
@@ -1,6 +1,9 @@
 package com.example.rentit.data.chat.repository
 
 import android.util.Log
+import com.example.rentit.common.exception.chat.ForbiddenChatAccessException
+import com.example.rentit.common.exception.chat.ServerException
+import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
 import com.example.rentit.data.chat.remote.ChatRemoteDataSource
 import javax.inject.Inject
@@ -26,4 +29,27 @@ class ChatRepository @Inject constructor(
             }
         }
     }
+
+    suspend fun getChatDetail(chatRoomMessageId: String): Result<ChatDetailResponseDto> {
+        return runCatching {
+            val response = chatRemoteDataSource.getChatDetail(chatRoomMessageId)
+            when (response.code()) {
+                200 -> response.body() ?: throw Exception("Empty response body")
+                403 -> {
+                    Log.e(TAG, "Server error 403: ${response.errorBody()?.string()}")
+                    throw ForbiddenChatAccessException("Server error")
+                }
+                500 -> {
+                    Log.e(TAG, "Server error 500: ${response.errorBody()?.string()}")
+                    throw ServerException("Server error")
+                }
+                else -> {
+                    Log.e(TAG, "Unexpected error: code=${response.code()}, ${response.errorBody()?.string()}")
+                    throw Exception("Unexpected error")
+                }
+            }
+        }
+    }
+
+
 }

--- a/app/src/main/java/com/example/rentit/data/product/dto/RequestHistoryResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/product/dto/RequestHistoryResponseDto.kt
@@ -25,4 +25,7 @@ data class RequestInfoDto(
 
     @SerializedName("requestedAt")
     val requestedAt: String,
+
+    @SerializedName("chatroomId")
+    val chatRoomId: String?,
 )

--- a/app/src/main/java/com/example/rentit/feature/MainView.kt
+++ b/app/src/main/java/com/example/rentit/feature/MainView.kt
@@ -120,10 +120,23 @@ fun TabNavHost(navHostController: NavHostController, paddingValues: PaddingValue
         composable(BottomNavItem.Home.screenRoute) { HomeScreen(navHostController) }
         composable(BottomNavItem.Chat.screenRoute) { ChatListScreen(navHostController) }
         composable(BottomNavItem.MyPage.screenRoute) { MyPageScreen(navHostController) }
-        composable(NavigationRoutes.NAVHOSTPRODUCTDETAIL+"/{productId}", arguments = listOf(navArgument("productId") { type = NavType.IntType })) { backStackEntry ->
+        composable(
+            route = NavigationRoutes.NAVHOSTPRODUCTDETAIL+"/{productId}",
+            arguments = listOf(navArgument("productId") { type = NavType.IntType })
+        ) { backStackEntry ->
             val productId = backStackEntry.arguments?.getInt("productId")
-            ProductDetailNavHost(productId) }
-        composable(NavigationRoutes.NAVHOSTCHAT) { ChatroomNavHost() }
+            ProductDetailNavHost(productId)
+        }
+        composable(
+            route = NavigationRoutes.NAVHOSTCHAT + "/{productId}/{chatRoomId}",
+            arguments = listOf(
+                navArgument("productId") { type = NavType.IntType },
+                navArgument("chatRoomId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val pId = backStackEntry.arguments?.getInt("productId")
+            val cId = backStackEntry.arguments?.getString("chatRoomId")
+            ChatroomNavHost(pId, cId)
+        }
         composable(NavigationRoutes.CREATEPOST) { CreatePostNavHost() }
     }
 }
@@ -145,17 +158,26 @@ fun ProductDetailNavHost(productId: Int?) {
         composable(NavigationRoutes.BOOKINGREQUEST) { BookingRequestScreen(navHostController, productViewModel) }
         composable(NavigationRoutes.REQUESTCONFIRM) { RequestConfirmationScreen(navHostController, productViewModel) }
         composable(NavigationRoutes.REQUESTHISTORY) { RequestHistoryScreen(navHostController, productViewModel) }
-        composable(NavigationRoutes.NAVHOSTCHAT) { ChatroomNavHost() }
+        composable(
+            route = NavigationRoutes.NAVHOSTCHAT + "/{productId}/{chatRoomId}",
+            arguments = listOf(
+                navArgument("productId") { type = NavType.IntType },
+                navArgument("chatRoomId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val pId = backStackEntry.arguments?.getInt("productId")
+            val cId = backStackEntry.arguments?.getString("chatRoomId")
+            ChatroomNavHost(pId, cId)
+        }
         composable(NavigationRoutes.MAIN) { MainView() }
     }
 }
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun ChatroomNavHost() {
+fun ChatroomNavHost(productId: Int?, chatRoomId: String?) {
     val navHostController: NavHostController = rememberNavController()
     NavHost(navController =  navHostController, startDestination = NavigationRoutes.CHATROOM){
-        composable(NavigationRoutes.CHATROOM) { ChatroomScreen(navHostController) }
+        composable(NavigationRoutes.CHATROOM) { ChatroomScreen(navHostController, productId, chatRoomId) }
         composable(NavigationRoutes.ACCEPTCONFIRM) { AcceptConfirmationScreen(navHostController) }
         composable(NavigationRoutes.MAIN) { MainView() }
     }

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
@@ -1,6 +1,7 @@
 package com.example.rentit.feature.chat
 
 import android.os.Build
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -9,13 +10,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.example.rentit.R
@@ -29,9 +36,26 @@ import com.example.rentit.feature.chat.component.ChatListItem
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun ChatListScreen(navHostController: NavHostController) {
-    Column(Modifier
-        .fillMaxSize()
-        .padding(top = 45.dp)) {
+    val chatViewModel: ChatViewModel = hiltViewModel()
+    val chatList by chatViewModel.chatList.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    // 최초 한 번만 호출
+    LaunchedEffect(Unit) {
+        chatViewModel.getChatList {
+            Toast.makeText(
+                context,
+                context.getString(R.string.error_chat_list_load),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .padding(top = 45.dp)
+    ) {
         Column(
             modifier = Modifier
                 .screenHorizontalPadding()
@@ -39,7 +63,11 @@ fun ChatListScreen(navHostController: NavHostController) {
             TopSection()
             OrderButtonSection()
         }
-        ChatListSection { moveScreen(navHostController, NavigationRoutes.NAVHOSTCHAT) }
+        LazyColumn {
+            items(chatList) {
+                ChatListItem(it) { moveScreen(navHostController, NavigationRoutes.NAVHOSTCHAT) }
+            }
+        }
     }
 }
 
@@ -62,16 +90,6 @@ fun OrderButtonSection() {
         horizontalArrangement = Arrangement.End
     ) {
         FilterButton(stringResource(R.string.screen_chat_list_btn_up_to_date_order)) {}
-    }
-}
-
-@RequiresApi(Build.VERSION_CODES.O)
-@Composable
-fun ChatListSection(onClick: () -> Unit) {
-    LazyColumn {
-        items(5) {
-            ChatListItem { onClick() }
-        }
     }
 }
 

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
@@ -65,7 +65,12 @@ fun ChatListScreen(navHostController: NavHostController) {
         }
         LazyColumn {
             items(chatList) {
-                ChatListItem(it) { moveScreen(navHostController, NavigationRoutes.NAVHOSTCHAT) }
+                ChatListItem(it) {
+                    moveScreen(
+                        navHostController,
+                        "${NavigationRoutes.NAVHOSTCHAT}/0/${it.chatRoomId}"
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
@@ -68,7 +68,7 @@ fun ChatListScreen(navHostController: NavHostController) {
                 ChatListItem(it) {
                     moveScreen(
                         navHostController,
-                        "${NavigationRoutes.NAVHOSTCHAT}/0/${it.chatRoomId}"
+                        "${NavigationRoutes.NAVHOSTCHAT}/8/${it.chatRoomId}"    // 임시 ProductId
                     )
                 }
             }

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
@@ -1,18 +1,30 @@
 package com.example.rentit.feature.chat
 
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.rentit.R
 import com.example.rentit.data.chat.dto.ChangedByDto
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatMessageDto
 import com.example.rentit.data.chat.dto.ChatParticipantDto
 import com.example.rentit.data.chat.dto.ChatRoomDetailDto
+import com.example.rentit.data.chat.dto.ChatRoomSummaryDto
 import com.example.rentit.data.chat.dto.SenderDto
 import com.example.rentit.data.chat.dto.StatusHistoryDto
+import com.example.rentit.data.chat.repository.ChatRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ChatViewModel @Inject constructor(
+    private val chatRepository: ChatRepository
 ) : ViewModel() {
     val exampleChatDetailResponse = ChatDetailResponseDto(
         chatRoom = ChatRoomDetailDto(
@@ -85,5 +97,18 @@ class ChatViewModel @Inject constructor(
         hasNext = false,
         totalPage = 2
     )
+
+    private val _chatList = MutableStateFlow<List<ChatRoomSummaryDto>>(emptyList())
+    val chatList: StateFlow<List<ChatRoomSummaryDto>> = _chatList
+
+    fun getChatList(onError: (Throwable) -> Unit = {}) {
+        viewModelScope.launch {
+            chatRepository.getChatList()
+                .onSuccess {
+                    _chatList.value = it.chatRooms
+                }
+                .onFailure(onError)
+        }
+    }
 
 }

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
@@ -2,15 +2,11 @@ package com.example.rentit.feature.chat
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.data.chat.dto.ChangedByDto
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
-import com.example.rentit.data.chat.dto.ChatMessageDto
-import com.example.rentit.data.chat.dto.ChatParticipantDto
-import com.example.rentit.data.chat.dto.ChatRoomDetailDto
 import com.example.rentit.data.chat.dto.ChatRoomSummaryDto
-import com.example.rentit.data.chat.dto.SenderDto
-import com.example.rentit.data.chat.dto.StatusHistoryDto
 import com.example.rentit.data.chat.repository.ChatRepository
+import com.example.rentit.data.product.dto.ProductDetailResponseDto
+import com.example.rentit.data.product.repository.ProductRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -19,82 +15,15 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ChatViewModel @Inject constructor(
-    private val chatRepository: ChatRepository
+    private val chatRepository: ChatRepository,
+    private val productRepository: ProductRepository
 ) : ViewModel() {
-    val exampleChatDetailResponse = ChatDetailResponseDto(
-        chatRoom = ChatRoomDetailDto(
-            chatroomId = "room_1234567890",
-            participants = listOf(
-                ChatParticipantDto(
-                    userId = "user_abc",
-                    nickname = "김숙명",
-                    role = "buyer",
-                    profileImageUrl = "https://cdn.example.com/user_abc.png"
-                ),
-                ChatParticipantDto(
-                    userId = "user_xyz",
-                    nickname = "홍길동",
-                    role = "seller",
-                    profileImageUrl = "https://cdn.example.com/user_xyz.png"
-                )
-            ),
-            statusHistory = listOf(
-                StatusHistoryDto(
-                    status = "PENDING",
-                    changedAt = "2025-03-25T09:00:00Z",
-                    changedBy = ChangedByDto(
-                        userId = 1,
-                        nickname = "김숙명"
-                    )
-                ),
-                StatusHistoryDto(
-                    status = "ACCEPTED",
-                    changedAt = "2025-03-25T10:00:00Z",
-                    changedBy = ChangedByDto(
-                        userId = 2,
-                        nickname = "홍길동"
-                    )
-                ),
-                StatusHistoryDto(
-                    status = "PENDING",
-                    changedAt = "2025-03-25T10:00:00Z",
-                    changedBy = ChangedByDto(
-                        userId = 1,
-                        nickname = "김숙명"
-                    )
-                )
-            )
-        ),
-        messages = listOf(
-            ChatMessageDto(
-                messageId = "msg_001",
-                sender = SenderDto(
-                    userId = 2,
-                    nickname = "홍길동"
-                ),
-                content = "요청보고 연락드렸습니다.",
-                sentAt = "2025-03-25T09:30:00Z",
-                type = "TEXT",
-                isMine = false
-            ),
-            ChatMessageDto(
-                messageId = "msg_002",
-                sender = SenderDto(
-                    userId = 1,
-                    nickname = "김숙명"
-                ),
-                content = "가나다라",
-                sentAt = "2025-03-25T09:31:00Z",
-                type = "TEXT",
-                isMine = true
-            )
-        ),
-        hasNext = false,
-        totalPage = 2
-    )
 
     private val _chatList = MutableStateFlow<List<ChatRoomSummaryDto>>(emptyList())
     val chatList: StateFlow<List<ChatRoomSummaryDto>> = _chatList
+
+    private val _productDetail = MutableStateFlow<ProductDetailResponseDto?>(null)
+    val productDetail: StateFlow<ProductDetailResponseDto?> = _productDetail
 
     private val _chatDetail = MutableStateFlow<ChatDetailResponseDto?>(null)
     val chatDetail: StateFlow<ChatDetailResponseDto?> = _chatDetail
@@ -104,6 +33,16 @@ class ChatViewModel @Inject constructor(
             chatRepository.getChatList()
                 .onSuccess {
                     _chatList.value = it.chatRooms
+                }
+                .onFailure(onError)
+        }
+    }
+
+    fun getProductDetail(productId: Int, onError: (Throwable) -> Unit = {}) {
+        viewModelScope.launch {
+            productRepository.getProductDetail(productId)
+                .onSuccess {
+                    _productDetail.value = it
                 }
                 .onFailure(onError)
         }

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
@@ -3,6 +3,7 @@ package com.example.rentit.feature.chat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
+import com.example.rentit.data.chat.dto.ChatMessageDto
 import com.example.rentit.data.chat.dto.ChatRoomSummaryDto
 import com.example.rentit.data.chat.repository.ChatRepository
 import com.example.rentit.data.product.dto.ProductDetailResponseDto
@@ -28,6 +29,9 @@ class ChatViewModel @Inject constructor(
     private val _chatDetail = MutableStateFlow<ChatDetailResponseDto?>(null)
     val chatDetail: StateFlow<ChatDetailResponseDto?> = _chatDetail
 
+    private val _initialMessages = MutableStateFlow<List<ChatMessageDto>>(emptyList())
+    val initialMessages: StateFlow<List<ChatMessageDto>> = _initialMessages
+
     fun getChatList(onError: (Throwable) -> Unit = {}) {
         viewModelScope.launch {
             chatRepository.getChatList()
@@ -50,9 +54,12 @@ class ChatViewModel @Inject constructor(
 
     fun getChatDetail(chatRoomMessageId: String, onError: (Throwable) -> Unit = {}) {
         viewModelScope.launch {
-            chatRepository.getChatDetail(chatRoomMessageId)
+            val skip = 0
+            val listSize = 30
+            chatRepository.getChatDetail(chatRoomMessageId, skip, listSize)
                 .onSuccess {
                     _chatDetail.value = it
+                    _initialMessages.value += it.messages
                 }
                 .onFailure(onError)
         }

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
@@ -1,11 +1,7 @@
 package com.example.rentit.feature.chat
 
-import android.content.Context
-import android.widget.Toast
-import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.R
 import com.example.rentit.data.chat.dto.ChangedByDto
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatMessageDto
@@ -16,7 +12,6 @@ import com.example.rentit.data.chat.dto.SenderDto
 import com.example.rentit.data.chat.dto.StatusHistoryDto
 import com.example.rentit.data.chat.repository.ChatRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -101,11 +96,24 @@ class ChatViewModel @Inject constructor(
     private val _chatList = MutableStateFlow<List<ChatRoomSummaryDto>>(emptyList())
     val chatList: StateFlow<List<ChatRoomSummaryDto>> = _chatList
 
+    private val _chatDetail = MutableStateFlow<ChatDetailResponseDto?>(null)
+    val chatDetail: StateFlow<ChatDetailResponseDto?> = _chatDetail
+
     fun getChatList(onError: (Throwable) -> Unit = {}) {
         viewModelScope.launch {
             chatRepository.getChatList()
                 .onSuccess {
                     _chatList.value = it.chatRooms
+                }
+                .onFailure(onError)
+        }
+    }
+
+    fun getChatDetail(chatRoomMessageId: String, onError: (Throwable) -> Unit = {}) {
+        viewModelScope.launch {
+            chatRepository.getChatDetail(chatRoomMessageId)
+                .onSuccess {
+                    _chatDetail.value = it
                 }
                 .onFailure(onError)
         }

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatroomScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatroomScreen.kt
@@ -82,6 +82,7 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, chatRo
     val chatViewModel: ChatViewModel = hiltViewModel()
     val productDetail by chatViewModel.productDetail.collectAsStateWithLifecycle()
     val chatDetail by chatViewModel.chatDetail.collectAsStateWithLifecycle()
+    val initialMessages by chatViewModel.initialMessages.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     var textFieldValue by remember { mutableStateOf(TextFieldValue("")) }
@@ -131,7 +132,7 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, chatRo
                     BookingActions(onAcceptAction = { showAcceptDialog = true })
                 }
             }
-            ChatMsgList(Modifier.weight(1F), detail.messages)
+            ChatMsgList(Modifier.weight(1F), initialMessages)
         } ?: Column(Modifier.weight(1F)){}
         BottomInputBar(
             textFieldValue = textFieldValue,

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatroomScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatroomScreen.kt
@@ -61,7 +61,7 @@ import com.example.rentit.common.component.NavigationRoutes
 import com.example.rentit.common.component.moveScreen
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.exception.chat.ForbiddenChatAccessException
-import com.example.rentit.common.exception.chat.ServerException
+import com.example.rentit.common.exception.ServerException
 import com.example.rentit.common.theme.Gray100
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.Gray800

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatroomScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatroomScreen.kt
@@ -77,7 +77,7 @@ import java.time.format.DateTimeFormatter
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun ChatroomScreen(navHostController: NavHostController) {
+fun ChatroomScreen(navHostController: NavHostController, productId: Int?, chatRoomId: String?) {
     val chatViewModel: ChatViewModel = hiltViewModel()
     val chatDetail by chatViewModel.chatDetail.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -89,13 +89,18 @@ fun ChatroomScreen(navHostController: NavHostController) {
     val isCursorAtEnd = textFieldValue.selection.max == textFieldValue.text.length
 
     LaunchedEffect(Unit) {
-        chatViewModel.getChatDetail(chatRoomMessageId = "room_74248fca-630a-4d25-9e26-a3b943afe300"){
-            var toastMsg = context.getString(R.string.error_chat_unknown)
-            when(it){
-                is ForbiddenChatAccessException -> toastMsg = context.getString(R.string.error_chat_access)
-                is ServerException -> toastMsg = context.getString(R.string.error_common_server)
-                else -> Unit
+        var toastMsg = context.getString(R.string.error_chat_unknown)
+        if (chatRoomId != null) {
+            chatViewModel.getChatDetail(chatRoomId){
+                when(it){
+                    is ForbiddenChatAccessException -> toastMsg = context.getString(R.string.error_chat_access)
+                    is ServerException -> toastMsg = context.getString(R.string.error_common_server)
+                    else -> Unit
+                }
+                Toast.makeText(context, toastMsg, Toast.LENGTH_SHORT).show()
+                moveScreen(navHostController, NavigationRoutes.MAIN)
             }
+        } else {
             Toast.makeText(context, toastMsg, Toast.LENGTH_SHORT).show()
             moveScreen(navHostController, NavigationRoutes.MAIN)
         }
@@ -368,6 +373,6 @@ private fun formatDateTime(dateTimeString: String): String {
 @Composable
 fun PreviewChatroomScreen() {
     RentItTheme {
-        ChatroomScreen(rememberNavController())
+        ChatroomScreen(rememberNavController(), -1, "")
     }
 }

--- a/app/src/main/java/com/example/rentit/feature/chat/component/ChatListItem.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/component/ChatListItem.kt
@@ -33,21 +33,14 @@ import com.example.rentit.common.component.basicListItemTopDivider
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.data.chat.dto.ChatRoomDataDto
-import java.time.LocalDateTime
+import com.example.rentit.data.chat.dto.ChatRoomSummaryDto
+import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun ChatListItem(onClick: () -> Unit) {
-    val data = ChatRoomDataDto(
-        chatroomId = "sadsadsadfas",
-        productTitle = "캐논 EOS 550D",
-        partnerNickname = "상대 아이디",
-        lastMessage = "내일 가능할까요?",
-        lastMessageTime = "2025-04-09T22:00:00"
-    )
-    val lastMessageTime = formatDateTime(data.lastMessageTime)
+fun ChatListItem(data: ChatRoomSummaryDto, onClick: () -> Unit) {
+    val lastMessageTime = if(data.lastMessageTime != null) formatDateTime(data.lastMessageTime) else ""
 
     Box(
         modifier = Modifier
@@ -112,19 +105,26 @@ fun ChatListItem(onClick: () -> Unit) {
     }
 }
 
+// 시간대(Offset)을 포함한 ISO 8601 형식의 OffsetDateTime 포맷팅
 @RequiresApi(Build.VERSION_CODES.O)
 private fun formatDateTime(dateTimeString: String): String {
-    val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
-    val localDateTime = LocalDateTime.parse(dateTimeString, formatter)
-    val dateFormatter = DateTimeFormatter.ofPattern("yy.MM.dd")
-    return localDateTime.format(dateFormatter)
+    val offsetDateTime = OffsetDateTime.parse(dateTimeString)
+    val localDateTime = offsetDateTime.toLocalDateTime()
+    return localDateTime.format(DateTimeFormatter.ofPattern("yy.MM.dd"))
 }
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
 fun ChatListItemPreview() {
+    val data = ChatRoomSummaryDto(
+        chatRoomId = "sadsadsadfas",
+        productTitle = "캐논 EOS 550D",
+        partnerNickname = "상대 아이디",
+        lastMessage = "내일 가능할까요?",
+        lastMessageTime = "2025-04-09T22:00:00"
+    )
     RentItTheme {
-        ChatListItem {}
+        ChatListItem(data) {}
     }
 }

--- a/app/src/main/java/com/example/rentit/feature/chat/component/ReceivedMsgBubble.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/component/ReceivedMsgBubble.kt
@@ -32,7 +32,7 @@ import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.theme.White
 import com.example.rentit.data.chat.dto.ChatMessageDto
 import com.example.rentit.data.chat.dto.SenderDto
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -83,8 +83,7 @@ fun ReceivedMsgBubble(msg: ChatMessageDto) {
 
 @RequiresApi(Build.VERSION_CODES.O)
 private fun formatDateTime(dateTimeString: String): String {
-    val offsetDateTime = OffsetDateTime.parse(dateTimeString)
-    val localDateTime = offsetDateTime.toLocalDateTime()
+    val localDateTime = LocalDateTime.parse(dateTimeString)
     return localDateTime.format(DateTimeFormatter.ofPattern("HH:mm"))
 }
 

--- a/app/src/main/java/com/example/rentit/feature/chat/component/ReceivedMsgBubble.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/component/ReceivedMsgBubble.kt
@@ -83,7 +83,7 @@ fun ReceivedMsgBubble(msg: ChatMessageDto) {
 
 @RequiresApi(Build.VERSION_CODES.O)
 private fun formatDateTime(dateTimeString: String): String {
-    val localDateTime = LocalDateTime.parse(dateTimeString)
+    val localDateTime = LocalDateTime.parse(dateTimeString, DateTimeFormatter.ISO_DATE_TIME)
     return localDateTime.format(DateTimeFormatter.ofPattern("HH:mm"))
 }
 

--- a/app/src/main/java/com/example/rentit/feature/chat/component/SentMsgBubble.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/component/SentMsgBubble.kt
@@ -26,7 +26,7 @@ import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.data.chat.dto.ChatMessageDto
 import com.example.rentit.data.chat.dto.SenderDto
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -65,8 +65,7 @@ fun SentMsgBubble(msg: ChatMessageDto) {
 
 @RequiresApi(Build.VERSION_CODES.O)
 private fun formatDateTime(dateTimeString: String): String {
-    val offsetDateTime = OffsetDateTime.parse(dateTimeString)
-    val localDateTime = offsetDateTime.toLocalDateTime()
+    val localDateTime = LocalDateTime.parse(dateTimeString, DateTimeFormatter.ISO_DATE_TIME)
     return localDateTime.format(DateTimeFormatter.ofPattern("HH:mm"))
 }
 

--- a/app/src/main/java/com/example/rentit/feature/product/ProductViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/product/ProductViewModel.kt
@@ -44,13 +44,13 @@ class ProductViewModel @Inject constructor(
             chatRoomId = "room_74248fca-630a-4d25-9e26-a3b943afe300"
         ),
         RequestInfoDto(
-            reservationId = 1002,
+            reservationId = 22,
             renterNickName = "눈송",
             startDate = "2025-07-04",
             endDate = "2025-07-05",
             status = "PENDING",
             requestedAt = LocalDateTime.of(2025, 4, 10, 10, 30, 0).format(formatter),
-            chatRoomId = "room_74248fca-630a-4d25-9e26-a3b943afe300"
+            chatRoomId = null   // 채팅방 생성 테스트 용
         ),
         RequestInfoDto(
             reservationId = 21,

--- a/app/src/main/java/com/example/rentit/feature/product/ProductViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/product/ProductViewModel.kt
@@ -40,7 +40,8 @@ class ProductViewModel @Inject constructor(
             startDate = "2025-06-15",
             endDate = "2025-06-17",
             status = "PENDING",
-            requestedAt = LocalDateTime.of(2025, 3, 20, 14, 0, 0).format(formatter)
+            requestedAt = LocalDateTime.of(2025, 3, 20, 14, 0, 0).format(formatter),
+            chatRoomId = "room_74248fca-630a-4d25-9e26-a3b943afe300"
         ),
         RequestInfoDto(
             reservationId = 1002,
@@ -48,7 +49,8 @@ class ProductViewModel @Inject constructor(
             startDate = "2025-07-04",
             endDate = "2025-07-05",
             status = "PENDING",
-            requestedAt = LocalDateTime.of(2025, 4, 10, 10, 30, 0).format(formatter)
+            requestedAt = LocalDateTime.of(2025, 4, 10, 10, 30, 0).format(formatter),
+            chatRoomId = "room_74248fca-630a-4d25-9e26-a3b943afe300"
         ),
         RequestInfoDto(
             reservationId = 21,
@@ -56,7 +58,8 @@ class ProductViewModel @Inject constructor(
             startDate = "2025-06-27",
             endDate = "2025-07-03",
             status = "PENDING",
-            requestedAt = LocalDateTime.of(2025, 6, 25, 16, 15, 0).format(formatter)
+            requestedAt = LocalDateTime.of(2025, 6, 25, 16, 15, 0).format(formatter),
+            chatRoomId = "room_74248fca-630a-4d25-9e26-a3b943afe300"
         ),
     )
 

--- a/app/src/main/java/com/example/rentit/feature/user/RequestHistoryScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/RequestHistoryScreen.kt
@@ -1,6 +1,7 @@
 package com.example.rentit.feature.user
 
 import android.os.Build
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -38,6 +39,7 @@ import java.time.YearMonth
 fun RequestHistoryScreen(navHostController: NavHostController, productViewModel: ProductViewModel) {
     //val requestHistory by productViewModel.requestList.collectAsStateWithLifecycle()
     var yearMonth by remember { mutableStateOf(YearMonth.now()) }
+    val productId by productViewModel.productId.collectAsStateWithLifecycle()
     val sampleRequestHistory = productViewModel.sampleReservationsList
 
     val requestPeriodList: List<RequestPeriodDto> = sampleRequestHistory.map {
@@ -63,7 +65,16 @@ fun RequestHistoryScreen(navHostController: NavHostController, productViewModel:
             ) {
                 item { Spacer(Modifier.size(2.dp)) }
                 items(groupedByMonth[yearMonth] ?: emptyList()) { info ->
-                    RequestHistoryListItem(requestInfo = info) { moveScreen(navHostController, NavigationRoutes.NAVHOSTCHAT) }
+                    RequestHistoryListItem(requestInfo = info) {
+                        if(info.chatRoomId != null) {
+                            moveScreen(
+                                navHostController,
+                                "${NavigationRoutes.NAVHOSTCHAT}/$productId/${info.chatRoomId}"
+                            )
+                        } else {
+                            Toast.makeText(navHostController.context, "채팅방이 없습니다.", Toast.LENGTH_SHORT).show()
+                        }
+                    }
                 }
                 item { Spacer(Modifier.size(50.dp)) }
             }

--- a/app/src/main/java/com/example/rentit/feature/user/UserViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/UserViewModel.kt
@@ -2,6 +2,7 @@ package com.example.rentit.feature.user
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.rentit.data.chat.repository.ChatRepository
 import com.example.rentit.data.product.dto.ProductDto
 import com.example.rentit.data.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,7 +13,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class UserViewModel @Inject constructor(
-    private val repository: UserRepository
+    private val userRepository: UserRepository,
+    private val chatRepository: ChatRepository
 ) : ViewModel() {
 
     private val _myProductList = MutableStateFlow<List<ProductDto>>(emptyList())
@@ -20,7 +22,7 @@ class UserViewModel @Inject constructor(
 
     fun getMyProductList() {
         viewModelScope.launch {
-            repository.getMyProductList().onSuccess {
+            userRepository.getMyProductList().onSuccess {
                 _myProductList.value = it.myProducts
             }.onFailure {
                 /* 로딩 실패 시 */
@@ -28,4 +30,13 @@ class UserViewModel @Inject constructor(
         }
     }
 
+    fun postNewChat(productId: Int, onSuccess: (String) -> Unit = {}, onError: (Throwable) -> Unit = {}) {
+        viewModelScope.launch {
+            chatRepository.postNewChat(productId)
+                .onSuccess {
+                    onSuccess(it.data.chatRoomId)
+                }
+                .onFailure(onError)
+        }
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,8 @@
     <string name="screen_mypage_tab_title_on_rent">대여 중</string>
     <string name="screen_mypage_text_tab_list_empty">게시글이 없어요</string>
 
+    <string name="error_mypage_new_chatroom">채팅방 생성에 실패했어요.</string>
+
     <string name="request_history_list_item_period">%s (%s) ~ %s (%s) · %d일</string>
     <string name="request_history_list_item_text_chat">채팅하기</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,8 @@
     
     <string name="screen_chat_list_btn_up_to_date_order">최신순</string>
 
+    <string name="error_chat_list_load">채팅 목록을 불러올 수 없어요</string>
+
     <string name="screen_chatroom_request_info_label">보낸 요청</string>
     <string name="screen_chatroom_request_action_btn_reject">거절하기</string>
     <string name="screen_chatroom_request_action_btn_accept">수락하기</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,7 +72,9 @@
     
     <string name="screen_chat_list_btn_up_to_date_order">최신순</string>
 
-    <string name="error_chat_list_load">채팅 목록을 불러올 수 없어요</string>
+    <string name="error_chat_list_load">채팅 목록을 불러올 수 없어요.</string>
+    <string name="error_chat_access">채팅방 접근 권한이 없어요.</string>
+    <string name="error_chat_unknown">채팅방에 접속할 수 없어요.</string>
 
     <string name="screen_chatroom_request_info_label">보낸 요청</string>
     <string name="screen_chatroom_request_action_btn_reject">거절하기</string>
@@ -111,5 +113,7 @@
     <string name="content_description_for_img_profile_placeholder">프로필 임시 이미지</string>
     <string name="content_description_for_img_empty_box">빈 박스 이미지</string>
     <string name="content_description_for_ic_check">확인 아이콘</string>
+
+    <string name="error_common_server">일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요.</string>
 
 </resources>


### PR DESCRIPTION
# Pull Request

## Summary  
- 채팅 리스트 및 채팅방 생성, 채팅방 세부정보 조회 등 실시간 채팅을 제외한 채팅 관련 API 연동

## Related Issue  
- Close: #32 

## Changes  
- 채팅방 리스트 조회 API 연동
- 채팅방 진입점 연결 (채팅방 리스트, 예약 요청 리스트)
- 채팅방 생성 API 연동
- 채팅방 세부 정보 API 연동
- 채팅방에서 사용될 상품 정보 API 호출 추가

## Notes  
- 채팅방 생성 API 는 서버와 호출 상황에 대한 논의 필요
- 채팅방 세부 정보 API에서 전체 메세지 리스트를 받기 위해 Pagination 고려한 코드 수정 필요
