### PR TITLE
Refactor/74 separate go back topappbar

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/TopAppBar.kt
+++ b/app/src/main/java/com/example/rentit/common/component/TopAppBar.kt
@@ -20,14 +20,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 
 @Composable
 fun CommonTopAppBar(
     modifier: Modifier = Modifier,
     title: String = "",
-    navHostController: NavHostController,
+    onBackClick: () -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -37,7 +35,7 @@ fun CommonTopAppBar(
             .padding(top = 5.dp)
     ) {
         IconButton(
-            onClick = { navHostController.popBackStack() },
+            onClick = onBackClick,
             modifier = Modifier.align(Alignment.CenterStart)
         ) {
             Icon(
@@ -59,6 +57,6 @@ fun CommonTopAppBar(
 @Composable
 fun TopAppBarPreview() {
     RentItTheme {
-        CommonTopAppBar(Modifier, "제목", rememberNavController())
+        CommonTopAppBar(Modifier, "제목") {}
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/JoinScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/JoinScreen.kt
@@ -66,8 +66,7 @@ fun JoinScreen(navHostController: NavHostController, name: String?, email: Strin
     Column {
         CommonTopAppBar(
             title = stringResource(id = R.string.screen_join_title),
-            navHostController = navHostController
-        )
+        ) { navHostController.popBackStack() }
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
@@ -141,7 +141,7 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reserv
     }
 
     Column(Modifier.background(Color.White)) {
-        CommonTopAppBar(navHostController = navHostController)
+        CommonTopAppBar { navHostController.popBackStack() }
         // 상단 예약 관련 정보
         productDetail?.let { ProductInfo(it.product) } ?: Column(Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/example/rentit/presentation/home/createpost/CreatePostScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/createpost/CreatePostScreen.kt
@@ -100,7 +100,7 @@ fun CreatePostScreen(navHostController: NavHostController) {
     val priceLimit = 5000000
 
     Scaffold(
-        topBar = { CommonTopAppBar(navHostController = navHostController) }
+        topBar = { CommonTopAppBar { navHostController.popBackStack() } }
     ) {
         Column(
             Modifier

--- a/app/src/main/java/com/example/rentit/presentation/pay/PayRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/pay/PayRoute.kt
@@ -23,11 +23,11 @@ fun PayRoute(navHostController: NavHostController, payInfo: PayUiModel) {
     val isDialogVisible = remember { mutableStateOf(false) }
 
     PayScreen(
-        navHostController = navHostController,
         payModel = payInfo,
         dialogModel = sampleDialogModel,
         isDialogVisible = isDialogVisible.value,
         scrollState = scrollState,
+        onBackClick = { navHostController.popBackStack() },
         onPayClick = { isDialogVisible.value = true },
         onDialogClose = { isDialogVisible.value = false },
         onDialogConfirm = { isDialogVisible.value = false }

--- a/app/src/main/java/com/example/rentit/presentation/pay/PayScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/pay/PayScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonButton
 import com.example.rentit.common.component.CommonTopAppBar
@@ -40,11 +38,11 @@ import com.example.rentit.presentation.rentaldetail.components.section.RentalPay
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun PayScreen(
-    navHostController: NavHostController,
     payModel: PayUiModel,
     dialogModel: PayResultDialogUiModel,
     isDialogVisible: Boolean,
     scrollState: ScrollState,
+    onBackClick: () -> Unit,
     onPayClick: () -> Unit,
     onDialogClose: () -> Unit,
     onDialogConfirm: () -> Unit,
@@ -64,7 +62,7 @@ fun PayScreen(
         topBar = {
             CommonTopAppBar(
                 title = stringResource(R.string.screen_pay_title)
-            ) { navHostController.popBackStack() }
+            ) { onBackClick() }
         },
         bottomBar = {
             CommonButton(
@@ -157,11 +155,11 @@ private fun Preview() {
 
     RentItTheme {
         PayScreen(
-            navHostController = rememberNavController(),
             payModel = sample,
             dialogModel = sampleDialog,
             isDialogVisible = false,
             scrollState = rememberScrollState(),
+            onBackClick = { },
             onPayClick = { },
             onDialogClose = { },
             onDialogConfirm = { }

--- a/app/src/main/java/com/example/rentit/presentation/pay/PayScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/pay/PayScreen.kt
@@ -63,9 +63,8 @@ fun PayScreen(
     Scaffold(
         topBar = {
             CommonTopAppBar(
-                title = stringResource(R.string.screen_pay_title),
-                navHostController = navHostController
-            )
+                title = stringResource(R.string.screen_pay_title)
+            ) { navHostController.popBackStack() }
         },
         bottomBar = {
             CommonButton(

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/ProductDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/ProductDetailScreen.kt
@@ -111,7 +111,7 @@ fun ProductDetailScreen(navHostController: NavHostController, productId: Int?) {
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
-        topBar = { CommonTopAppBar(navHostController = navHostController) },
+        topBar = { CommonTopAppBar { navHostController.popBackStack() } },
         bottomBar = { PostBottomBar(navHostController, productId, productDetail?.price ?: 0, isMyProduct, requestHistory.size) },
         floatingActionButton = { UsageDetailButton { showBottomSheet = true } }
     ) { innerPadding ->

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestScreen.kt
@@ -80,9 +80,8 @@ fun ResvRequestScreen(navHostController: NavHostController, productId: Int?) {
     Scaffold(
         topBar = {
             CommonTopAppBar(
-                title = stringResource(id = R.string.screen_resv_request_app_bar_title),
-                navHostController = navHostController
-            )
+                title = stringResource(id = R.string.screen_resv_request_app_bar_title)
+            ) { navHostController.popBackStack() }
         }
     ) {
         Column(

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/requesthistory/RequestHistoryScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/requesthistory/RequestHistoryScreen.kt
@@ -66,7 +66,7 @@ fun RequestHistoryScreen(navHostController: NavHostController, productId: Int?) 
     }
 
     Scaffold(
-        topBar = { CommonTopAppBar(title = "요청 내역", navHostController = navHostController) }
+        topBar = { CommonTopAppBar(title = "요청 내역") { navHostController.popBackStack() } }
     ) {
         Column(
             modifier = Modifier.padding(it)

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailRoute.kt
@@ -19,5 +19,5 @@ fun RentalDetailRoute(navHostController: NavHostController) {
 
     val scrollState = rememberScrollState()
 
-    RentalDetailRenterScreen(navHostController, uiModel, scrollState)
+    RentalDetailRenterScreen(uiModel, scrollState) { navHostController.popBackStack() }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonTopAppBar
 import com.example.rentit.common.theme.RentItTheme
@@ -32,9 +30,9 @@ import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerReturnedC
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun OwnerRentalDetailScreen(navHostController: NavHostController, uiModel: OwnerRentalStatusUiModel, scrollState: ScrollState) {
+fun OwnerRentalDetailScreen(uiModel: OwnerRentalStatusUiModel, scrollState: ScrollState, onBackClick: () -> Unit) {
     Scaffold(
-        topBar = { CommonTopAppBar(title = stringResource(R.string.screen_rental_detail_title), navHostController = navHostController) }
+        topBar = { CommonTopAppBar(title = stringResource(R.string.screen_rental_detail_title)) { onBackClick() } }
     ) {
         Column(modifier = Modifier.padding(it).verticalScroll(scrollState)) {
             when(uiModel) {
@@ -47,7 +45,7 @@ fun OwnerRentalDetailScreen(navHostController: NavHostController, uiModel: Owner
                 is OwnerRentalStatusUiModel.Returned ->
                     OwnerReturnedContent(uiModel)
                 is OwnerRentalStatusUiModel.Unknown ->
-                    UnknownStatusDialog { navHostController.popBackStack() }
+                    UnknownStatusDialog { onBackClick() }
             }
         }
     }
@@ -88,9 +86,8 @@ private fun Preview() {
 
     RentItTheme {
         OwnerRentalDetailScreen(
-            navHostController = rememberNavController(),
             sample2.toOwnerUiModel(),
             rememberScrollState()
-        )
+        ) {}
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonTopAppBar
 import com.example.rentit.common.theme.RentItTheme
@@ -32,9 +30,9 @@ import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterReturne
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RentalDetailRenterScreen(navHostController: NavHostController, uiModel: RenterRentalStatusUiModel, scrollState: ScrollState) {
+fun RentalDetailRenterScreen(uiModel: RenterRentalStatusUiModel, scrollState: ScrollState, onBackClick: () -> Unit) {
     Scaffold(
-        topBar = { CommonTopAppBar(title = stringResource(R.string.screen_rental_detail_title), navHostController = navHostController) }
+        topBar = { CommonTopAppBar(title = stringResource(R.string.screen_rental_detail_title)) { onBackClick() } }
     ) {
         Column(modifier = Modifier.padding(it).verticalScroll(scrollState)) {
             when(uiModel) {
@@ -47,7 +45,7 @@ fun RentalDetailRenterScreen(navHostController: NavHostController, uiModel: Rent
                 is RenterRentalStatusUiModel.Returned ->
                     RenterReturnedContent(uiModel)
                 is RenterRentalStatusUiModel.Unknown ->
-                    UnknownStatusDialog { navHostController.popBackStack() }
+                    UnknownStatusDialog { onBackClick() }
             }
         }
     }
@@ -88,9 +86,8 @@ private fun Preview() {
 
     RentItTheme {
         RentalDetailRenterScreen(
-            navHostController = rememberNavController(),
             sample2.toRenterUiModel(),
             rememberScrollState()
-        )
+        ) {}
     }
 }


### PR DESCRIPTION
# Pull Request

## Summary  
- `CommonTopAppBar`의 `NavHostContorller` 의존성 제거

## Related Issue  
- Close: #74 

## Changes  
- `CommonTopAppBar`의 뒤로가기 로직을 위한 파리미터 `navHostController`를 제거하고 람다 함수로 받도록 수정함
- `CommonTopAppBar`를 사용한 다른 파일 파라미터 수정
