### PR TITLE
refactor: Separate BottomTab navigation for tab switching and externa…

### DIFF
--- a/app/src/main/java/com/example/rentit/navigation/bottomtab/BottomTabNavigation.kt
+++ b/app/src/main/java/com/example/rentit/navigation/bottomtab/BottomTabNavigation.kt
@@ -11,11 +11,19 @@ import com.example.rentit.presentation.mypage.MyPageScreen
 
 fun NavHostController.navigateBottomTab(route: String) {
     navigate(route = route) {
-        popUpTo(BottomTabRoute.Home.route) {
+        popUpTo(graph.startDestinationId) {
             saveState = true
         }
         launchSingleTop = true
         restoreState = true
+    }
+}
+
+fun NavHostController.navigateToHome() {
+    navigate(BottomTabRoute.Home.route) {
+        popUpTo(graph.startDestinationId){
+            inclusive = true
+        }
     }
 }
 

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
@@ -67,8 +67,6 @@ import com.example.rentit.common.theme.Gray800
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.data.chat.dto.StatusHistoryDto
 import com.example.rentit.data.product.dto.ProductDto
-import com.example.rentit.navigation.bottomtab.BottomTabRoute
-import com.example.rentit.navigation.bottomtab.navigateBottomTab
 import com.example.rentit.navigation.chatroom.navigateToRequestAcceptConfirm
 import com.example.rentit.presentation.chat.chatroom.requestaccept.RequestAcceptDialog
 import com.example.rentit.presentation.chat.chatroom.components.ReceivedMsgBubble
@@ -118,15 +116,15 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reserv
                     else -> Unit
                 }
                 Toast.makeText(context, errorMsg, Toast.LENGTH_SHORT).show()
-                navHostController.navigateBottomTab(BottomTabRoute.Chat.route)
+                navHostController.popBackStack()
             }
             chatRoomViewModel.getProductDetail(productId){
                 Toast.makeText(context, errorMsg, Toast.LENGTH_SHORT).show()
-                navHostController.navigateBottomTab(BottomTabRoute.Chat.route)
+                navHostController.popBackStack()
             }
         } else {
             Toast.makeText(context, errorMsg, Toast.LENGTH_SHORT).show()
-            navHostController.navigateBottomTab(BottomTabRoute.Chat.route)
+            navHostController.popBackStack()
         }
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/home/createpost/CreatePostScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/createpost/CreatePostScreen.kt
@@ -79,6 +79,7 @@ import com.example.rentit.data.product.dto.CreatePostRequestDto
 import com.example.rentit.data.product.dto.PeriodDto
 import com.example.rentit.navigation.bottomtab.BottomTabRoute
 import com.example.rentit.navigation.bottomtab.navigateBottomTab
+import com.example.rentit.navigation.bottomtab.navigateToHome
 import com.example.rentit.presentation.home.createpost.categorytag.CategoryTagDrawer
 import com.example.rentit.presentation.home.createpost.components.RemovableTagButton
 import java.text.NumberFormat
@@ -187,7 +188,7 @@ fun CreatePostScreen(navHostController: NavHostController) {
         }
     }
     CreatePostResultHandler(createPostViewModel) {
-        navHostController.navigateBottomTab(BottomTabRoute.Home.route)
+        navHostController.navigateToHome()
     }
 }
 

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/complete/ResvRequestCompleteScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/complete/ResvRequestCompleteScreen.kt
@@ -29,8 +29,7 @@ import com.example.rentit.common.theme.Gray100
 import com.example.rentit.common.theme.Gray800
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.navigation.bottomtab.BottomTabRoute
-import com.example.rentit.navigation.bottomtab.navigateBottomTab
+import com.example.rentit.navigation.bottomtab.navigateToHome
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -75,7 +74,7 @@ fun ResvRequestCompleteScreen(
                 color = PrimaryBlue500)
         }
         CommonButton(text = "완료", containerColor = Gray100, contentColor = AppBlack, modifier = Modifier.padding(top = 52.dp)) {
-            navHostController.navigateBottomTab(BottomTabRoute.Home.route)
+            navHostController.navigateToHome()
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## Summary  
하단 탭간 화면 전환과 외부 그래프 -> 하단 탭 이동 화면 전환 함수를 구분

## Related Issue  
- Closed: #54 

## Changes  
변경된 주요 사항을 bullet point로 정리.
- 하단 탭간 이동에서 popUpTo를 문자열 경로가 아닌 startDestination Id 로 변경해 좀 더 명확한 stack 관리를 수행
- 외부 그래프 -> Home 전환하는 확장 함수 생성
- 외부 그래프의 상태 저장 및 복원(saveState, restoreState) 비활성화
- 외부 그래프에서 Home으로 이동 시 popUpTo에 inclusive = true 적용해 Home 상태 초기화
