### PR TITLE
Feat/66 UI rental detail owner

### DIFF
--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailViewModel.kt
@@ -11,8 +11,8 @@ import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.Renter
 import com.example.rentit.data.rental.dto.ReturnStatus
 import com.example.rentit.data.rental.dto.StatusHistory
-import com.example.rentit.presentation.rentaldetail.renter.stateui.RentalStatusRenterUiModel
-import com.example.rentit.presentation.rentaldetail.renter.toUiModel
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
+import com.example.rentit.presentation.rentaldetail.renter.toRenterUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -85,9 +85,9 @@ class RentalDetailViewModel @Inject constructor(
     )
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private val _uiModel = MutableStateFlow(sampleRentalDetail.toUiModel())
+    private val _uiModel = MutableStateFlow(sampleRentalDetail.toRenterUiModel())
 
     @RequiresApi(Build.VERSION_CODES.O)
-    val uiModel: StateFlow<RentalStatusRenterUiModel> = _uiModel
+    val uiModel: StateFlow<RenterRentalStatusUiModel> = _uiModel
 
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalTaskSection.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalTaskSection.kt
@@ -20,7 +20,7 @@ fun RentalTaskSection(
     policyText: String? = null,
     photoTaskLabel: String,
     trackingNumTaskLabel: String,
-    isReturnAvailable: Boolean,
+    isTaskAvailable: Boolean,
     isPhotoRegistered: Boolean,
     isTrackingNumRegistered: Boolean,
     content: @Composable () -> Unit
@@ -42,12 +42,12 @@ fun RentalTaskSection(
         )
         TaskCheckBox(
             taskText = photoTaskLabel,
-            isTaskEnable = isReturnAvailable,
+            isTaskEnable = isTaskAvailable,
             isDone = isPhotoRegistered,
         )
         TaskCheckBox(
             taskText = trackingNumTaskLabel,
-            isTaskEnable = isReturnAvailable,
+            isTaskEnable = isTaskAvailable,
             isDone = isTrackingNumRegistered
         )
         if (!policyText.isNullOrEmpty())
@@ -70,7 +70,7 @@ private fun Preview() {
             policyText = "※ 등록 후에는 수정이 어렵습니다.",
             photoTaskLabel = "반납 사진 등록",
             trackingNumTaskLabel = "운송장 번호 입력",
-            isReturnAvailable = true,
+            isTaskAvailable = true,
             isPhotoRegistered = true,
             isTrackingNumRegistered = false
         ) {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/model/RentingStatus.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/model/RentingStatus.kt
@@ -34,5 +34,13 @@ enum class RentingStatus(
         noticeBannerStrRes = R.string.screen_rental_detail_renter_return_overdue_notice_text,
         noticeBannerBgColor = Gray100,
         subLabelStrRes = R.string.screen_rental_detail_renter_renting_day_overdue
-    )
+    );
+
+    companion object {
+        fun fromDaysFromReturnDate(daysFromReturnDate: Int): RentingStatus = when {
+            daysFromReturnDate >= 0 -> RENTING_IN_USE
+            daysFromReturnDate == -1 -> RENTING_RETURN_DAY
+            else -> RENTING_OVERDUE
+        }
+    }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailMapper.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailMapper.kt
@@ -1,0 +1,91 @@
+package com.example.rentit.presentation.rentaldetail.owner
+
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import com.example.rentit.common.enums.RentalStatus
+import com.example.rentit.common.util.daysFromToday
+import com.example.rentit.data.rental.dto.RentalDetailResponseDto
+import com.example.rentit.common.model.RentalSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.model.RentingStatus
+import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
+
+private const val TAG = "RentalStatus"
+
+@RequiresApi(Build.VERSION_CODES.O)
+fun RentalDetailResponseDto.toOwnerUiModel(): OwnerRentalStatusUiModel {
+    val status = runCatching { RentalStatus.valueOf(rental.status) }
+        .onFailure { Log.w(TAG, "Unknown rental status: ${rental.status}")  }
+        .getOrNull()
+
+    val rentalSummary = RentalSummaryUiModel(
+        productTitle = rental.product.title,
+        thumbnailImgUrl = rental.product.thumbnailImgUrl,
+        startDate = rental.startDate,
+        endDate = rental.endDate,
+        totalPrice = rental.totalAmount,
+    )
+
+    val basicRentalFee = rental.totalAmount - rental.depositAmount
+
+    return when (status) {
+        RentalStatus.PENDING,
+        RentalStatus.ACCEPTED,
+        RentalStatus.REJECTED,
+        RentalStatus.CANCELED -> {
+            OwnerRentalStatusUiModel.Request(
+                status = status,
+                isAccepted = status == RentalStatus.ACCEPTED,
+                isPending = status == RentalStatus.PENDING,
+                rentalSummary = rentalSummary,
+                basicRentalFee = basicRentalFee,
+                deposit = rental.depositAmount
+            )
+        }
+
+        RentalStatus.PAID -> {
+            val daysUntilRental = daysFromToday(rental.startDate)
+            OwnerRentalStatusUiModel.Paid(
+                status = status,
+                daysUntilRental = daysUntilRental,
+                rentalSummary = rentalSummary,
+                deposit = rental.depositAmount,
+                basicRentalFee = basicRentalFee,
+                rentalTrackingNumber = rental.rentalTrackingNumber
+            )
+        }
+
+        RentalStatus.RENTING -> {
+            val daysFromReturnDate = daysFromToday(rental.endDate)
+            val rentingStatus = when {
+                daysFromReturnDate >= 0 -> RentingStatus.RENTING_IN_USE
+                daysFromReturnDate == -1 -> RentingStatus.RENTING_RETURN_DAY
+                else -> RentingStatus.RENTING_OVERDUE
+            }
+            val isReturnAvailable = daysFromReturnDate <= -1
+            OwnerRentalStatusUiModel.Renting(
+                status = rentingStatus,
+                isOverdue = rentingStatus == RentingStatus.RENTING_OVERDUE,
+                isReturnAvailable = isReturnAvailable,
+                daysFromReturnDate = daysFromReturnDate,
+                rentalSummary = rentalSummary,
+                deposit = rental.depositAmount,
+                basicRentalFee = basicRentalFee,
+                isReturnPhotoRegistered = rental.returnStatus.isPhotoRegistered,
+                isReturnTrackingNumRegistered = rental.returnStatus.isTrackingNumberRegistered,
+                rentalTrackingNumber = rental.rentalTrackingNumber
+            )
+        }
+
+        RentalStatus.RETURNED -> OwnerRentalStatusUiModel.Returned(
+            status = status,
+            rentalSummary = rentalSummary,
+            deposit = rental.depositAmount,
+            basicRentalFee = basicRentalFee,
+            rentalTrackingNumber = rental.rentalTrackingNumber,
+            returnTrackingNumber = rental.returnTrackingNumber
+        )
+
+        null -> OwnerRentalStatusUiModel.Unknown
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailMapper.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailMapper.kt
@@ -39,7 +39,6 @@ fun RentalDetailResponseDto.toOwnerUiModel(): OwnerRentalStatusUiModel {
                 isAccepted = status == RentalStatus.ACCEPTED,
                 rentalSummary = rentalSummary,
                 basicRentalFee = basicRentalFee,
-                deposit = rental.depositAmount
             )
         }
 
@@ -49,7 +48,6 @@ fun RentalDetailResponseDto.toOwnerUiModel(): OwnerRentalStatusUiModel {
                 status = status,
                 daysUntilRental = daysUntilRental,
                 rentalSummary = rentalSummary,
-                deposit = rental.depositAmount,
                 basicRentalFee = basicRentalFee,
                 isSendingPhotoRegistered = rental.deliveryStatus.isPhotoRegistered,
                 isSendingTrackingNumRegistered = rental.deliveryStatus.isTrackingNumberRegistered,
@@ -59,22 +57,15 @@ fun RentalDetailResponseDto.toOwnerUiModel(): OwnerRentalStatusUiModel {
 
         RentalStatus.RENTING -> {
             val daysFromReturnDate = daysFromToday(rental.endDate)
-            val rentingStatus = when {
-                daysFromReturnDate >= 0 -> RentingStatus.RENTING_IN_USE
-                daysFromReturnDate == -1 -> RentingStatus.RENTING_RETURN_DAY
-                else -> RentingStatus.RENTING_OVERDUE
-            }
-            val isReturnAvailable = daysFromReturnDate <= -1
+            val rentingStatus = RentingStatus.fromDaysFromReturnDate(daysFromReturnDate)
+
             OwnerRentalStatusUiModel.Renting(
                 status = rentingStatus,
                 isOverdue = rentingStatus == RentingStatus.RENTING_OVERDUE,
-                isReturnAvailable = isReturnAvailable,
                 daysFromReturnDate = daysFromReturnDate,
                 rentalSummary = rentalSummary,
                 deposit = rental.depositAmount,
                 basicRentalFee = basicRentalFee,
-                isReturnPhotoRegistered = rental.returnStatus.isPhotoRegistered,
-                isReturnTrackingNumRegistered = rental.returnStatus.isTrackingNumberRegistered,
                 rentalTrackingNumber = rental.rentalTrackingNumber
             )
         }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailMapper.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailMapper.kt
@@ -51,7 +51,9 @@ fun RentalDetailResponseDto.toOwnerUiModel(): OwnerRentalStatusUiModel {
                 rentalSummary = rentalSummary,
                 deposit = rental.depositAmount,
                 basicRentalFee = basicRentalFee,
-                rentalTrackingNumber = rental.rentalTrackingNumber
+                isSendingPhotoRegistered = rental.deliveryStatus.isPhotoRegistered,
+                isSendingTrackingNumRegistered = rental.deliveryStatus.isTrackingNumberRegistered,
+                rentalTrackingNumber = rental.rentalTrackingNumber,
             )
         }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailMapper.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailMapper.kt
@@ -35,8 +35,8 @@ fun RentalDetailResponseDto.toOwnerUiModel(): OwnerRentalStatusUiModel {
         RentalStatus.CANCELED -> {
             OwnerRentalStatusUiModel.Request(
                 status = status,
-                isAccepted = status == RentalStatus.ACCEPTED,
                 isPending = status == RentalStatus.PENDING,
+                isAccepted = status == RentalStatus.ACCEPTED,
                 rentalSummary = rentalSummary,
                 basicRentalFee = basicRentalFee,
                 deposit = rental.depositAmount

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailScreen.kt
@@ -1,0 +1,96 @@
+package com.example.rentit.presentation.rentaldetail.owner
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.example.rentit.R
+import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.data.rental.dto.DeliveryStatus
+import com.example.rentit.data.rental.dto.Product
+import com.example.rentit.data.rental.dto.Rental
+import com.example.rentit.data.rental.dto.RentalDetailResponseDto
+import com.example.rentit.data.rental.dto.Renter
+import com.example.rentit.data.rental.dto.ReturnStatus
+import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
+import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerPaidContent
+import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
+import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentingContent
+import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRequestContent
+import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerReturnedContent
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun OwnerRentalDetailScreen(navHostController: NavHostController, uiModel: OwnerRentalStatusUiModel, scrollState: ScrollState) {
+    Scaffold(
+        topBar = { CommonTopAppBar(title = stringResource(R.string.screen_rental_detail_title), navHostController = navHostController) }
+    ) {
+        Column(modifier = Modifier.padding(it).verticalScroll(scrollState)) {
+            when(uiModel) {
+                is OwnerRentalStatusUiModel.Request ->
+                    OwnerRequestContent(uiModel)
+                is OwnerRentalStatusUiModel.Paid ->
+                    OwnerPaidContent(uiModel)
+                is OwnerRentalStatusUiModel.Renting ->
+                    OwnerRentingContent(uiModel)
+                is OwnerRentalStatusUiModel.Returned ->
+                    OwnerReturnedContent(uiModel)
+                is OwnerRentalStatusUiModel.Unknown ->
+                    UnknownStatusDialog { navHostController.popBackStack() }
+            }
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+@Preview(showBackground = true)
+private fun Preview() {
+    val sample1 = RentalDetailResponseDto(
+        rental = Rental(
+            reservationId = 1001,
+            renter = Renter(userId = 101, nickname = "김철수"),
+            status = "RENTING",
+            product = Product(
+                title = "캐논 EOS R6 카메라",
+                thumbnailImgUrl = "https://example.com/image/123.jpg"
+            ),
+            startDate = "2025-08-02",
+            endDate = "2025-08-05",
+            totalAmount = 90000,
+            depositAmount = 45000,
+            rentalTrackingNumber = "1234567890",
+            returnTrackingNumber = null,
+            deliveryStatus = DeliveryStatus(isPhotoRegistered = true, isTrackingNumberRegistered = true),
+            returnStatus = ReturnStatus(isPhotoRegistered = false, isTrackingNumberRegistered = false)
+        ),
+        statusHistory = listOf(/* 생략 */)
+    )
+
+    val sample2 = sample1.copy(
+        rental = sample1.rental.copy(
+            status = "RETURNED",
+            endDate = "2025-07-28",
+            returnStatus = ReturnStatus(isPhotoRegistered = false, isTrackingNumberRegistered = true)
+        )
+    )
+
+    RentItTheme {
+        OwnerRentalDetailScreen(
+            navHostController = rememberNavController(),
+            sample2.toOwnerUiModel(),
+            rememberScrollState()
+        )
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerPaidContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerPaidContent.kt
@@ -1,0 +1,86 @@
+package com.example.rentit.presentation.rentaldetail.owner.stateui
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.rentit.R
+import com.example.rentit.common.enums.RentalStatus
+import com.example.rentit.common.theme.Gray400
+import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.common.model.PriceSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
+import com.example.rentit.common.model.RentalSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
+
+/**
+ * 대여 상세(판매자)에서
+ * 결제 완료 상태를 나타내는 UI 컨텐츠
+ */
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun OwnerPaidContent(
+    paidData: OwnerRentalStatusUiModel.Paid,
+) {
+    val priceItems = listOf(
+        PriceSummaryUiModel(
+            label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_basic_rent),
+            price = paidData.basicRentalFee
+        ),
+        PriceSummaryUiModel(
+            label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_deposit),
+            price = paidData.deposit
+        )
+    )
+
+    RentalInfoSection(
+        title = stringResource(paidData.status.strRes),
+        titleColor = paidData.status.textColor,
+        subTitle = stringResource(
+            R.string.screen_rental_detail_renter_paid_day_before_rent,
+            paidData.daysUntilRental
+        ),
+        subTitleColor = Gray400,
+        rentalInfo = paidData.rentalSummary,
+    )
+
+    RentalPaymentSection(
+        title = stringResource(R.string.screen_rental_detail_renter_paid_price_title),
+        priceItems = priceItems,
+        totalLabel = stringResource(R.string.screen_rental_detail_renter_paid_price_label_total)
+    )
+
+    RentalTrackingSection(
+        rentalTrackingNumber = paidData.rentalTrackingNumber,
+    )
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+@Preview(showBackground = true)
+private fun Preview() {
+    val examplePendingUiModel = OwnerRentalStatusUiModel.Paid(
+        status = RentalStatus.PAID,
+        daysUntilRental = 3,
+        rentalSummary = RentalSummaryUiModel(
+            productTitle = "프리미엄 캠핑 텐트",
+            thumbnailImgUrl = "https://example.com/images/tent_thumbnail.jpg",
+            startDate = "2025-08-10",
+            endDate = "2025-08-14",
+            totalPrice = 120_000
+        ),
+        basicRentalFee = 90_000,
+        deposit = 10_000 * 3,
+        rentalTrackingNumber = null,
+    )
+    RentItTheme {
+        Column {
+            OwnerPaidContent(paidData = examplePendingUiModel)
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerPaidContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerPaidContent.kt
@@ -2,10 +2,17 @@ package com.example.rentit.presentation.rentaldetail.owner.stateui
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.example.rentit.R
 import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.theme.Gray400
@@ -15,11 +22,13 @@ import com.example.rentit.presentation.rentaldetail.components.section.RentalPay
 import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
 import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
 import com.example.rentit.common.model.RentalSummaryUiModel
-import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
+import com.example.rentit.presentation.rentaldetail.components.ArrowedTextButton
+import com.example.rentit.presentation.rentaldetail.components.NoticeBanner
+import com.example.rentit.presentation.rentaldetail.components.section.RentalTaskSection
 
 /**
- * 대여 상세(판매자)에서
- * 결제 완료 상태를 나타내는 UI 컨텐츠
+ * 대여 상세(대여자)에서
+ * 상품 발송 준비(사용자 결제 완료) 상태를 나타내는 UI 컨텐츠
  */
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -27,37 +36,52 @@ import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalS
 fun OwnerPaidContent(
     paidData: OwnerRentalStatusUiModel.Paid,
 ) {
-    val priceItems = listOf(
+    val priceItem = listOf(
         PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_basic_rent),
+            label = stringResource(R.string.screen_rental_detail_owner_expected_price_label_basic_rent),
             price = paidData.basicRentalFee
-        ),
-        PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_deposit),
-            price = paidData.deposit
         )
     )
 
+    NoticeBanner(noticeText = AnnotatedString(stringResource(R.string.screen_rental_detail_owner_paid_notice_complete_requirement)))
+
     RentalInfoSection(
-        title = stringResource(paidData.status.strRes),
+        title = stringResource(R.string.rental_status_paid_owner),
         titleColor = paidData.status.textColor,
         subTitle = stringResource(
-            R.string.screen_rental_detail_renter_paid_day_before_rent,
+            R.string.screen_rental_detail_subtitle_day_before_rent,
             paidData.daysUntilRental
         ),
         subTitleColor = Gray400,
         rentalInfo = paidData.rentalSummary,
     )
 
+    RentalTaskSection(
+        title = stringResource(R.string.screen_rental_detail_owner_paid_sending_task_title),
+        guideText = stringResource(R.string.screen_rental_detail_owner_paid_sending_task_info),
+        photoTaskLabel = stringResource(R.string.screen_rental_detail_owner_paid_sending_task_photo),
+        trackingNumTaskLabel = stringResource(R.string.screen_rental_detail_owner_paid_sending_task_tracking_num),
+        isTaskAvailable = true,
+        isPhotoRegistered = paidData.isSendingPhotoRegistered,
+        isTrackingNumRegistered = paidData.isSendingTrackingNumRegistered
+    ) { }
+
     RentalPaymentSection(
-        title = stringResource(R.string.screen_rental_detail_renter_paid_price_title),
-        priceItems = priceItems,
-        totalLabel = stringResource(R.string.screen_rental_detail_renter_paid_price_label_total)
+        title = stringResource(R.string.screen_rental_detail_owner_expected_price_title),
+        priceItems = priceItem,
+        totalLabel = stringResource(R.string.screen_rental_detail_owner_expected_price_label_total)
     )
 
     RentalTrackingSection(
         rentalTrackingNumber = paidData.rentalTrackingNumber,
     )
+
+    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
+        ArrowedTextButton(
+            modifier = Modifier.padding(vertical = 10.dp),
+            text = stringResource(R.string.screen_rental_detail_request_btn_cancel_rent)
+        ) { }
+    }
 }
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -77,6 +101,8 @@ private fun Preview() {
         basicRentalFee = 90_000,
         deposit = 10_000 * 3,
         rentalTrackingNumber = null,
+        isSendingPhotoRegistered = false,
+        isSendingTrackingNumRegistered = false,
     )
     RentItTheme {
         Column {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerPaidContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerPaidContent.kt
@@ -99,7 +99,6 @@ private fun Preview() {
             totalPrice = 120_000
         ),
         basicRentalFee = 90_000,
-        deposit = 10_000 * 3,
         rentalTrackingNumber = null,
         isSendingPhotoRegistered = false,
         isSendingTrackingNumRegistered = false,

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentalStatusUiModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentalStatusUiModel.kt
@@ -1,0 +1,51 @@
+package com.example.rentit.presentation.rentaldetail.owner.stateui
+
+import com.example.rentit.common.enums.RentalStatus
+import com.example.rentit.common.model.RentalSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.model.RentingStatus
+
+
+sealed class OwnerRentalStatusUiModel {
+
+    data class Request(
+        val status: RentalStatus,
+        val isAccepted: Boolean,
+        val isPending: Boolean,
+        val rentalSummary: RentalSummaryUiModel,
+        val basicRentalFee: Int,
+        val deposit: Int,
+    ): OwnerRentalStatusUiModel()
+
+    data class Paid(
+        val status: RentalStatus,
+        val daysUntilRental: Int,
+        val rentalSummary: RentalSummaryUiModel,
+        val basicRentalFee: Int,
+        val deposit: Int,
+        val rentalTrackingNumber: String?
+    ): OwnerRentalStatusUiModel()
+
+    data class Renting(
+        val status: RentingStatus,
+        val isOverdue: Boolean,
+        val isReturnAvailable: Boolean,
+        val daysFromReturnDate: Int,
+        val rentalSummary: RentalSummaryUiModel,
+        val basicRentalFee: Int,
+        val deposit: Int,
+        val isReturnPhotoRegistered: Boolean,
+        val isReturnTrackingNumRegistered: Boolean,
+        val rentalTrackingNumber: String?
+    ): OwnerRentalStatusUiModel()
+
+    data class Returned(
+        val status: RentalStatus,
+        val rentalSummary: RentalSummaryUiModel,
+        val basicRentalFee: Int,
+        val deposit: Int,
+        val rentalTrackingNumber: String?,
+        val returnTrackingNumber: String?
+    ): OwnerRentalStatusUiModel()
+
+    data object Unknown: OwnerRentalStatusUiModel()
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentalStatusUiModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentalStatusUiModel.kt
@@ -22,6 +22,8 @@ sealed class OwnerRentalStatusUiModel {
         val rentalSummary: RentalSummaryUiModel,
         val basicRentalFee: Int,
         val deposit: Int,
+        val isSendingPhotoRegistered: Boolean,
+        val isSendingTrackingNumRegistered: Boolean,
         val rentalTrackingNumber: String?
     ): OwnerRentalStatusUiModel()
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentalStatusUiModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentalStatusUiModel.kt
@@ -13,7 +13,6 @@ sealed class OwnerRentalStatusUiModel {
         val isAccepted: Boolean,
         val rentalSummary: RentalSummaryUiModel,
         val basicRentalFee: Int,
-        val deposit: Int,
     ): OwnerRentalStatusUiModel()
 
     data class Paid(
@@ -21,7 +20,6 @@ sealed class OwnerRentalStatusUiModel {
         val daysUntilRental: Int,
         val rentalSummary: RentalSummaryUiModel,
         val basicRentalFee: Int,
-        val deposit: Int,
         val isSendingPhotoRegistered: Boolean,
         val isSendingTrackingNumRegistered: Boolean,
         val rentalTrackingNumber: String?
@@ -30,13 +28,10 @@ sealed class OwnerRentalStatusUiModel {
     data class Renting(
         val status: RentingStatus,
         val isOverdue: Boolean,
-        val isReturnAvailable: Boolean,
         val daysFromReturnDate: Int,
         val rentalSummary: RentalSummaryUiModel,
         val basicRentalFee: Int,
         val deposit: Int,
-        val isReturnPhotoRegistered: Boolean,
-        val isReturnTrackingNumRegistered: Boolean,
         val rentalTrackingNumber: String?
     ): OwnerRentalStatusUiModel()
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentalStatusUiModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentalStatusUiModel.kt
@@ -9,8 +9,8 @@ sealed class OwnerRentalStatusUiModel {
 
     data class Request(
         val status: RentalStatus,
-        val isAccepted: Boolean,
         val isPending: Boolean,
+        val isAccepted: Boolean,
         val rentalSummary: RentalSummaryUiModel,
         val basicRentalFee: Int,
         val deposit: Int,

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentingContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentingContent.kt
@@ -1,0 +1,106 @@
+package com.example.rentit.presentation.rentaldetail.owner.stateui
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.rentit.R
+import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.common.model.PriceSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.components.NoticeBanner
+import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalTaskSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
+import com.example.rentit.common.model.RentalSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.model.RentingStatus
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
+import kotlin.math.abs
+
+/**
+ * 대여 상세(판매자)에서
+ * 대여중 상태(대여중, 반납 전, 반납 지연)를 나타내는 UI 컨텐츠
+ */
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun OwnerRentingContent(
+    rentingData: OwnerRentalStatusUiModel.Renting,
+) {
+    val priceItems = listOf(
+        PriceSummaryUiModel(
+            label = stringResource(R.string.screen_rental_detail_renter_charge_price_label_basic_rent),
+            price = rentingData.basicRentalFee
+        ),
+        PriceSummaryUiModel(
+            label = stringResource(R.string.screen_rental_detail_renter_charge_price_label_deposit),
+            price = rentingData.deposit
+        )
+    )
+
+    if (rentingData.status.noticeBannerStrRes != null) {
+        NoticeBanner(noticeText = AnnotatedString(stringResource(rentingData.status.noticeBannerStrRes)))
+    }
+
+    RentalInfoSection(
+        title = stringResource(rentingData.status.strRes),
+        titleColor = rentingData.status.textColor,
+        subTitle = rentingData.status.subLabelStrRes?.let {
+            stringResource( it, abs(rentingData.daysFromReturnDate))
+        },
+        rentalInfo = rentingData.rentalSummary,
+    )
+
+    RentalTaskSection(
+        title = stringResource(R.string.screen_rental_detail_renter_return_task_title),
+        guideText = stringResource(R.string.screen_rental_detail_renter_return_task_info),
+        policyText = stringResource(R.string.screen_rental_detail_renter_return_task_policy),
+        photoTaskLabel = stringResource(R.string.screen_rental_detail_renter_return_task_photo),
+        trackingNumTaskLabel = stringResource(R.string.screen_rental_detail_renter_return_task_tracking_num),
+        isReturnAvailable = rentingData.isReturnAvailable,
+        isPhotoRegistered = rentingData.isReturnPhotoRegistered,
+        isTrackingNumRegistered = rentingData.isReturnTrackingNumRegistered
+    ) { }
+
+    RentalPaymentSection(
+        title = stringResource(R.string.screen_rental_detail_renter_paid_price_title),
+        priceItems = priceItems,
+        totalLabel = stringResource(R.string.screen_rental_detail_renter_paid_price_label_total)
+    )
+
+    RentalTrackingSection(
+        rentalTrackingNumber = rentingData.rentalTrackingNumber,
+    )
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+@Preview(showBackground = true)
+private fun Preview() {
+    val examplePendingUiModel = OwnerRentalStatusUiModel.Renting(
+        status = RentingStatus.RENTING_RETURN_DAY,
+        isOverdue = false,
+        daysFromReturnDate = 3,
+        rentalSummary = RentalSummaryUiModel(
+            productTitle = "프리미엄 캠핑 텐트",
+            thumbnailImgUrl = "https://example.com/images/tent_thumbnail.jpg",
+            startDate = "2025-08-10",
+            endDate = "2025-08-14",
+            totalPrice = 120_000
+        ),
+        basicRentalFee = 90_000,
+        deposit = 10_000 * 3,
+        rentalTrackingNumber = null,
+        isReturnAvailable = false,
+        isReturnPhotoRegistered = true,
+        isReturnTrackingNumRegistered = false,
+    )
+    RentItTheme {
+        Column {
+            OwnerRentingContent(rentingData = examplePendingUiModel)
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentingContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRentingContent.kt
@@ -3,25 +3,31 @@ package com.example.rentit.presentation.rentaldetail.owner.stateui
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.example.rentit.R
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.model.PriceSummaryUiModel
-import com.example.rentit.presentation.rentaldetail.components.NoticeBanner
 import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
 import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
-import com.example.rentit.presentation.rentaldetail.components.section.RentalTaskSection
 import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
 import com.example.rentit.common.model.RentalSummaryUiModel
+import com.example.rentit.common.theme.PrimaryBlue500
+import com.example.rentit.common.util.formatPrice
 import com.example.rentit.presentation.rentaldetail.model.RentingStatus
-import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
 import kotlin.math.abs
 
 /**
- * 대여 상세(판매자)에서
+ * 대여 상세(대여자)에서
  * 대여중 상태(대여중, 반납 전, 반납 지연)를 나타내는 UI 컨텐츠
  */
 
@@ -30,45 +36,42 @@ import kotlin.math.abs
 fun OwnerRentingContent(
     rentingData: OwnerRentalStatusUiModel.Renting,
 ) {
-    val priceItems = listOf(
+    val priceItem = listOf(
         PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_charge_price_label_basic_rent),
+            label = stringResource(R.string.screen_rental_detail_owner_expected_price_label_basic_rent),
             price = rentingData.basicRentalFee
-        ),
-        PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_charge_price_label_deposit),
-            price = rentingData.deposit
         )
     )
 
-    if (rentingData.status.noticeBannerStrRes != null) {
-        NoticeBanner(noticeText = AnnotatedString(stringResource(rentingData.status.noticeBannerStrRes)))
-    }
+    val formattedDeposit = formatPrice(rentingData.deposit)
 
     RentalInfoSection(
         title = stringResource(rentingData.status.strRes),
         titleColor = rentingData.status.textColor,
         subTitle = rentingData.status.subLabelStrRes?.let {
-            stringResource( it, abs(rentingData.daysFromReturnDate))
+            stringResource(it, abs(rentingData.daysFromReturnDate))
         },
         rentalInfo = rentingData.rentalSummary,
-    )
-
-    RentalTaskSection(
-        title = stringResource(R.string.screen_rental_detail_renter_return_task_title),
-        guideText = stringResource(R.string.screen_rental_detail_renter_return_task_info),
-        policyText = stringResource(R.string.screen_rental_detail_renter_return_task_policy),
-        photoTaskLabel = stringResource(R.string.screen_rental_detail_renter_return_task_photo),
-        trackingNumTaskLabel = stringResource(R.string.screen_rental_detail_renter_return_task_tracking_num),
-        isReturnAvailable = rentingData.isReturnAvailable,
-        isPhotoRegistered = rentingData.isReturnPhotoRegistered,
-        isTrackingNumRegistered = rentingData.isReturnTrackingNumRegistered
-    ) { }
+    ) {
+        if (rentingData.isOverdue) {
+            Text(
+                modifier = Modifier.padding(top = 16.dp),
+                text = buildAnnotatedString {
+                    append(stringResource(R.string.screen_rental_detail_owner_renting_overdue_info_reward_leading_text))
+                    withStyle(style = SpanStyle(color = PrimaryBlue500)) {
+                        append(" ${formattedDeposit}${stringResource(R.string.common_price_unit)}")
+                    }
+                    append(stringResource(R.string.screen_rental_detail_owner_renting_overdue_info_reward_tail_text))
+                },
+                style = MaterialTheme.typography.labelMedium
+            )
+        }
+    }
 
     RentalPaymentSection(
-        title = stringResource(R.string.screen_rental_detail_renter_paid_price_title),
-        priceItems = priceItems,
-        totalLabel = stringResource(R.string.screen_rental_detail_renter_paid_price_label_total)
+        title = stringResource(R.string.screen_rental_detail_owner_expected_price_title),
+        priceItems = priceItem,
+        totalLabel = stringResource(R.string.screen_rental_detail_owner_expected_price_label_total)
     )
 
     RentalTrackingSection(
@@ -81,8 +84,8 @@ fun OwnerRentingContent(
 @Preview(showBackground = true)
 private fun Preview() {
     val examplePendingUiModel = OwnerRentalStatusUiModel.Renting(
-        status = RentingStatus.RENTING_RETURN_DAY,
-        isOverdue = false,
+        status = RentingStatus.RENTING_OVERDUE,
+        isOverdue = true,
         daysFromReturnDate = 3,
         rentalSummary = RentalSummaryUiModel(
             productTitle = "프리미엄 캠핑 텐트",
@@ -94,9 +97,6 @@ private fun Preview() {
         basicRentalFee = 90_000,
         deposit = 10_000 * 3,
         rentalTrackingNumber = null,
-        isReturnAvailable = false,
-        isReturnPhotoRegistered = true,
-        isReturnTrackingNumRegistered = false,
     )
     RentItTheme {
         Column {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRequestContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRequestContent.kt
@@ -27,7 +27,7 @@ import com.example.rentit.presentation.rentaldetail.components.section.RentalInf
 import com.example.rentit.common.model.RentalSummaryUiModel
 
 /**
- * 대여 상세(판매자)에서
+ * 대여 상세(대여자)에서
  * 요청과 관련된 상태(대여 요청, 요청 수락, 요청 거절, 거래 취소)를 나타내는 UI 컨텐츠
  */
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRequestContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRequestContent.kt
@@ -38,20 +38,20 @@ fun OwnerRequestContent(
 ) {
     val priceItem = listOf(
         PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_charge_price_label_basic_rent),
+            label = stringResource(R.string.screen_rental_detail_owner_expected_price_label_basic_rent),
             price = requestData.basicRentalFee
         )
     )
 
     when {
         requestData.isPending -> NoticeBanner(noticeText = buildAnnotatedString {
-            append("새로운 대여 요청이 도착했어요.")
+            append(stringResource(R.string.screen_rental_detail_owner_request_notice_new_request))
         })
         requestData.isAccepted -> NoticeBanner(noticeText = buildAnnotatedString {
             withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle()) {
-                append(stringResource(R.string.screen_rental_detail_renter_request_notice_pay))
+                append(stringResource(R.string.screen_rental_detail_owner_request_notice_pay))
             }
-            append(stringResource(R.string.screen_rental_detail_renter_request_notice_wait))
+            append(stringResource(R.string.screen_rental_detail_owner_request_notice_wait))
         })
     }
 
@@ -65,22 +65,22 @@ fun OwnerRequestContent(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .offset(y = 8.dp),
-                text = "요청 응답하기"
+                text = stringResource(R.string.screen_rental_detail_owner_request_btn_request_response)
             ) { }
         }
     }
 
     RentalPaymentSection(
-        title = "예상 수익 상세",
+        title = stringResource(R.string.screen_rental_detail_owner_expected_price_title),
         priceItems = priceItem,
-        totalLabel = "합계"
+        totalLabel = stringResource(R.string.screen_rental_detail_owner_expected_price_label_total)
     )
 
     if(requestData.isAccepted) {
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
             ArrowedTextButton(
                 modifier = Modifier.padding(vertical = 10.dp),
-                text = stringResource(R.string.screen_rental_detail_renter_request_btn_cancel_rent)
+                text = stringResource(R.string.screen_rental_detail_request_btn_cancel_rent)
             ) { }
         }
     }
@@ -91,9 +91,9 @@ fun OwnerRequestContent(
 @Preview(showBackground = true)
 private fun Preview() {
     val examplePendingUiModel = OwnerRentalStatusUiModel.Request(
-        status = RentalStatus.ACCEPTED,
-        isAccepted = true,
+        status = RentalStatus.REJECTED,
         isPending = false,
+        isAccepted = false,
         rentalSummary = RentalSummaryUiModel(
             productTitle = "프리미엄 캠핑 텐트",
             thumbnailImgUrl = "https://example.com/images/tent_thumbnail.jpg",

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRequestContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRequestContent.kt
@@ -102,7 +102,6 @@ private fun Preview() {
             totalPrice = 120_000
         ),
         basicRentalFee = 90_000,
-        deposit = 10_000 * 3
     )
     RentItTheme {
         Column {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRequestContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRequestContent.kt
@@ -1,0 +1,112 @@
+package com.example.rentit.presentation.rentaldetail.owner.stateui
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.rentit.R
+import com.example.rentit.common.enums.RentalStatus
+import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.common.model.PriceSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.components.ArrowedTextButton
+import com.example.rentit.presentation.rentaldetail.components.NoticeBanner
+import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
+import com.example.rentit.common.model.RentalSummaryUiModel
+
+/**
+ * 대여 상세(판매자)에서
+ * 요청과 관련된 상태(대여 요청, 요청 수락, 요청 거절, 거래 취소)를 나타내는 UI 컨텐츠
+ */
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun OwnerRequestContent(
+    requestData: OwnerRentalStatusUiModel.Request,
+) {
+    val priceItem = listOf(
+        PriceSummaryUiModel(
+            label = stringResource(R.string.screen_rental_detail_renter_charge_price_label_basic_rent),
+            price = requestData.basicRentalFee
+        )
+    )
+
+    when {
+        requestData.isPending -> NoticeBanner(noticeText = buildAnnotatedString {
+            append("새로운 대여 요청이 도착했어요.")
+        })
+        requestData.isAccepted -> NoticeBanner(noticeText = buildAnnotatedString {
+            withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle()) {
+                append(stringResource(R.string.screen_rental_detail_renter_request_notice_pay))
+            }
+            append(stringResource(R.string.screen_rental_detail_renter_request_notice_wait))
+        })
+    }
+
+    RentalInfoSection(
+        title = stringResource(requestData.status.strRes),
+        titleColor = requestData.status.textColor,
+        rentalInfo = requestData.rentalSummary,
+    ) {
+        if(requestData.isPending) {
+            ArrowedTextButton(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .offset(y = 8.dp),
+                text = "요청 응답하기"
+            ) { }
+        }
+    }
+
+    RentalPaymentSection(
+        title = "예상 수익 상세",
+        priceItems = priceItem,
+        totalLabel = "합계"
+    )
+
+    if(requestData.isAccepted) {
+        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
+            ArrowedTextButton(
+                modifier = Modifier.padding(vertical = 10.dp),
+                text = stringResource(R.string.screen_rental_detail_renter_request_btn_cancel_rent)
+            ) { }
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+@Preview(showBackground = true)
+private fun Preview() {
+    val examplePendingUiModel = OwnerRentalStatusUiModel.Request(
+        status = RentalStatus.ACCEPTED,
+        isAccepted = true,
+        isPending = false,
+        rentalSummary = RentalSummaryUiModel(
+            productTitle = "프리미엄 캠핑 텐트",
+            thumbnailImgUrl = "https://example.com/images/tent_thumbnail.jpg",
+            startDate = "2025-08-10",
+            endDate = "2025-08-14",
+            totalPrice = 120_000
+        ),
+        basicRentalFee = 90_000,
+        deposit = 10_000 * 3
+    )
+    RentItTheme {
+        Column {
+            OwnerRequestContent(requestData = examplePendingUiModel)
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerReturnedContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerReturnedContent.kt
@@ -1,0 +1,93 @@
+package com.example.rentit.presentation.rentaldetail.owner.stateui
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.rentit.R
+import com.example.rentit.common.enums.RentalStatus
+import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.common.model.PriceSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.components.ArrowedTextButton
+import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
+import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
+import com.example.rentit.common.model.RentalSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
+
+/**
+ * 대여 상세(판매자)에서
+ * 반납 완료 완료 상태를 나타내는 UI 컨텐츠
+ */
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun OwnerReturnedContent(
+    returnedData: OwnerRentalStatusUiModel.Returned,
+) {
+    val priceItems = listOf(
+        PriceSummaryUiModel(
+            label = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_basic_rent),
+            price = returnedData.basicRentalFee
+        ),
+        PriceSummaryUiModel(
+            label = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_deposit),
+            price = returnedData.deposit
+        )
+    )
+
+    RentalInfoSection(
+        title = stringResource(returnedData.status.strRes),
+        titleColor = returnedData.status.textColor,
+        rentalInfo = returnedData.rentalSummary,
+    ) {
+        ArrowedTextButton(
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .offset(y = 8.dp),
+            text = stringResource(R.string.screen_rental_detail_renter_returned_check_photo_btn)
+        ) { }
+    }
+
+    RentalPaymentSection(
+        title = stringResource(R.string.screen_rental_detail_renter_total_paid_price_title),
+        priceItems = priceItems,
+        totalLabel = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_total)
+    )
+
+    RentalTrackingSection(
+        rentalTrackingNumber = returnedData.rentalTrackingNumber,
+        returnTrackingNumber = returnedData.returnTrackingNumber,
+    )
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+@Preview(showBackground = true)
+private fun Preview() {
+    val examplePendingUiModel = OwnerRentalStatusUiModel.Returned(
+        status = RentalStatus.RETURNED,
+        rentalSummary = RentalSummaryUiModel(
+            productTitle = "프리미엄 캠핑 텐트",
+            thumbnailImgUrl = "https://example.com/images/tent_thumbnail.jpg",
+            startDate = "2025-08-10",
+            endDate = "2025-08-14",
+            totalPrice = 120_000
+        ),
+        basicRentalFee = 90_000,
+        deposit = 10_000 * 3,
+        rentalTrackingNumber = null,
+        returnTrackingNumber = null,
+    )
+    RentItTheme {
+        Column {
+            OwnerReturnedContent(returnedData = examplePendingUiModel)
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerReturnedContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerReturnedContent.kt
@@ -21,7 +21,7 @@ import com.example.rentit.presentation.rentaldetail.components.section.RentalTra
 import com.example.rentit.common.model.RentalSummaryUiModel
 
 /**
- * 대여 상세(판매자)에서
+ * 대여 상세(대여자)에서
  * 반납 완료 완료 상태를 나타내는 UI 컨텐츠
  */
 
@@ -32,11 +32,11 @@ fun OwnerReturnedContent(
 ) {
     val priceItems = listOf(
         PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_basic_rent),
+            label = stringResource(R.string.screen_rental_detail_owner_total_profit_price_label_basic_rent),
             price = returnedData.basicRentalFee
         ),
         PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_deposit),
+            label = stringResource(R.string.screen_rental_detail_owner_total_profit_price_label_deposit),
             price = returnedData.deposit
         )
     )
@@ -55,9 +55,9 @@ fun OwnerReturnedContent(
     }
 
     RentalPaymentSection(
-        title = stringResource(R.string.screen_rental_detail_renter_total_paid_price_title),
+        title = stringResource(R.string.screen_rental_detail_owner_total_profit_price_title),
         priceItems = priceItems,
-        totalLabel = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_total)
+        totalLabel = stringResource(R.string.screen_rental_detail_owner_total_profit_price_label_total)
     )
 
     RentalTrackingSection(

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerReturnedContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerReturnedContent.kt
@@ -19,7 +19,6 @@ import com.example.rentit.presentation.rentaldetail.components.section.RentalPay
 import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
 import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
 import com.example.rentit.common.model.RentalSummaryUiModel
-import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
 
 /**
  * 대여 상세(판매자)에서
@@ -51,7 +50,7 @@ fun OwnerReturnedContent(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .offset(y = 8.dp),
-            text = stringResource(R.string.screen_rental_detail_renter_returned_check_photo_btn)
+            text = stringResource(R.string.screen_rental_detail_returned_check_photo_btn)
         ) { }
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailMapper.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailMapper.kt
@@ -56,12 +56,9 @@ fun RentalDetailResponseDto.toRenterUiModel(): RenterRentalStatusUiModel {
 
         RentalStatus.RENTING -> {
             val daysFromReturnDate = daysFromToday(rental.endDate)
-            val rentingStatus = when {
-                daysFromReturnDate >= 0 -> RentingStatus.RENTING_IN_USE
-                daysFromReturnDate == -1 -> RentingStatus.RENTING_RETURN_DAY
-                else -> RentingStatus.RENTING_OVERDUE
-            }
+            val rentingStatus = RentingStatus.fromDaysFromReturnDate(daysFromReturnDate)
             val isReturnAvailable = daysFromReturnDate <= -1
+
             RenterRentalStatusUiModel.Renting(
                 status = rentingStatus,
                 isOverdue = rentingStatus == RentingStatus.RENTING_OVERDUE,

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailMapper.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailMapper.kt
@@ -8,12 +8,12 @@ import com.example.rentit.common.util.daysFromToday
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.common.model.RentalSummaryUiModel
 import com.example.rentit.presentation.rentaldetail.model.RentingStatus
-import com.example.rentit.presentation.rentaldetail.renter.stateui.RentalStatusRenterUiModel
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
 
 private const val TAG = "RentalStatus"
 
 @RequiresApi(Build.VERSION_CODES.O)
-fun RentalDetailResponseDto.toUiModel(): RentalStatusRenterUiModel {
+fun RentalDetailResponseDto.toRenterUiModel(): RenterRentalStatusUiModel {
     val status = runCatching { RentalStatus.valueOf(rental.status) }
         .onFailure { Log.w(TAG, "Unknown rental status: ${rental.status}")  }
         .getOrNull()
@@ -33,7 +33,7 @@ fun RentalDetailResponseDto.toUiModel(): RentalStatusRenterUiModel {
         RentalStatus.ACCEPTED,
         RentalStatus.REJECTED,
         RentalStatus.CANCELED -> {
-            RentalStatusRenterUiModel.Request(
+            RenterRentalStatusUiModel.Request(
                 status = status,
                 isAccepted = status == RentalStatus.ACCEPTED,
                 rentalSummary = rentalSummary,
@@ -44,7 +44,7 @@ fun RentalDetailResponseDto.toUiModel(): RentalStatusRenterUiModel {
 
         RentalStatus.PAID -> {
             val daysUntilRental = daysFromToday(rental.startDate)
-            RentalStatusRenterUiModel.Paid(
+            RenterRentalStatusUiModel.Paid(
                 status = status,
                 daysUntilRental = daysUntilRental,
                 rentalSummary = rentalSummary,
@@ -62,7 +62,7 @@ fun RentalDetailResponseDto.toUiModel(): RentalStatusRenterUiModel {
                 else -> RentingStatus.RENTING_OVERDUE
             }
             val isReturnAvailable = daysFromReturnDate <= -1
-            RentalStatusRenterUiModel.Renting(
+            RenterRentalStatusUiModel.Renting(
                 status = rentingStatus,
                 isOverdue = rentingStatus == RentingStatus.RENTING_OVERDUE,
                 isReturnAvailable = isReturnAvailable,
@@ -76,7 +76,7 @@ fun RentalDetailResponseDto.toUiModel(): RentalStatusRenterUiModel {
             )
         }
 
-        RentalStatus.RETURNED -> RentalStatusRenterUiModel.Returned(
+        RentalStatus.RETURNED -> RenterRentalStatusUiModel.Returned(
             status = status,
             rentalSummary = rentalSummary,
             deposit = rental.depositAmount,
@@ -85,6 +85,6 @@ fun RentalDetailResponseDto.toUiModel(): RentalStatusRenterUiModel {
             returnTrackingNumber = rental.returnTrackingNumber
         )
 
-        null -> RentalStatusRenterUiModel.Unknown
+        null -> RenterRentalStatusUiModel.Unknown
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
@@ -24,29 +24,29 @@ import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.Renter
 import com.example.rentit.data.rental.dto.ReturnStatus
 import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
-import com.example.rentit.presentation.rentaldetail.renter.stateui.PaidContent
-import com.example.rentit.presentation.rentaldetail.renter.stateui.RentalRequestContent
-import com.example.rentit.presentation.rentaldetail.renter.stateui.RentalStatusRenterUiModel
-import com.example.rentit.presentation.rentaldetail.renter.stateui.RentingContent
-import com.example.rentit.presentation.rentaldetail.renter.stateui.ReturnedContent
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterPaidContent
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRequestContent
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentingContent
+import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterReturnedContent
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RentalDetailRenterScreen(navHostController: NavHostController, uiModel: RentalStatusRenterUiModel, scrollState: ScrollState) {
+fun RentalDetailRenterScreen(navHostController: NavHostController, uiModel: RenterRentalStatusUiModel, scrollState: ScrollState) {
     Scaffold(
         topBar = { CommonTopAppBar(title = stringResource(R.string.screen_rental_detail_title), navHostController = navHostController) }
     ) {
         Column(modifier = Modifier.padding(it).verticalScroll(scrollState)) {
             when(uiModel) {
-                is RentalStatusRenterUiModel.Request ->
-                    RentalRequestContent(uiModel)
-                is RentalStatusRenterUiModel.Paid ->
-                    PaidContent(uiModel)
-                is RentalStatusRenterUiModel.Renting ->
-                    RentingContent(uiModel)
-                is RentalStatusRenterUiModel.Returned ->
-                    ReturnedContent(uiModel)
-                is RentalStatusRenterUiModel.Unknown ->
+                is RenterRentalStatusUiModel.Request ->
+                    RenterRequestContent(uiModel)
+                is RenterRentalStatusUiModel.Paid ->
+                    RenterPaidContent(uiModel)
+                is RenterRentalStatusUiModel.Renting ->
+                    RenterRentingContent(uiModel)
+                is RenterRentalStatusUiModel.Returned ->
+                    RenterReturnedContent(uiModel)
+                is RenterRentalStatusUiModel.Unknown ->
                     UnknownStatusDialog { navHostController.popBackStack() }
             }
         }
@@ -89,7 +89,7 @@ private fun Preview() {
     RentItTheme {
         RentalDetailRenterScreen(
             navHostController = rememberNavController(),
-            sample2.toUiModel(),
+            sample2.toRenterUiModel(),
             rememberScrollState()
         )
     }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterPaidContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterPaidContent.kt
@@ -41,7 +41,7 @@ fun RenterPaidContent(
         title = stringResource(paidData.status.strRes),
         titleColor = paidData.status.textColor,
         subTitle = stringResource(
-            R.string.screen_rental_detail_renter_paid_day_before_rent,
+            R.string.screen_rental_detail_subtitle_day_before_rent,
             paidData.daysUntilRental
         ),
         subTitleColor = Gray400,

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterPaidContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterPaidContent.kt
@@ -3,66 +3,59 @@ package com.example.rentit.presentation.rentaldetail.renter.stateui
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.example.rentit.R
 import com.example.rentit.common.enums.RentalStatus
+import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.model.PriceSummaryUiModel
-import com.example.rentit.presentation.rentaldetail.components.ArrowedTextButton
 import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
 import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
 import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
 import com.example.rentit.common.model.RentalSummaryUiModel
 
 /**
- * 대여 상세(판매자)에서
- * 반납 완료 완료 상태를 나타내는 UI 컨텐츠
+ * 대여 상세(사용자)에서
+ * 결제 완료 상태를 나타내는 UI 컨텐츠
  */
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun ReturnedContent(
-    returnedData: RentalStatusRenterUiModel.Returned,
+fun RenterPaidContent(
+    paidData: RenterRentalStatusUiModel.Paid,
 ) {
     val priceItems = listOf(
         PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_basic_rent),
-            price = returnedData.basicRentalFee
+            label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_basic_rent),
+            price = paidData.basicRentalFee
         ),
         PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_deposit),
-            price = returnedData.deposit
+            label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_deposit),
+            price = paidData.deposit
         )
     )
 
     RentalInfoSection(
-        title = stringResource(returnedData.status.strRes),
-        titleColor = returnedData.status.textColor,
-        rentalInfo = returnedData.rentalSummary,
-    ) {
-        ArrowedTextButton(
-            modifier = Modifier
-                .align(Alignment.CenterHorizontally)
-                .offset(y = 8.dp),
-            text = stringResource(R.string.screen_rental_detail_renter_returned_check_photo_btn)
-        ) { }
-    }
+        title = stringResource(paidData.status.strRes),
+        titleColor = paidData.status.textColor,
+        subTitle = stringResource(
+            R.string.screen_rental_detail_renter_paid_day_before_rent,
+            paidData.daysUntilRental
+        ),
+        subTitleColor = Gray400,
+        rentalInfo = paidData.rentalSummary,
+    )
 
     RentalPaymentSection(
-        title = stringResource(R.string.screen_rental_detail_renter_total_paid_price_title),
+        title = stringResource(R.string.screen_rental_detail_renter_paid_price_title),
         priceItems = priceItems,
-        totalLabel = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_total)
+        totalLabel = stringResource(R.string.screen_rental_detail_renter_paid_price_label_total)
     )
 
     RentalTrackingSection(
-        rentalTrackingNumber = returnedData.rentalTrackingNumber,
-        returnTrackingNumber = returnedData.returnTrackingNumber,
+        rentalTrackingNumber = paidData.rentalTrackingNumber,
     )
 }
 
@@ -70,8 +63,9 @@ fun ReturnedContent(
 @Composable
 @Preview(showBackground = true)
 private fun Preview() {
-    val examplePendingUiModel = RentalStatusRenterUiModel.Returned(
-        status = RentalStatus.RETURNED,
+    val examplePendingUiModel = RenterRentalStatusUiModel.Paid(
+        status = RentalStatus.PAID,
+        daysUntilRental = 3,
         rentalSummary = RentalSummaryUiModel(
             productTitle = "프리미엄 캠핑 텐트",
             thumbnailImgUrl = "https://example.com/images/tent_thumbnail.jpg",
@@ -82,11 +76,10 @@ private fun Preview() {
         basicRentalFee = 90_000,
         deposit = 10_000 * 3,
         rentalTrackingNumber = null,
-        returnTrackingNumber = null,
     )
     RentItTheme {
         Column {
-            ReturnedContent(returnedData = examplePendingUiModel)
+            RenterPaidContent(paidData = examplePendingUiModel)
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRentalStatusUiModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRentalStatusUiModel.kt
@@ -5,7 +5,7 @@ import com.example.rentit.common.model.RentalSummaryUiModel
 import com.example.rentit.presentation.rentaldetail.model.RentingStatus
 
 
-sealed class RentalStatusRenterUiModel {
+sealed class RenterRentalStatusUiModel {
 
     data class Request(
         val status: RentalStatus,
@@ -13,7 +13,7 @@ sealed class RentalStatusRenterUiModel {
         val rentalSummary: RentalSummaryUiModel,
         val basicRentalFee: Int,
         val deposit: Int,
-    ): RentalStatusRenterUiModel()
+    ): RenterRentalStatusUiModel()
 
     data class Paid(
         val status: RentalStatus,
@@ -22,7 +22,7 @@ sealed class RentalStatusRenterUiModel {
         val basicRentalFee: Int,
         val deposit: Int,
         val rentalTrackingNumber: String?
-    ): RentalStatusRenterUiModel()
+    ): RenterRentalStatusUiModel()
 
     data class Renting(
         val status: RentingStatus,
@@ -35,7 +35,7 @@ sealed class RentalStatusRenterUiModel {
         val isReturnPhotoRegistered: Boolean,
         val isReturnTrackingNumRegistered: Boolean,
         val rentalTrackingNumber: String?
-    ): RentalStatusRenterUiModel()
+    ): RenterRentalStatusUiModel()
 
     data class Returned(
         val status: RentalStatus,
@@ -44,7 +44,7 @@ sealed class RentalStatusRenterUiModel {
         val deposit: Int,
         val rentalTrackingNumber: String?,
         val returnTrackingNumber: String?
-    ): RentalStatusRenterUiModel()
+    ): RenterRentalStatusUiModel()
 
-    data object Unknown: RentalStatusRenterUiModel()
+    data object Unknown: RenterRentalStatusUiModel()
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRentingContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRentingContent.kt
@@ -38,14 +38,14 @@ import com.example.rentit.presentation.rentaldetail.model.RentingStatus
 import kotlin.math.abs
 
 /**
- * 대여 상세(판매자)에서
+ * 대여 상세(사용자)에서
  * 대여중 상태(대여중, 반납 전, 반납 지연)를 나타내는 UI 컨텐츠
  */
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RentingContent(
-    rentingData: RentalStatusRenterUiModel.Renting,
+fun RenterRentingContent(
+    rentingData: RenterRentalStatusUiModel.Renting,
 ) {
     val priceItems = listOf(
         PriceSummaryUiModel(
@@ -133,7 +133,7 @@ fun ReturnOverdueWarning(daysFromReturnDate: Int, deposit: Int) {
 @Composable
 @Preview(showBackground = true)
 private fun Preview() {
-    val examplePendingUiModel = RentalStatusRenterUiModel.Renting(
+    val examplePendingUiModel = RenterRentalStatusUiModel.Renting(
         status = RentingStatus.RENTING_RETURN_DAY,
         isOverdue = false,
         daysFromReturnDate = 3,
@@ -153,7 +153,7 @@ private fun Preview() {
     )
     RentItTheme {
         Column {
-            RentingContent(rentingData = examplePendingUiModel)
+            RenterRentingContent(rentingData = examplePendingUiModel)
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRentingContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRentingContent.kt
@@ -77,7 +77,7 @@ fun RenterRentingContent(
         policyText = stringResource(R.string.screen_rental_detail_renter_return_task_policy),
         photoTaskLabel = stringResource(R.string.screen_rental_detail_renter_return_task_photo),
         trackingNumTaskLabel = stringResource(R.string.screen_rental_detail_renter_return_task_tracking_num),
-        isReturnAvailable = rentingData.isReturnAvailable,
+        isTaskAvailable = rentingData.isReturnAvailable,
         isPhotoRegistered = rentingData.isReturnPhotoRegistered,
         isTrackingNumRegistered = rentingData.isReturnTrackingNumRegistered
     ) { if (rentingData.isOverdue) {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRequestContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRequestContent.kt
@@ -81,7 +81,7 @@ fun RenterRequestContent(
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
             ArrowedTextButton(
                 modifier = Modifier.padding(vertical = 10.dp),
-                text = stringResource(R.string.screen_rental_detail_renter_request_btn_cancel_rent)
+                text = stringResource(R.string.screen_rental_detail_request_btn_cancel_rent)
             ) { }
         }
     }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRequestContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRequestContent.kt
@@ -33,8 +33,8 @@ import com.example.rentit.common.model.RentalSummaryUiModel
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RentalRequestContent(
-    requestData: RentalStatusRenterUiModel.Request,
+fun RenterRequestContent(
+    requestData: RenterRentalStatusUiModel.Request,
 ) {
     val priceItems = listOf(
         PriceSummaryUiModel(
@@ -91,7 +91,7 @@ fun RentalRequestContent(
 @Composable
 @Preview(showBackground = true)
 private fun Preview() {
-    val examplePendingUiModel = RentalStatusRenterUiModel.Request(
+    val examplePendingUiModel = RenterRentalStatusUiModel.Request(
         status = RentalStatus.ACCEPTED,
         isAccepted = true,
         rentalSummary = RentalSummaryUiModel(
@@ -106,7 +106,7 @@ private fun Preview() {
     )
     RentItTheme {
         Column {
-            RentalRequestContent(requestData = examplePendingUiModel)
+            RenterRequestContent(requestData = examplePendingUiModel)
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterReturnedContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterReturnedContent.kt
@@ -50,7 +50,7 @@ fun RenterReturnedContent(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .offset(y = 8.dp),
-            text = stringResource(R.string.screen_rental_detail_renter_returned_check_photo_btn)
+            text = stringResource(R.string.screen_rental_detail_returned_check_photo_btn)
         ) { }
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterReturnedContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterReturnedContent.kt
@@ -3,59 +3,66 @@ package com.example.rentit.presentation.rentaldetail.renter.stateui
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.example.rentit.R
 import com.example.rentit.common.enums.RentalStatus
-import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.model.PriceSummaryUiModel
+import com.example.rentit.presentation.rentaldetail.components.ArrowedTextButton
 import com.example.rentit.presentation.rentaldetail.components.section.RentalPaymentSection
 import com.example.rentit.presentation.rentaldetail.components.section.RentalInfoSection
 import com.example.rentit.presentation.rentaldetail.components.section.RentalTrackingSection
 import com.example.rentit.common.model.RentalSummaryUiModel
 
 /**
- * 대여 상세(판매자)에서
- * 결제 완료 상태를 나타내는 UI 컨텐츠
+ * 대여 상세(사용자)에서
+ * 반납 완료 완료 상태를 나타내는 UI 컨텐츠
  */
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun PaidContent(
-    paidData: RentalStatusRenterUiModel.Paid,
+fun RenterReturnedContent(
+    returnedData: RenterRentalStatusUiModel.Returned,
 ) {
     val priceItems = listOf(
         PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_basic_rent),
-            price = paidData.basicRentalFee
+            label = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_basic_rent),
+            price = returnedData.basicRentalFee
         ),
         PriceSummaryUiModel(
-            label = stringResource(R.string.screen_rental_detail_renter_paid_price_label_deposit),
-            price = paidData.deposit
+            label = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_deposit),
+            price = returnedData.deposit
         )
     )
 
     RentalInfoSection(
-        title = stringResource(paidData.status.strRes),
-        titleColor = paidData.status.textColor,
-        subTitle = stringResource(
-            R.string.screen_rental_detail_renter_paid_day_before_rent,
-            paidData.daysUntilRental
-        ),
-        subTitleColor = Gray400,
-        rentalInfo = paidData.rentalSummary,
-    )
+        title = stringResource(returnedData.status.strRes),
+        titleColor = returnedData.status.textColor,
+        rentalInfo = returnedData.rentalSummary,
+    ) {
+        ArrowedTextButton(
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .offset(y = 8.dp),
+            text = stringResource(R.string.screen_rental_detail_renter_returned_check_photo_btn)
+        ) { }
+    }
 
     RentalPaymentSection(
-        title = stringResource(R.string.screen_rental_detail_renter_paid_price_title),
+        title = stringResource(R.string.screen_rental_detail_renter_total_paid_price_title),
         priceItems = priceItems,
-        totalLabel = stringResource(R.string.screen_rental_detail_renter_paid_price_label_total)
+        totalLabel = stringResource(R.string.screen_rental_detail_renter_total_paid_price_label_total)
     )
 
     RentalTrackingSection(
-        rentalTrackingNumber = paidData.rentalTrackingNumber,
+        rentalTrackingNumber = returnedData.rentalTrackingNumber,
+        returnTrackingNumber = returnedData.returnTrackingNumber,
     )
 }
 
@@ -63,9 +70,8 @@ fun PaidContent(
 @Composable
 @Preview(showBackground = true)
 private fun Preview() {
-    val examplePendingUiModel = RentalStatusRenterUiModel.Paid(
-        status = RentalStatus.PAID,
-        daysUntilRental = 3,
+    val examplePendingUiModel = RenterRentalStatusUiModel.Returned(
+        status = RentalStatus.RETURNED,
         rentalSummary = RentalSummaryUiModel(
             productTitle = "프리미엄 캠핑 텐트",
             thumbnailImgUrl = "https://example.com/images/tent_thumbnail.jpg",
@@ -76,10 +82,11 @@ private fun Preview() {
         basicRentalFee = 90_000,
         deposit = 10_000 * 3,
         rentalTrackingNumber = null,
+        returnTrackingNumber = null,
     )
     RentItTheme {
         Column {
-            PaidContent(paidData = examplePendingUiModel)
+            RenterReturnedContent(returnedData = examplePendingUiModel)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,11 @@
 
     <!-- 대여 상세 -->
     <string name="screen_rental_detail_title">대여 상세</string>
+    <string name="screen_rental_detail_request_btn_cancel_rent">대여 취소하기</string>
+    <string name="screen_rental_detail_returned_check_photo_btn">대여 전/후 사진 확인하기</string>
+
+    <string name="screen_rental_detail_unknown_dialog_title">대여 정보가 존재하지 않아요.</string>
+    <string name="screen_rental_detail_unknown_dialog_confirm_btn">확인</string>
 
     <string name="screen_rental_detail_tracking_info_title">운송장 정보</string>
     <string name="screen_rental_detail_rental_tracking_num">대여 송장 번호</string>
@@ -161,12 +166,16 @@
     <string name="screen_rental_detail_renter_total_paid_price_label_deposit">반납 지연 요금</string>
     <string name="screen_rental_detail_renter_total_paid_price_label_total">총 결제 금액</string>
 
+    <string name="screen_rental_detail_owner_expected_price_title">예상 수익 상세</string>
+    <string name="screen_rental_detail_owner_expected_price_label_basic_rent">기본 대여료</string>
+    <string name="screen_rental_detail_owner_expected_price_label_total">총합</string>
+
     <string name="screen_rental_detail_renter_request_notice_pay">결제</string>
     <string name="screen_rental_detail_renter_request_notice_wait">를 기다리고 있어요!</string>
     <string name="screen_rental_detail_renter_request_btn_pay">결제하고 예약 확정하기</string>
-    <string name="screen_rental_detail_renter_request_btn_cancel_rent">대여 취소하기</string>
 
     <string name="screen_rental_detail_renter_paid_day_before_rent">· 대여 %d일전</string>
+
     <string name="screen_rental_detail_renter_return_day_notice_text">오늘은 반납일이에요. 24시간 이내 반납을 진행해주세요.</string>
     <string name="screen_rental_detail_renter_return_overdue_notice_text">반납이 지연되고 있어요. 반납 등록을 완료해주세요.</string>
 
@@ -183,10 +192,10 @@
     <string name="screen_rental_detail_renter_renting_overdue_warning_middle_text">되고 있어요.\n현재까지 보증금에서 </string>
     <string name="screen_rental_detail_renter_renting_overdue_warning_tail_text">이 차감되었어요.</string>
 
-    <string name="screen_rental_detail_renter_returned_check_photo_btn">대여 전/후 사진 확인하기</string>
-
-    <string name="screen_rental_detail_unknown_dialog_title">대여 정보가 존재하지 않아요.</string>
-    <string name="screen_rental_detail_unknown_dialog_confirm_btn">확인</string>
+    <string name="screen_rental_detail_owner_request_notice_new_request">새로운 대여 요청이 도착했어요!</string>
+    <string name="screen_rental_detail_owner_request_notice_pay">결제</string>
+    <string name="screen_rental_detail_owner_request_notice_wait">를 기다리고 있어요!</string>
+    <string name="screen_rental_detail_owner_request_btn_request_response">요청 응답하기</string>
 
     <string name="error_mypage_new_chatroom">채팅방 생성에 실패했어요.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,11 @@
     <string name="screen_rental_detail_owner_expected_price_label_basic_rent">기본 대여료</string>
     <string name="screen_rental_detail_owner_expected_price_label_total">총합</string>
 
+    <string name="screen_rental_detail_owner_total_profit_price_title">정산 상세 내역</string>
+    <string name="screen_rental_detail_owner_total_profit_price_label_basic_rent">기본 대여료</string>
+    <string name="screen_rental_detail_owner_total_profit_price_label_deposit">지연 보상금</string>
+    <string name="screen_rental_detail_owner_total_profit_price_label_total">총 정산 금액</string>
+
     <string name="screen_rental_detail_renter_request_notice_pay">결제</string>
     <string name="screen_rental_detail_renter_request_notice_wait">를 기다리고 있어요!</string>
     <string name="screen_rental_detail_renter_request_btn_pay">결제하고 예약 확정하기</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,6 +202,9 @@
     <string name="screen_rental_detail_owner_paid_sending_task_photo">발송 전 사진 등록</string>
     <string name="screen_rental_detail_owner_paid_sending_task_tracking_num">운송장 등록</string>
 
+    <string name="screen_rental_detail_owner_renting_overdue_info_reward_leading_text">지연 보상금</string>
+    <string name="screen_rental_detail_owner_renting_overdue_info_reward_tail_text">이 지급될 예정이에요.</string>
+
     <string name="error_mypage_new_chatroom">채팅방 생성에 실패했어요.</string>
 
     <string name="request_history_list_item_text_chat">채팅하기</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="screen_rental_detail_title">대여 상세</string>
     <string name="screen_rental_detail_request_btn_cancel_rent">대여 취소하기</string>
     <string name="screen_rental_detail_returned_check_photo_btn">대여 전/후 사진 확인하기</string>
+    <string name="screen_rental_detail_subtitle_day_before_rent">· 대여 %d일전</string>
 
     <string name="screen_rental_detail_unknown_dialog_title">대여 정보가 존재하지 않아요.</string>
     <string name="screen_rental_detail_unknown_dialog_confirm_btn">확인</string>
@@ -174,8 +175,6 @@
     <string name="screen_rental_detail_renter_request_notice_wait">를 기다리고 있어요!</string>
     <string name="screen_rental_detail_renter_request_btn_pay">결제하고 예약 확정하기</string>
 
-    <string name="screen_rental_detail_renter_paid_day_before_rent">· 대여 %d일전</string>
-
     <string name="screen_rental_detail_renter_return_day_notice_text">오늘은 반납일이에요. 24시간 이내 반납을 진행해주세요.</string>
     <string name="screen_rental_detail_renter_return_overdue_notice_text">반납이 지연되고 있어요. 반납 등록을 완료해주세요.</string>
 
@@ -196,6 +195,12 @@
     <string name="screen_rental_detail_owner_request_notice_pay">결제</string>
     <string name="screen_rental_detail_owner_request_notice_wait">를 기다리고 있어요!</string>
     <string name="screen_rental_detail_owner_request_btn_request_response">요청 응답하기</string>
+
+    <string name="screen_rental_detail_owner_paid_notice_complete_requirement">남은 단계를 완료하고 거래를 확정하세요!</string>
+    <string name="screen_rental_detail_owner_paid_sending_task_title">상품 발송</string>
+    <string name="screen_rental_detail_owner_paid_sending_task_info">아래 항목을 완료해야 추후에 정산이 진행돼요.</string>
+    <string name="screen_rental_detail_owner_paid_sending_task_photo">발송 전 사진 등록</string>
+    <string name="screen_rental_detail_owner_paid_sending_task_tracking_num">운송장 등록</string>
 
     <string name="error_mypage_new_chatroom">채팅방 생성에 실패했어요.</string>
 


### PR DESCRIPTION
# Pull Request

## Summary  
대여자용 대여 상세 화면 UI 및 Mapper, UiModel 구현

## Related Issue  
- Close: #66 

## Changes  
- 사용자용 대여 상세 화면 UI 관련파일을 복사한뒤 대여자용 UI 디자인에 맞게 수정
- 대여중 상태의 대여중, 반납 D-Day, 반납 지연 상태를 구분하는 코드를 사용자용, 판매자용 동일하게 사용하므로, 이를 Renting Status 하위 함수로 통합하여 추후 로직 수정이 용이하도록 함
