### PR TITLE
feat(38): finalize chat request and link history

### DIFF
--- a/app/src/main/java/com/example/rentit/data/chat/dto/ChatListResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/dto/ChatListResponseDto.kt
@@ -17,6 +17,12 @@ data class ChatRoomSummaryDto(
     @SerializedName("chatroomId")
     val chatRoomId: String,
 
+    @SerializedName("productId")
+    val productId: Int,
+
+    @SerializedName("reservationId")
+    val reservationId: Int,
+
     @SerializedName("productTitle")
     val productTitle: String,
 

--- a/app/src/main/java/com/example/rentit/data/user/dto/MyRentalListtResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/user/dto/MyRentalListtResponseDto.kt
@@ -1,0 +1,46 @@
+package com.example.rentit.data.user.dto
+
+import com.example.rentit.data.product.dto.ProductDto
+import com.google.gson.annotations.SerializedName
+
+data class MyRentalListResponseDto(
+    @SerializedName("myReservations")
+    val myReservations: List<ReservationDto>,
+
+    @SerializedName("nearestDueItem")
+    val nearestDueItem: NearestDueItemDto?
+)
+
+data class ReservationDto(
+    @SerializedName("reservationId")
+    val reservationId: Int,
+
+    @SerializedName("product")
+    val product: ProductDto,
+
+    @SerializedName("startDate")
+    val startDate: String, // "YYYY-MM-DD"
+
+    @SerializedName("endDate")
+    val endDate: String, // "YYYY-MM-DD"
+
+    @SerializedName("status")
+    val status: String, // PENDING, REJECTED, ACCEPTED
+
+    @SerializedName("requestedAt")
+    val requestedAt: String // ISO 8601
+)
+
+data class NearestDueItemDto(
+    @SerializedName("reservationId")
+    val reservationId: Int,
+
+    @SerializedName("productTitle")
+    val productTitle: String,
+
+    @SerializedName("returnDueDate")
+    val returnDueDate: String, // "YYYY-MM-DD"
+
+    @SerializedName("daysUntilReturn")
+    val daysUntilReturn: Int
+)

--- a/app/src/main/java/com/example/rentit/data/user/remote/UserApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/user/remote/UserApiService.kt
@@ -4,6 +4,7 @@ import com.example.rentit.data.user.dto.GoogleLoginRequestDto
 import com.example.rentit.data.user.dto.GoogleLoginResponseDto
 import com.example.rentit.data.user.dto.MyInfoResponseDto
 import com.example.rentit.data.user.dto.MyProductListResponseDto
+import com.example.rentit.data.user.dto.MyRentalListResponseDto
 import com.example.rentit.data.user.dto.SignUpRequestDto
 import retrofit2.Response
 import retrofit2.http.Body
@@ -27,4 +28,8 @@ interface UserApiService {
     @GET("api/v1/users/products")
     @Headers("Content-Type: application/json")
     suspend fun getMyProductList(): Response<MyProductListResponseDto>
+
+    @GET("api/v1/users/reservations")
+    @Headers("Content-Type: application/json")
+    suspend fun getMyRentalList(): Response<MyRentalListResponseDto>
 }

--- a/app/src/main/java/com/example/rentit/data/user/remote/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/user/remote/UserRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.example.rentit.data.user.dto.GoogleLoginRequestDto
 import com.example.rentit.data.user.dto.GoogleLoginResponseDto
 import com.example.rentit.data.user.dto.MyInfoResponseDto
 import com.example.rentit.data.user.dto.MyProductListResponseDto
+import com.example.rentit.data.user.dto.MyRentalListResponseDto
 import com.example.rentit.data.user.dto.SignUpRequestDto
 import retrofit2.Response
 import javax.inject.Inject
@@ -27,5 +28,9 @@ class UserRemoteDataSource @Inject constructor(
 
     suspend fun getMyProductList(): Response<MyProductListResponseDto> {
         return userApiService.getMyProductList()
+    }
+
+    suspend fun getMyRentalList(): Response<MyRentalListResponseDto> {
+        return userApiService.getMyRentalList()
     }
 }

--- a/app/src/main/java/com/example/rentit/data/user/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/user/repository/UserRepository.kt
@@ -1,8 +1,10 @@
 package com.example.rentit.data.user.repository
 
+import com.example.rentit.common.exception.ServerException
 import com.example.rentit.data.user.dto.GoogleLoginResponseDto
 import com.example.rentit.data.user.dto.MyInfoResponseDto
 import com.example.rentit.data.user.dto.MyProductListResponseDto
+import com.example.rentit.data.user.dto.MyRentalListResponseDto
 import com.example.rentit.data.user.remote.UserRemoteDataSource
 import javax.inject.Inject
 
@@ -103,6 +105,30 @@ class UserRepository @Inject constructor(
                 }
                 500 -> {
                     Result.failure(Exception("Server error"))
+                }
+                else -> {
+                    Result.failure(Exception("Unexpected error"))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getMyRentalList(): Result<MyRentalListResponseDto> {
+        return try {
+            val response = remoteDataSource.getMyRentalList()
+            when(response.code()) {
+                200 -> {
+                    val body = response.body()
+                    if(body != null) {
+                        Result.success(body)
+                    } else {
+                        Result.failure(Exception("Empty response body"))
+                    }
+                }
+                500 -> {
+                    Result.failure(ServerException())
                 }
                 else -> {
                     Result.failure(Exception("Unexpected error"))

--- a/app/src/main/java/com/example/rentit/feature/MainView.kt
+++ b/app/src/main/java/com/example/rentit/feature/MainView.kt
@@ -128,14 +128,16 @@ fun TabNavHost(navHostController: NavHostController, paddingValues: PaddingValue
             ProductDetailNavHost(productId)
         }
         composable(
-            route = NavigationRoutes.NAVHOSTCHAT + "/{productId}/{chatRoomId}",
+            route = NavigationRoutes.NAVHOSTCHAT + "/{productId}/{reservationId}/{chatRoomId}",
             arguments = listOf(
                 navArgument("productId") { type = NavType.IntType },
+                navArgument("reservationId") { type = NavType.IntType },
                 navArgument("chatRoomId") { type = NavType.StringType })
         ) { backStackEntry ->
             val pId = backStackEntry.arguments?.getInt("productId")
+            val rId = backStackEntry.arguments?.getInt("reservationId")
             val cId = backStackEntry.arguments?.getString("chatRoomId")
-            ChatroomNavHost(pId, cId)
+            ChatroomNavHost(pId, rId, cId)
         }
         composable(NavigationRoutes.CREATEPOST) { CreatePostNavHost() }
     }
@@ -159,14 +161,16 @@ fun ProductDetailNavHost(productId: Int?) {
         composable(NavigationRoutes.REQUESTCONFIRM) { RequestConfirmationScreen(navHostController, productViewModel) }
         composable(NavigationRoutes.REQUESTHISTORY) { RequestHistoryScreen(navHostController, productViewModel) }
         composable(
-            route = NavigationRoutes.NAVHOSTCHAT + "/{productId}/{chatRoomId}",
+            route = NavigationRoutes.NAVHOSTCHAT + "/{productId}/{reservationId}/{chatRoomId}",
             arguments = listOf(
                 navArgument("productId") { type = NavType.IntType },
+                navArgument("reservationId") { type = NavType.IntType },
                 navArgument("chatRoomId") { type = NavType.StringType })
         ) { backStackEntry ->
             val pId = backStackEntry.arguments?.getInt("productId")
+            val rId = backStackEntry.arguments?.getInt("reservationId")
             val cId = backStackEntry.arguments?.getString("chatRoomId")
-            ChatroomNavHost(pId, cId)
+            ChatroomNavHost(pId, rId, cId)
         }
         composable(NavigationRoutes.MAIN) { MainView() }
     }
@@ -174,10 +178,10 @@ fun ProductDetailNavHost(productId: Int?) {
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun ChatroomNavHost(productId: Int?, chatRoomId: String?) {
+fun ChatroomNavHost(productId: Int?, reservationId: Int?, chatRoomId: String?) {
     val navHostController: NavHostController = rememberNavController()
     NavHost(navController =  navHostController, startDestination = NavigationRoutes.CHATROOM){
-        composable(NavigationRoutes.CHATROOM) { ChatroomScreen(navHostController, productId, chatRoomId) }
+        composable(NavigationRoutes.CHATROOM) { ChatroomScreen(navHostController, productId, reservationId, chatRoomId) }
         composable(NavigationRoutes.ACCEPTCONFIRM) { AcceptConfirmationScreen(navHostController) }
         composable(NavigationRoutes.MAIN) { MainView() }
     }

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
@@ -68,7 +68,7 @@ fun ChatListScreen(navHostController: NavHostController) {
                 ChatListItem(it) {
                     moveScreen(
                         navHostController,
-                        "${NavigationRoutes.NAVHOSTCHAT}/8/${it.chatRoomId}"    // 임시 ProductId
+                        "${NavigationRoutes.NAVHOSTCHAT}/${it.productId}/${it.reservationId}/${it.chatRoomId}"    // 임시 ProductId
                     )
                 }
             }

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
@@ -51,6 +51,10 @@ class ChatViewModel @Inject constructor(
     private val _senderNickname = MutableStateFlow<String?>(null)
     val senderNickname: StateFlow<String?> = _senderNickname
 
+    // 백엔드 오류로 인한 임시 요청 확인 처리
+    private val _isRequestAccepted = MutableStateFlow(false)
+    val isRequestAccepted: StateFlow<Boolean> = _isRequestAccepted
+
     @RequiresApi(Build.VERSION_CODES.O)
     fun connectWebSocket(chatroomId: String, onConnect: () -> Unit) {
         val token = getToken(context) ?: return
@@ -66,6 +70,17 @@ class ChatViewModel @Inject constructor(
 
     fun disconnectWebSocket() {
         WebSocketManager.disconnect()
+    }
+
+    fun resetRealTimeMessages() {
+        _realTimeMessages.value = emptyList()
+    }
+
+    // 백엔드 오류로 인한 임시 요청 확인 처리
+    fun checkRequestAccepted() {
+        if(_initialMessages.value.find { it.message == AutoMsgType.REQUEST_ACCEPT.code } != null) {
+            _isRequestAccepted.value = true
+        }
     }
 
     fun getChatList(onError: (Throwable) -> Unit = {}) {

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatroomScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatroomScreen.kt
@@ -81,7 +81,7 @@ import java.time.format.DateTimeFormatter
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun ChatroomScreen(navHostController: NavHostController, productId: Int?, chatRoomId: String?) {
+fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reservationId: Int?, chatRoomId: String?) {
     val chatViewModel: ChatViewModel = hiltViewModel()
     val productDetail by chatViewModel.productDetail.collectAsStateWithLifecycle()
     val chatDetail by chatViewModel.chatDetail.collectAsStateWithLifecycle()
@@ -169,11 +169,11 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, chatRo
         RequestAcceptDialog(
             onDismissRequest = { showAcceptDialog = false },
             onAcceptRequest = {
-                if(productId != null && chatRoomId != null){
+                if(productId != null && chatRoomId != null && reservationId != null){
                     chatViewModel.updateBookingStatus(
                         chatRoomId,
-                        11, // sample product id
-                        24, // sample chatroom id
+                        productId,
+                        reservationId,
                         onSuccess = { moveScreen(navHostController, NavigationRoutes.ACCEPTCONFIRM) },
                         onError = {
                             var errorMsg = context.getString(R.string.error_cant_process_accept_request)
@@ -443,14 +443,4 @@ private fun formatDateTime(dateTimeString: String): String {
     val localDateTime = LocalDateTime.parse(dateTimeString, formatter)
     val dateFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
     return localDateTime.format(dateFormatter)
-}
-
-
-@RequiresApi(Build.VERSION_CODES.O)
-@Preview(showBackground = true)
-@Composable
-fun PreviewChatroomScreen() {
-    RentItTheme {
-        ChatroomScreen(rememberNavController(), -1, "")
-    }
 }

--- a/app/src/main/java/com/example/rentit/feature/chat/RequestAcceptDialog.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/RequestAcceptDialog.kt
@@ -29,9 +29,12 @@ import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.Gray800
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
+import java.text.NumberFormat
 
 @Composable
-fun RequestAcceptDialog(onDismissRequest: () -> Unit, onAcceptRequest: () -> Unit) {
+fun RequestAcceptDialog(productPrice: Int, onDismissRequest: () -> Unit, onAcceptRequest: () -> Unit) {
+    val rentalPeriod = 4
+    val numFormat = NumberFormat.getNumberInstance()
     Dialog(
         onDismissRequest = onDismissRequest
     ) {
@@ -77,7 +80,7 @@ fun RequestAcceptDialog(onDismissRequest: () -> Unit, onAcceptRequest: () -> Uni
                         style = MaterialTheme.typography.bodyLarge
                     )
                     Text(
-                        text = "40,000 ${stringResource(R.string.common_price_unit)}",
+                        text = "${numFormat.format(productPrice * rentalPeriod)} ${stringResource(R.string.common_price_unit)}",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
@@ -111,6 +114,6 @@ fun RequestAcceptDialog(onDismissRequest: () -> Unit, onAcceptRequest: () -> Uni
 @Composable
 fun PreviewRequestAcceptDialog() {
     RentItTheme {
-        RequestAcceptDialog(onDismissRequest = {}, onAcceptRequest = {})
+        RequestAcceptDialog(10000, onDismissRequest = {}, onAcceptRequest = {})
     }
 }

--- a/app/src/main/java/com/example/rentit/feature/chat/component/ChatListItem.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/component/ChatListItem.kt
@@ -124,6 +124,8 @@ private fun formatDateTime(dateTimeString: String): String {
 fun ChatListItemPreview() {
     val data = ChatRoomSummaryDto(
         chatRoomId = "sadsadsadfas",
+        productId = 1,
+        reservationId = 1,
         productTitle = "캐논 EOS 550D",
         partnerNickname = "상대 아이디",
         lastMessage = "내일 가능할까요?",

--- a/app/src/main/java/com/example/rentit/feature/product/ProductDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/product/ProductDetailScreen.kt
@@ -80,8 +80,7 @@ fun ProductDetailScreen(navHostController: NavHostController, productViewModel: 
     val productId by productViewModel.productId.collectAsStateWithLifecycle()
     val productDetailResult by productViewModel.productDetail.collectAsStateWithLifecycle()
     val reservedDateList by productViewModel.reservedDateList.collectAsStateWithLifecycle()
-
-    val sampleRequestHistory = productViewModel.sampleReservationsList
+    val requestHistory by productViewModel.requestList.collectAsStateWithLifecycle()
 
     val productDetail = productDetailResult?.getOrNull()?.product
     val ownerId = productDetail?.owner?.userId ?: -1
@@ -105,7 +104,7 @@ fun ProductDetailScreen(navHostController: NavHostController, productViewModel: 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = { CommonTopAppBar(onClick = { /*TODO*/ }) },
-        bottomBar = { PostBottomBar(navHostController, productDetail?.price ?: 0, isMyProduct, sampleRequestHistory.size) },
+        bottomBar = { PostBottomBar(navHostController, productDetail?.price ?: 0, isMyProduct, requestHistory.size) },
         floatingActionButton = { UsageDetailButton { showBottomSheet = true } }
     ) { innerPadding ->
         Box(

--- a/app/src/main/java/com/example/rentit/feature/product/ProductViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/product/ProductViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RequiresApi
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.rentit.common.enums.BookingStatus
 import com.example.rentit.data.product.dto.BookingRequestDto
 import com.example.rentit.data.product.dto.BookingResponseDto
 import com.example.rentit.data.product.dto.ProductDetailResponseDto
@@ -31,37 +32,6 @@ class ProductViewModel @Inject constructor(
 
     @RequiresApi(Build.VERSION_CODES.O)
     val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss") // requestedAt 형식을 위한 포맷터
-
-    @RequiresApi(Build.VERSION_CODES.O)
-    val sampleReservationsList = listOf(
-        RequestInfoDto(
-            reservationId = 1001,
-            renterNickName = "눈송",
-            startDate = "2025-06-15",
-            endDate = "2025-06-17",
-            status = "PENDING",
-            requestedAt = LocalDateTime.of(2025, 3, 20, 14, 0, 0).format(formatter),
-            chatRoomId = "room_74248fca-630a-4d25-9e26-a3b943afe300"
-        ),
-        RequestInfoDto(
-            reservationId = 22,
-            renterNickName = "눈송",
-            startDate = "2025-07-04",
-            endDate = "2025-07-05",
-            status = "PENDING",
-            requestedAt = LocalDateTime.of(2025, 4, 10, 10, 30, 0).format(formatter),
-            chatRoomId = null   // 채팅방 생성 테스트 용
-        ),
-        RequestInfoDto(
-            reservationId = 21,
-            renterNickName = "눈송",
-            startDate = "2025-06-27",
-            endDate = "2025-07-03",
-            status = "PENDING",
-            requestedAt = LocalDateTime.of(2025, 6, 25, 16, 15, 0).format(formatter),
-            chatRoomId = "room_74248fca-630a-4d25-9e26-a3b943afe300"
-        ),
-    )
 
     private val _productId = savedStateHandle.getStateFlow("productId", -1)
     val productId: StateFlow<Int> = _productId
@@ -151,7 +121,7 @@ class ProductViewModel @Inject constructor(
     fun getProductRequestList(productId: Int){
         viewModelScope.launch {
             repository.getProductRequestList(productId).onSuccess {
-                _requestList.value = it.reservations
+                _requestList.value = it.reservations.filter { data -> BookingStatus.isPending(data.status) }
             }
         }
     }

--- a/app/src/main/java/com/example/rentit/feature/product/UsageDetailBottomDrawer.kt
+++ b/app/src/main/java/com/example/rentit/feature/product/UsageDetailBottomDrawer.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -20,11 +21,11 @@ import java.time.YearMonth
 fun UsageDetailBottomDrawer(reservedDateList: List<String>) {
     Column(modifier = Modifier.fillMaxHeight(0.85f)) {
         ReadOnlyCalender(yearMonth = YearMonth.now(), reservedDateList)
-        LazyColumn(modifier = Modifier.padding(bottom = 25.dp)) {
-            this.items(1) {
+        /*LazyColumn(modifier = Modifier.padding(bottom = 25.dp)) {
+            this.items(reservedDateList) {
                 UsageListItem()
             }
-        }
+        }*/
     }
 
 }

--- a/app/src/main/java/com/example/rentit/feature/user/MyPageScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/MyPageScreen.kt
@@ -38,13 +38,11 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonDivider
@@ -56,24 +54,26 @@ import com.example.rentit.common.theme.AppRed
 import com.example.rentit.common.theme.Gray200
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.PrimaryBlue500
-import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.theme.pretendardFamily
 import com.example.rentit.data.product.dto.ProductDto
+import com.example.rentit.data.user.dto.ReservationDto
 import com.example.rentit.feature.home.component.ProductListItem
+import com.example.rentit.feature.user.component.RentalHistoryListItem
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun MyPageScreen(navHostController: NavHostController) {
-    val onRentList = emptyList<ProductDto>()
     val userViewModel: UserViewModel = hiltViewModel()
 
     var isFirstTabSelected by remember { mutableStateOf(true) }
 
     LaunchedEffect(Unit) {
         userViewModel.getMyProductList()
+        userViewModel.getMyRentalList()
     }
 
     val myProductList by userViewModel.myProductList.collectAsStateWithLifecycle()
+    val myRentalList by userViewModel.myRentalList.collectAsStateWithLifecycle()
 
     Column {
         Column(
@@ -88,9 +88,16 @@ fun MyPageScreen(navHostController: NavHostController) {
         TabbedListSection(
             isFirstTabSelected = isFirstTabSelected,
             myProductList = myProductList,
-            onRentList = onRentList,
+            myRentList = myRentalList,
             onTabActive = { isFirstTabSelected = !isFirstTabSelected },
-            onItemClick = { id -> moveScreen(navHostController, NavigationRoutes.NAVHOSTPRODUCTDETAIL + "/$id", saveStateEnabled = true, restoreStateEnabled = true) }
+            onItemClick = { id ->
+                moveScreen(
+                    navHostController,
+                    NavigationRoutes.NAVHOSTPRODUCTDETAIL + "/$id",
+                    saveStateEnabled = true,
+                    restoreStateEnabled = true
+                )
+            }
         )
     }
 }
@@ -224,7 +231,7 @@ fun InfoBox() {
 fun TabbedListSection(
     isFirstTabSelected: Boolean,
     myProductList: List<ProductDto>,
-    onRentList: List<ProductDto>,
+    myRentList: List<ReservationDto>,
     onTabActive: () -> Unit,
     onItemClick: (Int) -> Unit,
 ) {
@@ -249,10 +256,16 @@ fun TabbedListSection(
             .background(Gray200),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        val list = if (isFirstTabSelected) myProductList else onRentList
+        val list = if (isFirstTabSelected) myProductList else myRentList
         if (list.isNotEmpty()) {
-            items(list) {
-                ProductListItem(it, true) { onItemClick(it.productId) }
+            if (isFirstTabSelected) {
+                items(myProductList) {
+                    ProductListItem(it, true) { onItemClick(it.productId) }
+                }
+            } else {
+                items(myRentList) {
+                    RentalHistoryListItem(it)
+                }
             }
         } else {
             item {
@@ -297,14 +310,5 @@ fun TabTitle(title: String, isTabSelected: Boolean, modifier: Modifier, onClick:
                     .background(PrimaryBlue500)
             )
         }
-    }
-}
-
-@RequiresApi(Build.VERSION_CODES.O)
-@Preview(showBackground = true)
-@Composable
-fun PreviewMyPageScreen() {
-    RentItTheme {
-        MyPageScreen(rememberNavController())
     }
 }

--- a/app/src/main/java/com/example/rentit/feature/user/RequestHistoryScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/RequestHistoryScreen.kt
@@ -40,20 +40,19 @@ import java.time.YearMonth
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun RequestHistoryScreen(navHostController: NavHostController, productViewModel: ProductViewModel) {
-    //val requestHistory by productViewModel.requestList.collectAsStateWithLifecycle()
+    val requestHistory by productViewModel.requestList.collectAsStateWithLifecycle()
     val userViewModel: UserViewModel = hiltViewModel()
     var yearMonth by remember { mutableStateOf(YearMonth.now()) }
     val productId by productViewModel.productId.collectAsStateWithLifecycle()
-    val sampleRequestHistory = productViewModel.sampleReservationsList
     val errorMsgNewChatRoom = LocalContext.current.getString(R.string.error_mypage_new_chatroom)
 
-    val requestPeriodList: List<RequestPeriodDto> = sampleRequestHistory.map {
+    val requestPeriodList: List<RequestPeriodDto> = requestHistory.map {
         RequestPeriodDto(
             LocalDate.parse(it.startDate), LocalDate.parse(it.endDate)
         )
     }
 
-    val groupedByMonth: Map<YearMonth, List<RequestInfoDto>> = sampleRequestHistory.groupBy {
+    val groupedByMonth: Map<YearMonth, List<RequestInfoDto>> = requestHistory.groupBy {
         YearMonth.from(LocalDate.parse(it.startDate))
     }
 
@@ -74,7 +73,7 @@ fun RequestHistoryScreen(navHostController: NavHostController, productViewModel:
                         if (info.chatRoomId != null) {
                             moveScreen(
                                 navHostController,
-                                "${NavigationRoutes.NAVHOSTCHAT}/$productId/${info.chatRoomId}"
+                                "${NavigationRoutes.NAVHOSTCHAT}/$productId/${info.reservationId}/${info.chatRoomId}"
                             )
                         } else {
                             userViewModel.postNewChat(
@@ -82,7 +81,7 @@ fun RequestHistoryScreen(navHostController: NavHostController, productViewModel:
                                 onSuccess = { chatRoomId ->
                                     moveScreen(
                                         navHostController,
-                                        "${NavigationRoutes.NAVHOSTCHAT}/$productId/$chatRoomId"
+                                        "${NavigationRoutes.NAVHOSTCHAT}/$productId/${info.reservationId}/$chatRoomId"
                                     )
                                 },
                                 onError = {

--- a/app/src/main/java/com/example/rentit/feature/user/UserViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/UserViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.data.chat.repository.ChatRepository
 import com.example.rentit.data.product.dto.ProductDto
+import com.example.rentit.data.user.dto.ReservationDto
 import com.example.rentit.data.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,10 +21,23 @@ class UserViewModel @Inject constructor(
     private val _myProductList = MutableStateFlow<List<ProductDto>>(emptyList())
     val myProductList: StateFlow<List<ProductDto>> = _myProductList
 
+    private val _myRentalList = MutableStateFlow<List<ReservationDto>>(emptyList())
+    val myRentalList: StateFlow<List<ReservationDto>> = _myRentalList
+
     fun getMyProductList() {
         viewModelScope.launch {
             userRepository.getMyProductList().onSuccess {
                 _myProductList.value = it.myProducts
+            }.onFailure {
+                /* 로딩 실패 시 */
+            }
+        }
+    }
+
+    fun getMyRentalList() {
+        viewModelScope.launch {
+            userRepository.getMyRentalList().onSuccess {
+                _myRentalList.value = it.myReservations
             }.onFailure {
                 /* 로딩 실패 시 */
             }

--- a/app/src/main/java/com/example/rentit/feature/user/component/RentalHistoryListItem.kt
+++ b/app/src/main/java/com/example/rentit/feature/user/component/RentalHistoryListItem.kt
@@ -1,0 +1,140 @@
+package com.example.rentit.feature.user.component
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.rentit.R
+import com.example.rentit.common.component.getKorDayOfWeek
+import com.example.rentit.common.enums.BookingStatus
+import com.example.rentit.common.theme.Gray400
+import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.common.theme.SecondaryYellow
+import com.example.rentit.data.product.dto.OwnerDto
+import com.example.rentit.data.product.dto.PeriodDto
+import com.example.rentit.data.product.dto.ProductDto
+import com.example.rentit.data.user.dto.ReservationDto
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun RentalHistoryListItem(rentalInfo: ReservationDto) {
+    val formatter = DateTimeFormatter.ofPattern("yy.MM.dd")
+    val requestedAt = LocalDateTime.parse(rentalInfo.requestedAt).toLocalDate()
+    val startDate = LocalDate.parse(rentalInfo.startDate)
+    val endDate = LocalDate.parse(rentalInfo.endDate)
+    val period = ChronoUnit.DAYS.between(startDate, endDate).toInt() + 1
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(25.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            modifier = Modifier
+                .size(70.dp)
+                .clip(RoundedCornerShape(20.dp)),
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(rentalInfo.product.thumbnailImgUrl)
+                .error(R.drawable.img_thumbnail_placeholder)
+                .placeholder(R.drawable.img_thumbnail_placeholder)
+                .fallback(R.drawable.img_thumbnail_placeholder)
+                .build(),
+            contentDescription = stringResource(id = R.string.common_list_item_thumbnail_img_placeholder_description),
+            contentScale = ContentScale.Crop
+        )
+        Column(Modifier.padding(start = 18.dp)) {
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(
+                    modifier = Modifier.padding(end = 8.dp),
+                    text = rentalInfo.product.title,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                Text(
+                    text = if(rentalInfo.status == BookingStatus.ACCEPTED.name)
+                        stringResource(R.string.screen_mypage_my_rental_list_item_label_renting)
+                    else BookingStatus.fromLabel(rentalInfo.status)?.label ?: "",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = if(rentalInfo.status == BookingStatus.ACCEPTED.name) SecondaryYellow else Gray400
+                )
+            }
+            Text(
+                modifier = Modifier.padding(top = 5.dp, bottom = 8.dp),
+                text = stringResource(
+                    id = R.string.request_history_list_item_period,
+                    startDate.format(formatter),
+                    getKorDayOfWeek(startDate.dayOfWeek.toString()),
+                    endDate.format(formatter),
+                    getKorDayOfWeek(endDate.dayOfWeek.toString()),
+                    period
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                text = "${stringResource(R.string.screen_mypage_my_rental_list_item_label_request_at)} ${requestedAt.format(formatter)}",
+                style = MaterialTheme.typography.labelMedium,
+                color = Gray400
+            )
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Preview
+@Composable
+fun PreviewRentalHistoryListItem() {
+    val sampleReservation = ReservationDto(
+        reservationId = 1001,
+        product = ProductDto(
+            productId = 1,
+            title = "캐논 EOS 550D",
+            description = "가볍고 튼튼해요",
+            price = 10000,
+            thumbnailImgUrl = "",
+            region = "서울특별시",
+            period = PeriodDto(
+                cycle = "daily",
+                min = 1,
+                max = 6
+            ),
+            owner = OwnerDto(
+                userId = 1,
+                nickname = "예준"
+            ),
+            status = "AVAILABLE",
+            categories = emptyList(),
+            createdAt = "2025-03-22T12:00:00"
+        ),
+        startDate = "2025-04-15",
+        endDate = "2025-04-17",
+        status = "PENDING",
+        requestedAt = "2025-03-20T14:00:00"
+    )
+    RentItTheme {
+        RentalHistoryListItem(sampleReservation)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,9 @@
     <string name="screen_mypage_tab_title_on_rent">대여 중</string>
     <string name="screen_mypage_text_tab_list_empty">게시글이 없어요</string>
 
+    <string name="screen_mypage_my_rental_list_item_label_renting">대여중</string>
+    <string name="screen_mypage_my_rental_list_item_label_request_at">요청일: </string>
+
     <string name="error_mypage_new_chatroom">채팅방 생성에 실패했어요.</string>
 
     <string name="request_history_list_item_period">%s (%s) ~ %s (%s) · %d일</string>


### PR DESCRIPTION
# Pull Request

## Summary  
- 백엔드 수정에 따른 채팅방 상세 데이터 연결 수정과 채팅방에서 진행되는 예약 요청 수락 후 처리 플로우 완성
- 대여 내역과 관련된 페이지 수정 및 구현

## Related Issue  
- Close: #38 

## Changes  
- 채팅 리스트 API Response DTO 수정하여 productId와 reservationId 받음
- 채팅방 화면에서 임시 데이터를 제거하고 productId를 사용, 상품 정보를 실제 데이터로 연결
- 채팅방 화면에서 예약 요청 처리 시 reservationId, productId에 사용되었던 임시 데이터를 제거하고 실제 데이터로 연결
- 마이페이지의 대여중 탭에 표시될 리스트 요소 UI 컴포넌트 구현 
- '대여중인 상품' API 연결 및 대여중 탭에 연동
- 상품 상세 페이지의 상품 대여 내역에 임시 데이터를 지우고 실제 데이터 연결
- 상품 상세 및 연결된 예약 내역 페이지의 예약 내역 실제 데이터로 연결
- 예약 내역 페이지의 예약 내역을 'PENDING'(예약 요청) 상태만 표시하도록 변경
- 상품 상세 페이지의 대여 내역 확인 Drawer에서 리스트 임시 제거 (서버 데이터 부족)

## Notes  
- '대여중인 상품' API 수정 이후 구현 결과 확인 필요
