### PR TITLE
Refactor/42 home chat mypage restructure

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/CommonProductListItem.kt
+++ b/app/src/main/java/com/example/rentit/common/component/CommonProductListItem.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.home.component
+package com.example.rentit.common.component
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -33,8 +33,6 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.rentit.R
 import com.example.rentit.common.component.ProductStatus.getKorProductStatus
-import com.example.rentit.common.component.basicListItemTopDivider
-import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme

--- a/app/src/main/java/com/example/rentit/common/websocket/WebSocketManager.kt
+++ b/app/src/main/java/com/example/rentit/common/websocket/WebSocketManager.kt
@@ -21,7 +21,7 @@ object WebSocketManager {
     private var sendDisposable: Disposable? = null
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun connect(chatroomId: String, receiverId: Long, token: String, onConnect: () -> Unit, onMessageReceived: (MessageResponseDto) -> Unit) {
+    fun connect(chatroomId: String, token: String, onConnect: () -> Unit, onMessageReceived: (MessageResponseDto) -> Unit) {
         val url = "ws://api.rentit.o-r.kr:8080/ws/chat/websocket"
         stompClient = Stomp.over(Stomp.ConnectionProvider.OKHTTP, url)
 

--- a/app/src/main/java/com/example/rentit/common/websocket/WebSocketManager.kt
+++ b/app/src/main/java/com/example/rentit/common/websocket/WebSocketManager.kt
@@ -5,7 +5,7 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import com.example.rentit.data.chat.dto.MessageRequestDto
 import com.example.rentit.data.chat.dto.MessageResponseDto
-import com.example.rentit.feature.chat.model.ChatMessageUiModel
+import com.example.rentit.feature.chat.chatroom.model.ChatMessageUiModel
 import com.google.gson.Gson
 import ua.naiksoftware.stomp.Stomp
 import ua.naiksoftware.stomp.StompClient

--- a/app/src/main/java/com/example/rentit/common/websocket/WebSocketManager.kt
+++ b/app/src/main/java/com/example/rentit/common/websocket/WebSocketManager.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import com.example.rentit.data.chat.dto.MessageRequestDto
 import com.example.rentit.data.chat.dto.MessageResponseDto
-import com.example.rentit.feature.chat.chatroom.model.ChatMessageUiModel
 import com.google.gson.Gson
 import ua.naiksoftware.stomp.Stomp
 import ua.naiksoftware.stomp.StompClient
@@ -22,7 +21,7 @@ object WebSocketManager {
     private var sendDisposable: Disposable? = null
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun connect(chatroomId: String, receiverId: Long, token: String, onConnect: () -> Unit, onMessageReceived: (ChatMessageUiModel) -> Unit) {
+    fun connect(chatroomId: String, receiverId: Long, token: String, onConnect: () -> Unit, onMessageReceived: (MessageResponseDto) -> Unit) {
         val url = "ws://api.rentit.o-r.kr:8080/ws/chat/websocket"
         stompClient = Stomp.over(Stomp.ConnectionProvider.OKHTTP, url)
 
@@ -46,9 +45,9 @@ object WebSocketManager {
             ?.observeOn(AndroidSchedulers.mainThread())
             ?.subscribe { topicMessage ->
                 val json = topicMessage.payload
-                val dto = Gson().fromJson(json, MessageResponseDto::class.java)
+                val response = Gson().fromJson(json, MessageResponseDto::class.java)
                 Log.d(TAG, "Received message: ${topicMessage.payload}")
-                onMessageReceived(ChatMessageUiModel(dto.senderId == receiverId, dto.content, dto.sentAt))
+                onMessageReceived(response)
             }
 
     }

--- a/app/src/main/java/com/example/rentit/feature/MainView.kt
+++ b/app/src/main/java/com/example/rentit/feature/MainView.kt
@@ -38,7 +38,7 @@ import com.example.rentit.feature.chat.AcceptConfirmationScreen
 import com.example.rentit.feature.chat.ChatListScreen
 import com.example.rentit.feature.chat.ChatroomScreen
 import com.example.rentit.feature.home.HomeScreen
-import com.example.rentit.feature.user.MyPageScreen
+import com.example.rentit.feature.mypage.MyPageScreen
 import com.example.rentit.feature.productdetail.reservation.request.ResvRequestScreen
 import com.example.rentit.feature.createpost.CreatePostScreen
 import com.example.rentit.feature.productdetail.ProductDetailScreen

--- a/app/src/main/java/com/example/rentit/feature/MainView.kt
+++ b/app/src/main/java/com/example/rentit/feature/MainView.kt
@@ -34,9 +34,9 @@ import com.example.rentit.common.component.moveScreen
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.feature.chat.AcceptConfirmationScreen
+import com.example.rentit.feature.chat.chatroom.requestaccept.confirm.RequestAcceptConfirmScreen
 import com.example.rentit.feature.chat.ChatListScreen
-import com.example.rentit.feature.chat.ChatroomScreen
+import com.example.rentit.feature.chat.chatroom.ChatroomScreen
 import com.example.rentit.feature.home.HomeScreen
 import com.example.rentit.feature.mypage.MyPageScreen
 import com.example.rentit.feature.productdetail.reservation.request.ResvRequestScreen
@@ -185,7 +185,7 @@ fun ChatroomNavHost(productId: Int?, reservationId: Int?, chatRoomId: String?) {
     val navHostController: NavHostController = rememberNavController()
     NavHost(navController =  navHostController, startDestination = NavigationRoutes.CHATROOM){
         composable(NavigationRoutes.CHATROOM) { ChatroomScreen(navHostController, productId, reservationId, chatRoomId) }
-        composable(NavigationRoutes.ACCEPTCONFIRM) { AcceptConfirmationScreen(navHostController) }
+        composable(NavigationRoutes.ACCEPTCONFIRM) { RequestAcceptConfirmScreen(navHostController) }
         composable(NavigationRoutes.MAIN) { MainView() }
     }
 }

--- a/app/src/main/java/com/example/rentit/feature/MainView.kt
+++ b/app/src/main/java/com/example/rentit/feature/MainView.kt
@@ -40,7 +40,7 @@ import com.example.rentit.feature.chat.chatroom.ChatroomScreen
 import com.example.rentit.feature.home.HomeScreen
 import com.example.rentit.feature.mypage.MyPageScreen
 import com.example.rentit.feature.productdetail.reservation.request.ResvRequestScreen
-import com.example.rentit.feature.createpost.CreatePostScreen
+import com.example.rentit.feature.home.createpost.CreatePostScreen
 import com.example.rentit.feature.productdetail.ProductDetailScreen
 import com.example.rentit.feature.productdetail.reservation.request.complete.ResvRequestCompleteScreen
 import com.example.rentit.feature.productdetail.reservation.requesthistory.RequestHistoryScreen

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
@@ -31,7 +31,7 @@ import com.example.rentit.common.component.NavigationRoutes
 import com.example.rentit.common.component.moveScreen
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.feature.chat.component.ChatListItem
+import com.example.rentit.feature.chat.components.ChatListItem
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -101,7 +101,7 @@ fun OrderButtonSection() {
 @RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
-fun ChatListScreenPreview() {
+private fun Preview() {
     RentItTheme {
         ChatListScreen(rememberNavController())
     }

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatListScreen.kt
@@ -36,13 +36,13 @@ import com.example.rentit.feature.chat.components.ChatListItem
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun ChatListScreen(navHostController: NavHostController) {
-    val chatViewModel: ChatViewModel = hiltViewModel()
-    val chatList by chatViewModel.chatList.collectAsStateWithLifecycle()
+    val chatListViewModel: ChatListViewModel = hiltViewModel()
+    val chatList by chatListViewModel.chatList.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     // 최초 한 번만 호출
     LaunchedEffect(Unit) {
-        chatViewModel.getChatList {
+        chatListViewModel.getChatList {
             Toast.makeText(
                 context,
                 context.getString(R.string.error_chat_list_load),

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatListViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatListViewModel.kt
@@ -1,0 +1,30 @@
+package com.example.rentit.feature.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.rentit.data.chat.dto.ChatRoomSummaryDto
+import com.example.rentit.data.chat.repository.ChatRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatListViewModel @Inject constructor(
+    private val chatRepository: ChatRepository,
+) : ViewModel() {
+
+    private val _chatList = MutableStateFlow<List<ChatRoomSummaryDto>>(emptyList())
+    val chatList: StateFlow<List<ChatRoomSummaryDto>> = _chatList
+
+    fun getChatList(onError: (Throwable) -> Unit = {}) {
+        viewModelScope.launch {
+            chatRepository.getChatList()
+                .onSuccess {
+                    _chatList.value = it.chatRooms
+                }
+                .onFailure(onError)
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
@@ -58,8 +58,9 @@ class ChatViewModel @Inject constructor(
     @RequiresApi(Build.VERSION_CODES.O)
     fun connectWebSocket(chatroomId: String, onConnect: () -> Unit) {
         val token = getToken(context) ?: return
-        WebSocketManager.connect(chatroomId, myId, token, onConnect) {
-            _realTimeMessages.value = listOf(it) + _realTimeMessages.value
+        WebSocketManager.connect(chatroomId, myId, token, onConnect) { data ->
+            val msg = ChatMessageUiModel(data.senderId == myId, data.content, data.sentAt)
+            _realTimeMessages.value = listOf(msg) + _realTimeMessages.value
         }
     }
 

--- a/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/ChatViewModel.kt
@@ -16,7 +16,7 @@ import com.example.rentit.data.chat.repository.ChatRepository
 import com.example.rentit.data.product.dto.ProductDetailResponseDto
 import com.example.rentit.data.product.dto.UpdateResvStatusRequestDto
 import com.example.rentit.data.product.repository.ProductRepository
-import com.example.rentit.feature.chat.model.ChatMessageUiModel
+import com.example.rentit.feature.chat.chatroom.model.ChatMessageUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/example/rentit/feature/chat/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/chatroom/ChatRoomScreen.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.chat
+package com.example.rentit.feature.chat.chatroom
 
 import android.os.Build
 import android.widget.Toast
@@ -69,9 +69,11 @@ import com.example.rentit.common.theme.Gray800
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.data.chat.dto.StatusHistoryDto
 import com.example.rentit.data.product.dto.ProductDto
-import com.example.rentit.feature.chat.component.ReceivedMsgBubble
-import com.example.rentit.feature.chat.component.SentMsgBubble
-import com.example.rentit.feature.chat.model.ChatMessageUiModel
+import com.example.rentit.feature.chat.ChatViewModel
+import com.example.rentit.feature.chat.chatroom.requestaccept.RequestAcceptDialog
+import com.example.rentit.feature.chat.chatroom.components.ReceivedMsgBubble
+import com.example.rentit.feature.chat.chatroom.components.SentMsgBubble
+import com.example.rentit.feature.chat.chatroom.model.ChatMessageUiModel
 import java.text.NumberFormat
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter

--- a/app/src/main/java/com/example/rentit/feature/chat/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/chatroom/ChatRoomScreen.kt
@@ -69,7 +69,6 @@ import com.example.rentit.common.theme.Gray800
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.data.chat.dto.StatusHistoryDto
 import com.example.rentit.data.product.dto.ProductDto
-import com.example.rentit.feature.chat.ChatViewModel
 import com.example.rentit.feature.chat.chatroom.requestaccept.RequestAcceptDialog
 import com.example.rentit.feature.chat.chatroom.components.ReceivedMsgBubble
 import com.example.rentit.feature.chat.chatroom.components.SentMsgBubble
@@ -81,17 +80,17 @@ import java.time.format.DateTimeFormatter
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reservationId: Int?, chatRoomId: String?) {
-    val chatViewModel: ChatViewModel = hiltViewModel()
-    val productDetail by chatViewModel.productDetail.collectAsStateWithLifecycle()
-    val chatDetail by chatViewModel.chatDetail.collectAsStateWithLifecycle()
+    val chatRoomViewModel: ChatRoomViewModel = hiltViewModel()
+    val productDetail by chatRoomViewModel.productDetail.collectAsStateWithLifecycle()
+    val chatDetail by chatRoomViewModel.chatDetail.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     // 백엔드 오류로 인한 임시 요청 확인 처리
-    val isRequestAccepted by chatViewModel.isRequestAccepted.collectAsStateWithLifecycle()
+    val isRequestAccepted by chatRoomViewModel.isRequestAccepted.collectAsStateWithLifecycle()
 
-    val senderNickname by chatViewModel.senderNickname.collectAsStateWithLifecycle()
-    val initialMessages by chatViewModel.initialMessages.collectAsStateWithLifecycle()
-    val realTimeMessages by chatViewModel.realTimeMessages.collectAsStateWithLifecycle()
+    val senderNickname by chatRoomViewModel.senderNickname.collectAsStateWithLifecycle()
+    val initialMessages by chatRoomViewModel.initialMessages.collectAsStateWithLifecycle()
+    val realTimeMessages by chatRoomViewModel.realTimeMessages.collectAsStateWithLifecycle()
 
     var textFieldValue by remember { mutableStateOf(TextFieldValue("")) }
     val inputScrollState = rememberScrollState()
@@ -101,17 +100,17 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reserv
 
     // 백엔드 오류로 인한 임시 요청 확인 처리
     LaunchedEffect(initialMessages + realTimeMessages) {
-        chatViewModel.checkRequestAccepted()
+        chatRoomViewModel.checkRequestAccepted()
     }
 
     LaunchedEffect(Unit) {
-        chatViewModel.resetRealTimeMessages()
+        chatRoomViewModel.resetRealTimeMessages()
         var errorMsg = context.getString(R.string.error_chat_unknown)
         if (chatRoomId != null && productId != null) {
-            chatViewModel.connectWebSocket(chatRoomId) {
+            chatRoomViewModel.connectWebSocket(chatRoomId) {
                 Toast.makeText(context, context.getString(R.string.toast_chatroom_entered), Toast.LENGTH_SHORT).show()
             }
-            chatViewModel.getChatDetail(chatRoomId){
+            chatRoomViewModel.getChatDetail(chatRoomId){
                 when(it){
                     is ForbiddenChatAccessException -> errorMsg = context.getString(R.string.error_chat_access)
                     is ServerException -> errorMsg = context.getString(R.string.error_common_server)
@@ -120,7 +119,7 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reserv
                 Toast.makeText(context, errorMsg, Toast.LENGTH_SHORT).show()
                 moveScreen(navHostController, NavigationRoutes.MAIN)
             }
-            chatViewModel.getProductDetail(productId){
+            chatRoomViewModel.getProductDetail(productId){
                 Toast.makeText(context, errorMsg, Toast.LENGTH_SHORT).show()
                 moveScreen(navHostController, NavigationRoutes.MAIN)
             }
@@ -138,7 +137,7 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reserv
 
     DisposableEffect(Unit) {
         onDispose {
-            chatViewModel.disconnectWebSocket()
+            chatRoomViewModel.disconnectWebSocket()
         }
     }
 
@@ -169,7 +168,7 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reserv
             onValueChange = { textFieldValue = it },
             onSend = {
                 if (chatRoomId != null && textFieldValue.text.isNotEmpty()) {
-                    chatViewModel.sendMessage(chatRoomId, textFieldValue.text)
+                    chatRoomViewModel.sendMessage(chatRoomId, textFieldValue.text)
                     textFieldValue = TextFieldValue("")
                 }
             }
@@ -181,7 +180,7 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reserv
             onDismissRequest = { showAcceptDialog = false },
             onAcceptRequest = {
                 if(productId != null && chatRoomId != null && reservationId != null){
-                    chatViewModel.updateResvStatus(
+                    chatRoomViewModel.updateResvStatus(
                         chatRoomId,
                         productId,
                         reservationId,

--- a/app/src/main/java/com/example/rentit/feature/chat/chatroom/ChatRoomViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/chatroom/ChatRoomViewModel.kt
@@ -80,7 +80,7 @@ class ChatRoomViewModel @Inject constructor(
     @RequiresApi(Build.VERSION_CODES.O)
     fun connectWebSocket(chatroomId: String, onConnect: () -> Unit) {
         val token = getToken(context) ?: return
-        WebSocketManager.connect(chatroomId, myId, token, onConnect) { data ->
+        WebSocketManager.connect(chatroomId, token, onConnect) { data ->
             val msg = ChatMessageUiModel(data.senderId == myId, data.content, data.sentAt)
             _realTimeMessages.value = listOf(msg) + _realTimeMessages.value
         }

--- a/app/src/main/java/com/example/rentit/feature/chat/chatroom/ChatRoomViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/chatroom/ChatRoomViewModel.kt
@@ -78,17 +78,17 @@ class ChatRoomViewModel @Inject constructor(
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun connectWebSocket(chatroomId: String, onConnect: () -> Unit) {
+    fun connectWebSocket(chatRoomId: String, onConnect: () -> Unit) {
         val token = getToken(context) ?: return
-        WebSocketManager.connect(chatroomId, token, onConnect) { data ->
+        WebSocketManager.connect(chatRoomId, token, onConnect) { data ->
             val msg = ChatMessageUiModel(data.senderId == myId, data.content, data.sentAt)
             _realTimeMessages.value = listOf(msg) + _realTimeMessages.value
         }
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun sendMessage(chatroomId: String, message: String) {
-        WebSocketManager.sendMessage(chatroomId, myId, message)
+    fun sendMessage(chatRoomId: String, message: String) {
+        WebSocketManager.sendMessage(chatRoomId, myId, message)
     }
 
     fun disconnectWebSocket() {

--- a/app/src/main/java/com/example/rentit/feature/chat/chatroom/components/AutoMsgBubble.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/chatroom/components/AutoMsgBubble.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.chat.component
+package com.example.rentit.feature.chat.chatroom.components
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -96,7 +96,7 @@ fun AutoMsgBubble(isSender: Boolean, type: AutoMsgType, onPayClick: () -> Unit =
 @RequiresApi(Build.VERSION_CODES.O)
 @Preview
 @Composable
-fun PreviewAutoMsgBubble() {
+private fun Preview() {
     RentItTheme {
         AutoMsgBubble(true, AutoMsgType.COMPLETE_PAY)
     }

--- a/app/src/main/java/com/example/rentit/feature/chat/chatroom/components/ReceivedMsgBubble.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/chatroom/components/ReceivedMsgBubble.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.chat.component
+package com.example.rentit.feature.chat.chatroom.components
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -99,7 +99,7 @@ private fun formatDateTime(dateTimeString: String): String {
 @RequiresApi(Build.VERSION_CODES.O)
 @Preview
 @Composable
-fun PreviewReceivedMsgBubble() {
+private fun Preview() {
     RentItTheme {
         ReceivedMsgBubble("메세지 샘플", "2025-03-25T09:30:00Z", "홍길동")
     }

--- a/app/src/main/java/com/example/rentit/feature/chat/chatroom/components/SentMsgBubble.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/chatroom/components/SentMsgBubble.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.chat.component
+package com.example.rentit.feature.chat.chatroom.components
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -82,7 +82,7 @@ private fun formatDateTime(dateTimeString: String): String {
 @RequiresApi(Build.VERSION_CODES.O)
 @Preview
 @Composable
-fun PreviewSentMsgBubble() {
+private fun Preview() {
     RentItTheme {
         SentMsgBubble("메세지 샘플", "2025-03-25T09:30:00Z")
     }

--- a/app/src/main/java/com/example/rentit/feature/chat/chatroom/model/ChatMessageUiModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/chatroom/model/ChatMessageUiModel.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.chat.model
+package com.example.rentit.feature.chat.chatroom.model
 
 data class ChatMessageUiModel (
     val isMine: Boolean,

--- a/app/src/main/java/com/example/rentit/feature/chat/chatroom/requestaccept/RequestAcceptDialog.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/chatroom/requestaccept/RequestAcceptDialog.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.chat
+package com.example.rentit.feature.chat.chatroom.requestaccept
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -112,7 +112,7 @@ fun RequestAcceptDialog(productPrice: Int, onDismissRequest: () -> Unit, onAccep
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewRequestAcceptDialog() {
+private fun Preview() {
     RentItTheme {
         RequestAcceptDialog(10000, onDismissRequest = {}, onAcceptRequest = {})
     }

--- a/app/src/main/java/com/example/rentit/feature/chat/chatroom/requestaccept/confirm/RequestAcceptConfirmScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/chatroom/requestaccept/confirm/RequestAcceptConfirmScreen.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.chat
+package com.example.rentit.feature.chat.chatroom.requestaccept.confirm
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -27,7 +27,7 @@ import com.example.rentit.common.theme.RentItTheme
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun AcceptConfirmationScreen(navHostController: NavHostController) {
+fun RequestAcceptConfirmScreen(navHostController: NavHostController) {
 
     Column(
         modifier = Modifier
@@ -62,8 +62,8 @@ fun AcceptConfirmationScreen(navHostController: NavHostController) {
 @RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
-fun PreviewAcceptConfirmationScreen() {
+private fun Preview() {
     RentItTheme {
-        AcceptConfirmationScreen(rememberNavController())
+        RequestAcceptConfirmScreen(rememberNavController())
     }
 }

--- a/app/src/main/java/com/example/rentit/feature/chat/components/ChatListItem.kt
+++ b/app/src/main/java/com/example/rentit/feature/chat/components/ChatListItem.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.chat.component
+package com.example.rentit.feature.chat.components
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/example/rentit/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/home/HomeScreen.kt
@@ -32,7 +32,7 @@ import com.example.rentit.common.component.NavigationRoutes
 import com.example.rentit.common.component.moveScreen
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.feature.home.component.ProductListItem
+import com.example.rentit.common.component.ProductListItem
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable

--- a/app/src/main/java/com/example/rentit/feature/home/createpost/CreatePostScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/home/createpost/CreatePostScreen.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.createpost
+package com.example.rentit.feature.home.createpost
 
 import android.net.Uri
 import android.util.Log
@@ -79,7 +79,8 @@ import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.data.product.dto.CategoryDto
 import com.example.rentit.data.product.dto.CreatePostRequestDto
 import com.example.rentit.data.product.dto.PeriodDto
-import com.example.rentit.feature.createpost.component.RemovableTagButton
+import com.example.rentit.feature.home.createpost.categorytag.CategoryTagDrawer
+import com.example.rentit.feature.home.createpost.component.RemovableTagButton
 import java.text.NumberFormat
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -91,8 +92,10 @@ fun CreatePostScreen(navHostController: NavHostController) {
     var periodSliderPosition by remember { mutableStateOf(3F..15F) }
     var price by remember { mutableIntStateOf(0) }
     var priceInput by remember { mutableStateOf(TextFieldValue()) }
+
     val createPostViewModel: CreatePostViewModel = hiltViewModel()
-    val selectedCategoryList by createPostViewModel.categoryTagList.collectAsStateWithLifecycle()
+    val categoryList by createPostViewModel.categoryList.collectAsStateWithLifecycle()
+    val selectedCategoryList by createPostViewModel.selectedCategoryList.collectAsStateWithLifecycle()
     val selectedImgUriList by createPostViewModel.selectedImgUriList.collectAsStateWithLifecycle()
 
     val priceLimit = 5000000
@@ -176,6 +179,7 @@ fun CreatePostScreen(navHostController: NavHostController) {
         if(showTagDrawer) {
             ModalBottomSheet(onDismissRequest = { showTagDrawer = false }) {
                 CategoryTagDrawer(
+                    categoryList = categoryList,
                     selectedCategoryList = selectedCategoryList,
                     onTagButtonClick = createPostViewModel::handleCategoryClick
                 )

--- a/app/src/main/java/com/example/rentit/feature/home/createpost/CreatePostViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/home/createpost/CreatePostViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.createpost
+package com.example.rentit.feature.home.createpost
 
 import android.content.Context
 import android.net.Uri
@@ -29,24 +29,11 @@ class CreatePostViewModel @Inject constructor(
     private val repository: ProductRepository
 ) : ViewModel() {
 
-    val sampleCategoryList = listOf(
-        CategoryDto(1, "취미", true, null),
-        CategoryDto(2, "태그2", false, 1),
-        CategoryDto(3, "태그3", false, 1),
-        CategoryDto(4, "태그4", false, 1),
-        CategoryDto(5, "스포츠", true, null),
-        CategoryDto(6, "태그22", false, 5),
-        CategoryDto(7, "태그22", false, 5),
-        CategoryDto(8, "태그2sdfasdfasdf2", false, 5),
-        CategoryDto(9, "태그2sdfasdfasdf2", false, 5),
-        CategoryDto(10, "태그22", false, 5),
-    )
-
     private val _categoryList = MutableStateFlow<List<CategoryDto>>(emptyList())
     val categoryList: StateFlow<List<CategoryDto>> = _categoryList
 
-    private val _categoryTagList =  MutableStateFlow<List<CategoryDto>>(emptyList())
-    val categoryTagList: StateFlow<List<CategoryDto>> = _categoryTagList
+    private val _selectedCategoryList =  MutableStateFlow<List<CategoryDto>>(emptyList())
+    val selectedCategoryList: StateFlow<List<CategoryDto>> = _selectedCategoryList
 
     private val _selectedImgUriList =  MutableStateFlow<List<Uri>>(emptyList())
     val selectedImgUriList: StateFlow<List<Uri>> = _selectedImgUriList
@@ -55,10 +42,9 @@ class CreatePostViewModel @Inject constructor(
     val createPostResult: StateFlow<Result<CreatePostResponseDto>?> = _createPostResult
 
     init {
-        viewModelScope.launch {
-            getCategoryList()
-        }
+        getCategoryList()
     }
+
     private fun getCategoryList() {
         viewModelScope.launch {
             repository.getCategories().onSuccess {
@@ -70,16 +56,16 @@ class CreatePostViewModel @Inject constructor(
     }
 
     fun handleCategoryClick(category: CategoryDto) {
-        if(_categoryTagList.value.contains(category)){
-            _categoryTagList.value = _categoryTagList.value - category
+        if(_selectedCategoryList.value.contains(category)){
+            _selectedCategoryList.value -= category
         } else {
-            _categoryTagList.value = _categoryTagList.value + category
+            _selectedCategoryList.value += category
         }
     }
 
     fun removeSelectedCategory(category: CategoryDto) {
-        if(_categoryTagList.value.contains(category)){
-            _categoryTagList.value = _categoryTagList.value - category
+        if(_selectedCategoryList.value.contains(category)){
+            _selectedCategoryList.value -= category
         }
     }
 
@@ -88,7 +74,7 @@ class CreatePostViewModel @Inject constructor(
     }
 
     fun removeImageUri(uri: Uri){
-        _selectedImgUriList.value = _selectedImgUriList.value - uri
+        _selectedImgUriList.value -= uri
     }
 
     fun createPost(postData: CreatePostRequestDto, thumbnailImgUri: Uri?) {

--- a/app/src/main/java/com/example/rentit/feature/home/createpost/categorytag/CategoryTagDrawer.kt
+++ b/app/src/main/java/com/example/rentit/feature/home/createpost/categorytag/CategoryTagDrawer.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.createpost
+package com.example.rentit.feature.home.createpost.categorytag
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -7,26 +7,22 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.data.product.dto.CategoryDto
-import com.example.rentit.feature.createpost.component.TagButton
+import com.example.rentit.feature.home.createpost.LabeledContent
+import com.example.rentit.feature.home.createpost.component.TagButton
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun CategoryTagDrawer(
-    selectedCategoryList: List<CategoryDto>,
+    categoryList: List<CategoryDto>,
+    selectedCategoryList: List<CategoryDto> = emptyList(),
     onTagButtonClick: (CategoryDto) -> Unit
 ) {
-    val createPostViewModel: CreatePostViewModel = hiltViewModel()
-    val categoryList by createPostViewModel.categoryList.collectAsStateWithLifecycle()
-
     val parentCatList = categoryList.filter { it.isParent }
     Column(
         modifier = Modifier
@@ -58,6 +54,6 @@ fun CategoryTagDrawer(
 @Composable
 fun PreviewCategoryTagDrawer() {
     RentItTheme {
-        CategoryTagDrawer(selectedCategoryList = emptyList()){}
+        CategoryTagDrawer(categoryList = emptyList()){}
     }
 }

--- a/app/src/main/java/com/example/rentit/feature/home/createpost/component/RemovableTagButton.kt
+++ b/app/src/main/java/com/example/rentit/feature/home/createpost/component/RemovableTagButton.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.createpost.component
+package com.example.rentit.feature.home.createpost.component
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height

--- a/app/src/main/java/com/example/rentit/feature/home/createpost/component/TagButton.kt
+++ b/app/src/main/java/com/example/rentit/feature/home/createpost/component/TagButton.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.createpost.component
+package com.example.rentit.feature.home.createpost.component
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row

--- a/app/src/main/java/com/example/rentit/feature/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/example/rentit/feature/mypage/MyPageScreen.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.user
+package com.example.rentit.feature.mypage
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -57,23 +57,23 @@ import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.pretendardFamily
 import com.example.rentit.data.product.dto.ProductDto
 import com.example.rentit.data.user.dto.ReservationDto
-import com.example.rentit.feature.home.component.ProductListItem
-import com.example.rentit.feature.user.component.RentalHistoryListItem
+import com.example.rentit.common.component.ProductListItem
+import com.example.rentit.feature.mypage.component.MyRentalHistoryListItem
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun MyPageScreen(navHostController: NavHostController) {
-    val userViewModel: UserViewModel = hiltViewModel()
+    val myPageViewModel: MyPageViewModel = hiltViewModel()
 
     var isFirstTabSelected by remember { mutableStateOf(true) }
 
     LaunchedEffect(Unit) {
-        userViewModel.getMyProductList()
-        userViewModel.getMyRentalList()
+        myPageViewModel.getMyProductList()
+        myPageViewModel.getMyRentalList()
     }
 
-    val myProductList by userViewModel.myProductList.collectAsStateWithLifecycle()
-    val myRentalList by userViewModel.myRentalList.collectAsStateWithLifecycle()
+    val myProductList by myPageViewModel.myProductList.collectAsStateWithLifecycle()
+    val myRentalList by myPageViewModel.myRentalList.collectAsStateWithLifecycle()
 
     Column {
         Column(
@@ -264,7 +264,7 @@ fun TabbedListSection(
                 }
             } else {
                 items(myRentList) {
-                    RentalHistoryListItem(it)
+                    MyRentalHistoryListItem(it)
                 }
             }
         } else {

--- a/app/src/main/java/com/example/rentit/feature/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/example/rentit/feature/mypage/MyPageViewModel.kt
@@ -1,8 +1,7 @@
-package com.example.rentit.feature.user
+package com.example.rentit.feature.mypage
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.data.chat.repository.ChatRepository
 import com.example.rentit.data.product.dto.ProductDto
 import com.example.rentit.data.user.dto.ReservationDto
 import com.example.rentit.data.user.repository.UserRepository
@@ -13,9 +12,8 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class UserViewModel @Inject constructor(
+class MyPageViewModel @Inject constructor(
     private val userRepository: UserRepository,
-    private val chatRepository: ChatRepository
 ) : ViewModel() {
 
     private val _myProductList = MutableStateFlow<List<ProductDto>>(emptyList())
@@ -41,16 +39,6 @@ class UserViewModel @Inject constructor(
             }.onFailure {
                 /* 로딩 실패 시 */
             }
-        }
-    }
-
-    fun postNewChat(productId: Int, onSuccess: (String) -> Unit = {}, onError: (Throwable) -> Unit = {}) {
-        viewModelScope.launch {
-            chatRepository.postNewChat(productId)
-                .onSuccess {
-                    onSuccess(it.data.chatRoomId)
-                }
-                .onFailure(onError)
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/feature/mypage/component/MyRentalHistoryListItem.kt
+++ b/app/src/main/java/com/example/rentit/feature/mypage/component/MyRentalHistoryListItem.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.feature.user.component
+package com.example.rentit.feature.mypage.component
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -40,7 +40,7 @@ import java.time.temporal.ChronoUnit
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RentalHistoryListItem(rentalInfo: ReservationDto) {
+fun MyRentalHistoryListItem(rentalInfo: ReservationDto) {
     val formatter = DateTimeFormatter.ofPattern("yy.MM.dd")
     val requestedAt = LocalDateTime.parse(rentalInfo.requestedAt).toLocalDate()
     val startDate = LocalDate.parse(rentalInfo.startDate)
@@ -135,6 +135,6 @@ fun PreviewRentalHistoryListItem() {
         requestedAt = "2025-03-20T14:00:00"
     )
     RentItTheme {
-        RentalHistoryListItem(sampleReservation)
+        MyRentalHistoryListItem(sampleReservation)
     }
 }


### PR DESCRIPTION
# Pull Request

## Summary  
- 하단 탭(홈, 채팅, 마이페이지)과 관련된 화면들 패키지 구조 정리, 각 화면별 뷰모델 분리
- 패키지명 및 변수명 수정

## Related Issue  
- Close: #42 

## Changes  
- chatroom 정확한 카멜 케이스(chatRoom)로 수정
- 홈, 채팅, 마이페이지 화면별로 패키지 생성, 화면의 흐름에 따라 패키지 구조 설정
- API 통신이 필요한 화면의 경우 각각 화면별로 뷰모델 분리

## Screenshots (if applicable)  
<div align="center">
  <img alt="image" src="https://github.com/user-attachments/assets/26ac450c-bf4e-4cd2-967e-fbd1a96aae5f" width="30%"/>
  <img alt="image" src="https://github.com/user-attachments/assets/6ca45f72-4f81-462e-be69-79f34048ccd9" width="30%"/>
  <img alt="image" src="https://github.com/user-attachments/assets/1874ac87-5232-42ec-b68c-2ca49ff7ef4a" width="30%"/>
</div>

## Notes  
UI의 최상위 패키지인 feature은 추후 presentation으로 이름 변경 예정