### PR TITLE
refactor: Rename package 'component' to 'components' (#46)

### DIFF
--- a/app/src/main/java/com/example/rentit/presentation/home/createpost/CreatePostScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/createpost/CreatePostScreen.kt
@@ -80,7 +80,7 @@ import com.example.rentit.data.product.dto.CategoryDto
 import com.example.rentit.data.product.dto.CreatePostRequestDto
 import com.example.rentit.data.product.dto.PeriodDto
 import com.example.rentit.presentation.home.createpost.categorytag.CategoryTagDrawer
-import com.example.rentit.presentation.home.createpost.component.RemovableTagButton
+import com.example.rentit.presentation.home.createpost.components.RemovableTagButton
 import java.text.NumberFormat
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/example/rentit/presentation/home/createpost/categorytag/CategoryTagDrawer.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/createpost/categorytag/CategoryTagDrawer.kt
@@ -14,7 +14,7 @@ import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.data.product.dto.CategoryDto
 import com.example.rentit.presentation.home.createpost.LabeledContent
-import com.example.rentit.presentation.home.createpost.component.TagButton
+import com.example.rentit.presentation.home.createpost.components.TagButton
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable

--- a/app/src/main/java/com/example/rentit/presentation/home/createpost/components/RemovableTagButton.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/createpost/components/RemovableTagButton.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.home.createpost.component
+package com.example.rentit.presentation.home.createpost.components
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height

--- a/app/src/main/java/com/example/rentit/presentation/home/createpost/components/TagButton.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/createpost/components/TagButton.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.home.createpost.component
+package com.example.rentit.presentation.home.createpost.components
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageScreen.kt
@@ -58,7 +58,7 @@ import com.example.rentit.common.theme.pretendardFamily
 import com.example.rentit.data.product.dto.ProductDto
 import com.example.rentit.data.user.dto.ReservationDto
 import com.example.rentit.common.component.ProductListItem
-import com.example.rentit.presentation.mypage.component.MyRentalHistoryListItem
+import com.example.rentit.presentation.mypage.components.MyRentalHistoryListItem
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable

--- a/app/src/main/java/com/example/rentit/presentation/mypage/components/MyRentalHistoryListItem.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/components/MyRentalHistoryListItem.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.mypage.component
+package com.example.rentit.presentation.mypage.components
 
 import android.os.Build
 import androidx.annotation.RequiresApi


### PR DESCRIPTION
# Pull Request

## Summary  
- 각 UI 패키지의 컴포넌트 요소를 담는 패키지 이름 'Components'로 통일

## Related Issue  
- Close: #46 

## Changes  
- home/createpost, mypage 하위 컴포넌트 패키지 이름 'Components'로 수정
