### PR TITLE
Refactor/67 rental detail package structure

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/PriceSummary.kt
+++ b/app/src/main/java/com/example/rentit/common/component/PriceSummary.kt
@@ -18,8 +18,8 @@ import com.example.rentit.R
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.util.formatPrice
-import com.example.rentit.presentation.rentaldetail.common.components.LabeledValue
-import com.example.rentit.presentation.rentaldetail.common.model.PriceItemUiModel
+import com.example.rentit.presentation.rentaldetail.components.LabeledValue
+import com.example.rentit.common.model.PriceSummaryUiModel
 
 /**
  * 비용 내역과 총합을 나타내는 UI 컴포넌트
@@ -32,7 +32,7 @@ private val dividerBottomPadding = 14.dp
 @Composable
 fun PriceSummary(
     modifier: Modifier = Modifier,
-    priceItems: List<PriceItemUiModel>,
+    priceItems: List<PriceSummaryUiModel>,
     totalLabel: String,
 ) {
     val totalPrice = priceItems.sumOf { it.price }
@@ -71,8 +71,8 @@ fun PriceSummary(
 @Preview(showBackground = true)
 private fun Preview() {
     val priceItems = listOf(
-        PriceItemUiModel(label = "기본 대여료", price = 30_000),
-        PriceItemUiModel(label = "지연 보상금 (2일)", price = 60_000)
+        PriceSummaryUiModel(label = "기본 대여료", price = 30_000),
+        PriceSummaryUiModel(label = "지연 보상금 (2일)", price = 60_000)
     )
     RentItTheme {
         PriceSummary(

--- a/app/src/main/java/com/example/rentit/common/model/PriceSummaryUiModel.kt
+++ b/app/src/main/java/com/example/rentit/common/model/PriceSummaryUiModel.kt
@@ -1,0 +1,6 @@
+package com.example.rentit.common.model
+
+data class PriceSummaryUiModel(
+    val label: String,
+    val price: Int
+)

--- a/app/src/main/java/com/example/rentit/common/model/RentalSummaryUiModel.kt
+++ b/app/src/main/java/com/example/rentit/common/model/RentalSummaryUiModel.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.common.model
+package com.example.rentit.common.model
 
 data class RentalSummaryUiModel(
     val productTitle: String,

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailRoute.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.renter
+package com.example.rentit.presentation.rentaldetail
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -8,12 +8,13 @@ import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
+import com.example.rentit.presentation.rentaldetail.renter.RentalDetailRenterScreen
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun RentalDetailRenterRoute(navHostController: NavHostController) {
 
-    val viewModel: RentalDetailRenterViewModel = hiltViewModel()
+    val viewModel: RentalDetailViewModel = hiltViewModel()
     val uiModel by viewModel.uiModel.collectAsStateWithLifecycle()
 
     val scrollState = rememberScrollState()

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailRoute.kt
@@ -12,7 +12,7 @@ import com.example.rentit.presentation.rentaldetail.renter.RentalDetailRenterScr
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RentalDetailRenterRoute(navHostController: NavHostController) {
+fun RentalDetailRoute(navHostController: NavHostController) {
 
     val viewModel: RentalDetailViewModel = hiltViewModel()
     val uiModel by viewModel.uiModel.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.renter
+package com.example.rentit.presentation.rentaldetail
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -11,14 +11,15 @@ import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.Renter
 import com.example.rentit.data.rental.dto.ReturnStatus
 import com.example.rentit.data.rental.dto.StatusHistory
-import com.example.rentit.presentation.rentaldetail.renter.model.RentalStatusRenterUiModel
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RentalStatusRenterUiModel
+import com.example.rentit.presentation.rentaldetail.renter.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class RentalDetailRenterViewModel @Inject constructor(
+class RentalDetailViewModel @Inject constructor(
 ): ViewModel() {
     private val sampleRentalDetail = RentalDetailResponseDto(
         rental = Rental(

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/common/model/PriceItemUiModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/common/model/PriceItemUiModel.kt
@@ -1,6 +1,0 @@
-package com.example.rentit.presentation.rentaldetail.common.model
-
-data class PriceItemUiModel(
-    val label: String,
-    val price: Int
-)

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/ArrowedTextButton.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/ArrowedTextButton.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.common.components
+package com.example.rentit.presentation.rentaldetail.components
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/LabeledValue.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/LabeledValue.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.common.components
+package com.example.rentit.presentation.rentaldetail.components
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/NoticeBanner.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/NoticeBanner.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.common.components
+package com.example.rentit.presentation.rentaldetail.components
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/TaskCheckBox.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/TaskCheckBox.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.common.components
+package com.example.rentit.presentation.rentaldetail.components
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalInfoSection.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalInfoSection.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.common.components.section
+package com.example.rentit.presentation.rentaldetail.components.section
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -14,7 +14,7 @@ import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.component.TitledContainer
 import com.example.rentit.common.component.RentalSummary
-import com.example.rentit.presentation.rentaldetail.common.model.RentalSummaryUiModel
+import com.example.rentit.common.model.RentalSummaryUiModel
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalPaymentSection.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalPaymentSection.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.common.components.section
+package com.example.rentit.presentation.rentaldetail.components.section
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
@@ -6,14 +6,14 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.rentit.R
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.presentation.rentaldetail.common.model.PriceItemUiModel
+import com.example.rentit.common.model.PriceSummaryUiModel
 import com.example.rentit.common.component.TitledContainer
 import com.example.rentit.common.component.PriceSummary
 
 @Composable
 fun RentalPaymentSection(
     title: String,
-    priceItems: List<PriceItemUiModel>,
+    priceItems: List<PriceSummaryUiModel>,
     totalLabel: String
 ) {
     TitledContainer(labelText = AnnotatedString(title)) {
@@ -28,11 +28,11 @@ fun RentalPaymentSection(
 @Preview(showBackground = true)
 private fun Preview() {
     val examplePriceItems = listOf(
-        PriceItemUiModel(
+        PriceSummaryUiModel(
             label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_basic_rent),
             price = 30000
         ),
-        PriceItemUiModel(
+        PriceSummaryUiModel(
             label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_deposit),
             price = 30000
         )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalTaskSection.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalTaskSection.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.common.components.section
+package com.example.rentit.presentation.rentaldetail.components.section
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -11,7 +11,7 @@ import androidx.compose.ui.unit.dp
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.component.TitledContainer
-import com.example.rentit.presentation.rentaldetail.common.components.TaskCheckBox
+import com.example.rentit.presentation.rentaldetail.components.TaskCheckBox
 
 @Composable
 fun RentalTaskSection(

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalTrackingSection.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalTrackingSection.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.common.components.section
+package com.example.rentit.presentation.rentaldetail.components.section
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -10,7 +10,7 @@ import androidx.compose.ui.unit.dp
 import com.example.rentit.R
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.component.TitledContainer
-import com.example.rentit.presentation.rentaldetail.common.components.LabeledValue
+import com.example.rentit.presentation.rentaldetail.components.LabeledValue
 
 @Composable
 fun RentalTrackingSection(rentalTrackingNumber: String? = null, returnTrackingNumber: String? = null) {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/UnknownStatusDialog.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/UnknownStatusDialog.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.common.dialog
+package com.example.rentit.presentation.rentaldetail.dialog
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/model/RentingStatus.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/model/RentingStatus.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.renter.model
+package com.example.rentit.presentation.rentaldetail.model
 
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RentalDetailRenterMapper.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RentalDetailRenterMapper.kt
@@ -6,9 +6,9 @@ import androidx.annotation.RequiresApi
 import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.util.daysFromToday
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
-import com.example.rentit.presentation.rentaldetail.common.model.RentalSummaryUiModel
-import com.example.rentit.presentation.rentaldetail.renter.model.RentalStatusRenterUiModel
-import com.example.rentit.presentation.rentaldetail.renter.model.RentingStatus
+import com.example.rentit.common.model.RentalSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.model.RentingStatus
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RentalStatusRenterUiModel
 
 private const val TAG = "RentalStatus"
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RentalDetailRenterScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RentalDetailRenterScreen.kt
@@ -23,12 +23,12 @@ import com.example.rentit.data.rental.dto.Rental
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.Renter
 import com.example.rentit.data.rental.dto.ReturnStatus
-import com.example.rentit.presentation.rentaldetail.common.dialog.UnknownStatusDialog
-import com.example.rentit.presentation.rentaldetail.renter.components.PaidContent
-import com.example.rentit.presentation.rentaldetail.renter.components.RentalRequestContent
-import com.example.rentit.presentation.rentaldetail.renter.components.RentingContent
-import com.example.rentit.presentation.rentaldetail.renter.components.ReturnedContent
-import com.example.rentit.presentation.rentaldetail.renter.model.RentalStatusRenterUiModel
+import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
+import com.example.rentit.presentation.rentaldetail.renter.stateui.PaidContent
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RentalRequestContent
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RentalStatusRenterUiModel
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RentingContent
+import com.example.rentit.presentation.rentaldetail.renter.stateui.ReturnedContent
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/PaidContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/PaidContent.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.renter.components
+package com.example.rentit.presentation.rentaldetail.renter.stateui
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -10,12 +10,11 @@ import com.example.rentit.R
 import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.presentation.rentaldetail.common.model.PriceItemUiModel
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalPaymentSection
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalInfoSection
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalTrackingSection
-import com.example.rentit.presentation.rentaldetail.common.model.RentalSummaryUiModel
-import com.example.rentit.presentation.rentaldetail.renter.model.RentalStatusRenterUiModel
+import com.example.rentit.common.model.PriceSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
+import com.example.rentit.common.model.RentalSummaryUiModel
 
 /**
  * 대여 상세(판매자)에서
@@ -28,11 +27,11 @@ fun PaidContent(
     paidData: RentalStatusRenterUiModel.Paid,
 ) {
     val priceItems = listOf(
-        PriceItemUiModel(
+        PriceSummaryUiModel(
             label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_basic_rent),
             price = paidData.basicRentalFee
         ),
-        PriceItemUiModel(
+        PriceSummaryUiModel(
             label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_deposit),
             price = paidData.deposit
         )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RentalRequestContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RentalRequestContent.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.renter.components
+package com.example.rentit.presentation.rentaldetail.renter.stateui
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -19,13 +19,12 @@ import androidx.compose.ui.unit.dp
 import com.example.rentit.R
 import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.presentation.rentaldetail.common.model.PriceItemUiModel
-import com.example.rentit.presentation.rentaldetail.common.components.ArrowedTextButton
-import com.example.rentit.presentation.rentaldetail.common.components.NoticeBanner
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalPaymentSection
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalInfoSection
-import com.example.rentit.presentation.rentaldetail.common.model.RentalSummaryUiModel
-import com.example.rentit.presentation.rentaldetail.renter.model.RentalStatusRenterUiModel
+import com.example.rentit.common.model.PriceSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.components.ArrowedTextButton
+import com.example.rentit.presentation.rentaldetail.components.NoticeBanner
+import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
+import com.example.rentit.common.model.RentalSummaryUiModel
 
 /**
  * 대여 상세(판매자)에서
@@ -38,11 +37,11 @@ fun RentalRequestContent(
     requestData: RentalStatusRenterUiModel.Request,
 ) {
     val priceItems = listOf(
-        PriceItemUiModel(
+        PriceSummaryUiModel(
             label = stringResource(R.string.screen_rental_detail_renter_charge_price_label_basic_rent),
             price = requestData.basicRentalFee
         ),
-        PriceItemUiModel(
+        PriceSummaryUiModel(
             label = stringResource(R.string.screen_rental_detail_renter_charge_price_label_deposit),
             price = requestData.deposit
         )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RentalStatusRenterUiModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RentalStatusRenterUiModel.kt
@@ -1,7 +1,8 @@
-package com.example.rentit.presentation.rentaldetail.renter.model
+package com.example.rentit.presentation.rentaldetail.renter.stateui
 
 import com.example.rentit.common.enums.RentalStatus
-import com.example.rentit.presentation.rentaldetail.common.model.RentalSummaryUiModel
+import com.example.rentit.common.model.RentalSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.model.RentingStatus
 
 
 sealed class RentalStatusRenterUiModel {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RentingContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RentingContent.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.renter.components
+package com.example.rentit.presentation.rentaldetail.renter.stateui
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -27,15 +27,14 @@ import com.example.rentit.R
 import com.example.rentit.common.theme.AppRed
 import com.example.rentit.common.theme.Gray100
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.presentation.rentaldetail.common.model.PriceItemUiModel
-import com.example.rentit.presentation.rentaldetail.common.components.NoticeBanner
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalPaymentSection
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalInfoSection
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalTaskSection
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalTrackingSection
-import com.example.rentit.presentation.rentaldetail.common.model.RentalSummaryUiModel
-import com.example.rentit.presentation.rentaldetail.renter.model.RentalStatusRenterUiModel
-import com.example.rentit.presentation.rentaldetail.renter.model.RentingStatus
+import com.example.rentit.common.model.PriceSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.components.NoticeBanner
+import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalTaskSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
+import com.example.rentit.common.model.RentalSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.model.RentingStatus
 import kotlin.math.abs
 
 /**
@@ -49,11 +48,11 @@ fun RentingContent(
     rentingData: RentalStatusRenterUiModel.Renting,
 ) {
     val priceItems = listOf(
-        PriceItemUiModel(
+        PriceSummaryUiModel(
             label = stringResource(R.string.screen_rental_detail_renter_charge_price_label_basic_rent),
             price = rentingData.basicRentalFee
         ),
-        PriceItemUiModel(
+        PriceSummaryUiModel(
             label = stringResource(R.string.screen_rental_detail_renter_charge_price_label_deposit),
             price = rentingData.deposit
         )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/ReturnedContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/ReturnedContent.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail.renter.components
+package com.example.rentit.presentation.rentaldetail.renter.stateui
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -13,13 +13,12 @@ import androidx.compose.ui.unit.dp
 import com.example.rentit.R
 import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.presentation.rentaldetail.common.model.PriceItemUiModel
-import com.example.rentit.presentation.rentaldetail.common.components.ArrowedTextButton
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalPaymentSection
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalInfoSection
-import com.example.rentit.presentation.rentaldetail.common.components.section.RentalTrackingSection
-import com.example.rentit.presentation.rentaldetail.common.model.RentalSummaryUiModel
-import com.example.rentit.presentation.rentaldetail.renter.model.RentalStatusRenterUiModel
+import com.example.rentit.common.model.PriceSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.components.ArrowedTextButton
+import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
+import com.example.rentit.common.model.RentalSummaryUiModel
 
 /**
  * 대여 상세(판매자)에서
@@ -32,11 +31,11 @@ fun ReturnedContent(
     returnedData: RentalStatusRenterUiModel.Returned,
 ) {
     val priceItems = listOf(
-        PriceItemUiModel(
+        PriceSummaryUiModel(
             label = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_basic_rent),
             price = returnedData.basicRentalFee
         ),
-        PriceItemUiModel(
+        PriceSummaryUiModel(
             label = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_deposit),
             price = returnedData.deposit
         )


### PR DESCRIPTION
# Pull Request

## Summary  
- 대여 상세 패키지 구조 개선하여 각 패키지의 역할과 책임을 명확히함

## Related Issue  
- Close: #67 

## Changes  
- 공통 대여 정보 컴포넌트, 가격 정보 컴포넌트에서 사용하는 Ui Model Common 하위로 이동
- 공통으로 사용할 `Route`와 `ViewMode`를, 사용자용 `Screen`과 `Mapper`, `UiModel`, `Content`과 분리

## Screenshots 
<img width="278" height="628" alt="image" src="https://github.com/user-attachments/assets/2b236544-5a58-4463-965e-f7522020e3b0" />