### PR TITLE
Feat/76 UI photo before renting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,15 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.RentIt"
         tools:targetApi="31">
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/example/rentit/common/component/Buttons.kt
+++ b/app/src/main/java/com/example/rentit/common/component/Buttons.kt
@@ -22,9 +22,10 @@ import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
 
 @Composable
-fun CommonButton(text: String, containerColor: Color, contentColor: Color, modifier: Modifier = Modifier, onClick: () -> Unit) {
+fun CommonButton(modifier: Modifier = Modifier, text: String, enabled: Boolean = true, containerColor: Color, contentColor: Color, onClick: () -> Unit) {
     Button(
         onClick = onClick,
+        enabled = enabled,
         modifier = modifier
             .fillMaxWidth()
             .height(48.dp),
@@ -66,7 +67,7 @@ fun FilterButton(title: String, modifier: Modifier = Modifier, iconContent: @Com
 fun ButtonPreview(){
     RentItTheme {
         Column(){
-            CommonButton("Button", PrimaryBlue500, Color.White) {}
+            CommonButton(text = "Button", containerColor = PrimaryBlue500, contentColor = Color.White) {}
             FilterButton("Button") {}
         }
     }

--- a/app/src/main/java/com/example/rentit/common/component/item/RemovableImageBox.kt
+++ b/app/src/main/java/com/example/rentit/common/component/item/RemovableImageBox.kt
@@ -20,8 +20,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/example/rentit/common/component/item/RemovableImageBox.kt
+++ b/app/src/main/java/com/example/rentit/common/component/item/RemovableImageBox.kt
@@ -1,0 +1,78 @@
+package com.example.rentit.common.component.item
+
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.IconButton
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.rentit.R
+import com.example.rentit.common.component.basicRoundedGrayBorder
+import com.example.rentit.common.theme.AppBlack
+import com.example.rentit.common.theme.RentItTheme
+import androidx.core.net.toUri
+
+@Composable
+fun RemovableImageBox(width: Dp, aspectRatio: Float, imageUri: Uri, onImageRemoveClick: (Uri) -> Unit) {
+    Box(modifier = Modifier
+        .width(width)
+        .aspectRatio(aspectRatio)
+        .clip(RoundedCornerShape(20.dp))
+        .basicRoundedGrayBorder()) {
+        AsyncImage(
+            modifier = Modifier.fillMaxWidth(),
+            model = imageUri,
+            contentDescription = stringResource(id = R.string.screen_product_create_selected_image_description),
+            contentScale = ContentScale.Crop
+        )
+        IconButton(
+            modifier = Modifier
+                .padding(10.dp)
+                .align(Alignment.TopEnd)
+                .clip(CircleShape)
+                .size(20.dp)
+                .background(Color(255, 255, 255, 160)),
+            onClick = { onImageRemoveClick(imageUri) }
+        ) {
+            Icon(
+                modifier = Modifier.size(8.dp),
+                painter = painterResource(id = R.drawable.ic_x_bold),
+                tint = AppBlack,
+                contentDescription = stringResource(R.string.content_description_for_ic_x_delete)
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun RemovableImageBoxPreview() {
+    RentItTheme {
+        RemovableImageBox(
+            width = 160.dp,
+            aspectRatio = 4f/3f,
+            imageUri = "".toUri(),
+            onImageRemoveClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/JoinScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/JoinScreen.kt
@@ -92,9 +92,9 @@ fun JoinScreen(navHostController: NavHostController, name: String?, email: Strin
             }
             Spacer(modifier = Modifier.weight(1f))
             CommonButton(
-                stringResource(R.string.screen_join_btn_text),
-                PrimaryBlue500,
-                Color.White
+                text = stringResource(R.string.screen_join_btn_text),
+                containerColor = PrimaryBlue500,
+                contentColor = Color.White
             ) {
                 if (nickname.value.isEmpty()) {
                     isButtonClicked.value = true

--- a/app/src/main/java/com/example/rentit/presentation/home/createpost/CreatePostScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/createpost/CreatePostScreen.kt
@@ -1,14 +1,12 @@
 package com.example.rentit.presentation.home.createpost
 
 import android.net.Uri
-import android.util.Log
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.activity.result.contract.ActivityResultContracts.PickMultipleVisualMedia
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -17,6 +15,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -24,8 +24,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
@@ -45,9 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
@@ -61,14 +57,13 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import coil.compose.AsyncImage
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonButton
 import com.example.rentit.common.component.CommonTextField
 import com.example.rentit.common.component.CommonTopAppBar
 import com.example.rentit.common.component.basicRoundedGrayBorder
+import com.example.rentit.common.component.item.RemovableImageBox
 import com.example.rentit.common.component.screenHorizontalPadding
-import com.example.rentit.common.theme.AppBlack
 import com.example.rentit.common.theme.Gray200
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.Gray800
@@ -206,39 +201,19 @@ fun ImageSelectSection(
     onImageRemoveClick: (Uri) -> Unit
 ) {
     val pickMultipleImage = pickMultipleImage(onUpdateImageList)
-    val boxModifier = Modifier
-        .width(160.dp)
-        .height(120.dp)
-        .padding(end = 12.dp)
-        .basicRoundedGrayBorder()
+    val imageBoxWidth = 160.dp
+    val imageBoxAspectRatio = 4f/3f
+
     Row(Modifier.horizontalScroll(state = rememberScrollState())) {
         selectedImgUriList.forEach { uri ->
-            Box(modifier = boxModifier.clip(RoundedCornerShape(20.dp))) {
-                AsyncImage(
-                    modifier = Modifier.fillMaxWidth(),
-                    model = uri,
-                    contentDescription = stringResource(id = R.string.screen_product_create_selected_image_description),
-                    contentScale = ContentScale.Crop
-                )
-                IconButton(
-                    modifier = Modifier
-                        .padding(10.dp)
-                        .align(Alignment.TopEnd)
-                        .clip(CircleShape)
-                        .size(20.dp)
-                        .background(Color(255, 255, 255, 160)),
-                    onClick = { onImageRemoveClick(uri) }
-                ) {
-                    Icon(
-                        modifier = Modifier.size(8.dp),
-                        painter = painterResource(id = R.drawable.ic_x_bold),
-                        tint = AppBlack,
-                        contentDescription = stringResource(id = R.string.screen_product_create_category_add_text)
-                    )
-                }
-            }
+            RemovableImageBox(imageBoxWidth, imageBoxAspectRatio, uri, onImageRemoveClick)
+            Spacer(Modifier.width(10.dp))
         }
-        Box(modifier = boxModifier.clickable {
+        Box(modifier = Modifier
+            .width(imageBoxWidth)
+            .aspectRatio(imageBoxAspectRatio)
+            .basicRoundedGrayBorder()
+            .clickable {
             pickMultipleImage.launch(
                 PickVisualMediaRequest(
                     PickVisualMedia.ImageOnly
@@ -274,10 +249,6 @@ fun pickMultipleImage(onUpdateImageList: (List<Uri>) -> Unit): ManagedActivityRe
         PickMultipleVisualMedia()
     ) { uris ->
         if (uris.isNotEmpty()) {
-            Log.d("PhotoPicker", "Number of item selected: ${uris.size}")
-            uris.forEach { uri ->
-                Log.d("PhotoPicker", "Selected: $uri")
-            }
             onUpdateImageList(uris)
         }
     }

--- a/app/src/main/java/com/example/rentit/presentation/pay/PayScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/pay/PayScreen.kt
@@ -66,12 +66,12 @@ fun PayScreen(
         },
         bottomBar = {
             CommonButton(
-                stringResource(R.string.screen_pay_btn_text),
-                PrimaryBlue500,
-                Color.White,
-                Modifier
+                modifier = Modifier
                     .screenHorizontalPadding()
                     .padding(bottom = 30.dp),
+                text = stringResource(R.string.screen_pay_btn_text),
+                containerColor = PrimaryBlue500,
+                contentColor = Color.White
             ) { onPayClick() }
         }
     ) {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/TakePhotoLauncher.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/TakePhotoLauncher.kt
@@ -1,0 +1,77 @@
+package com.example.rentit.presentation.rentaldetail.components
+
+import android.content.Context
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.FileProvider
+import com.example.rentit.R
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// 사진 촬영 후 결과를 받기 위한 Launcher
+@Composable
+fun rememberTakePhotoLauncher(
+    onTakePhotoSuccess: (Uri) -> Unit,
+    onTakePhotoFail: () -> Unit
+): () -> Unit {
+    val context = LocalContext.current
+    var photoUri by remember { mutableStateOf<Uri?>(null) }
+    val cameraLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicture()
+    ) { success ->
+        val uri = photoUri
+        if (success && uri != null) {
+            onTakePhotoSuccess(uri)
+        } else {
+            onTakePhotoFail()
+        }
+    }
+
+    val launchCameraWithNewPhotoUri: () -> Unit = {
+        val uri = createPhotoUri(context)
+        if(uri != null){
+            photoUri = uri
+            cameraLauncher.launch(uri)
+        } else {
+            Toast.makeText(context, context.getString(R.string.toast_camera_launcher_fail), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    return launchCameraWithNewPhotoUri
+}
+
+/**
+ * 사진 파일을 생성하고, 해당 파일의 URI를 반환
+ */
+fun createPhotoUri(context: Context): Uri? {
+    return try {
+        val photoFile = createImageFile(context)
+        FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            photoFile
+        )
+    } catch (e: IllegalArgumentException) {
+        e.printStackTrace()
+        null
+    }
+}
+
+/**
+ * 앱 내부 캐시 디렉토리에 JPEG 형식의 임시 파일 생성
+ */
+fun createImageFile(context: Context): File {
+    val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+    val storageDir: File? = context.cacheDir
+    return File.createTempFile("JPEG_${timeStamp}_", ".jpg", storageDir)
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/photobeforerent/PhotoBeforeRentRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/photobeforerent/PhotoBeforeRentRoute.kt
@@ -1,0 +1,29 @@
+package com.example.rentit.presentation.rentaldetail.owner.photobeforerent
+
+import android.net.Uri
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+
+private const val minPhotoCnt = 2
+private const val maxPhotoCnt = 6
+
+@Composable
+fun PhotoBeforeRentRoute() {
+    var takenPhotoUris by remember { mutableStateOf(listOf<Uri>()) }
+    val isMaxPhotoTaken = takenPhotoUris.size >= maxPhotoCnt
+    val isRegisterEnabled = takenPhotoUris.size >= minPhotoCnt
+
+    PhotoBeforeRentScreen(
+        minPhotoCnt = minPhotoCnt,
+        maxPhotoCnt = maxPhotoCnt,
+        isRegisterEnabled = isRegisterEnabled,
+        isMaxPhotoTaken = isMaxPhotoTaken,
+        takenPhotoUris = takenPhotoUris,
+        onTakePhotoSuccess = { uri -> takenPhotoUris = listOf(uri) + takenPhotoUris },
+        onRemovePhoto = { uri -> takenPhotoUris -= uri },
+    )
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/photobeforerent/PhotoBeforeRentScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/photobeforerent/PhotoBeforeRentScreen.kt
@@ -1,0 +1,118 @@
+package com.example.rentit.presentation.rentaldetail.owner.photobeforerent
+
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.rentit.R
+import com.example.rentit.common.component.CommonButton
+import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.component.item.RemovableImageBox
+import com.example.rentit.common.component.screenHorizontalPadding
+import com.example.rentit.common.theme.Gray200
+import com.example.rentit.common.theme.PrimaryBlue500
+import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.common.theme.White
+import com.example.rentit.presentation.rentaldetail.owner.photobeforerent.components.TakePhotoButton
+
+@Composable
+fun PhotoBeforeRentScreen(
+    minPhotoCnt: Int,
+    maxPhotoCnt: Int,
+    isRegisterEnabled: Boolean,
+    isMaxPhotoTaken: Boolean,
+    takenPhotoUris: List<Uri>,
+    onTakePhotoSuccess: (Uri) -> Unit,
+    onRemovePhoto: (Uri) -> Unit,
+) {
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = { CommonTopAppBar {} },
+        bottomBar = { CommonButton(
+                modifier = Modifier.screenHorizontalPadding().padding(bottom = 30.dp),
+                text = stringResource(R.string.screen_photo_before_rent_btn_registration),
+                enabled = isRegisterEnabled,
+                containerColor = if (isRegisterEnabled) PrimaryBlue500 else Gray200,
+                contentColor = White
+            ) { }
+        }
+    ) {
+        Column(
+            Modifier
+                .padding(it)
+                .screenHorizontalPadding()
+        ) {
+
+            PhotoBeforeRentGuide(minPhotoCnt, maxPhotoCnt)
+
+            TakePhotoButton(
+                isMaxPhotoTaken = isMaxPhotoTaken,
+                onTakePhotoSuccess = onTakePhotoSuccess,
+                onTakePhotoFail = { Toast.makeText(context, context.getString(R.string.toast_take_photo_fail), Toast.LENGTH_SHORT).show() }
+            )
+
+            TakenPhotos(takenPhotoUris, onRemovePhoto)
+        }
+    }
+}
+
+@Composable
+fun PhotoBeforeRentGuide(minPhotoCnt: Int, maxPhotoCnt: Int) {
+    Text(
+        modifier = Modifier.padding(top = 16.dp, bottom = 14.dp),
+        text = stringResource(R.string.screen_photo_before_rent_title),
+        style = MaterialTheme.typography.bodyLarge
+    )
+    Text(
+        modifier = Modifier.padding(bottom = 20.dp),
+        text = stringResource(R.string.screen_photo_before_rent_guide, minPhotoCnt, maxPhotoCnt),
+        style = MaterialTheme.typography.labelMedium.copy(lineHeight = 20.sp)
+    )
+}
+
+@Composable
+fun TakenPhotos(photoList: List<Uri>, onRemoveClick: (Uri) -> Unit) {
+    Row(
+        Modifier
+            .horizontalScroll(state = rememberScrollState())
+            .padding(top = 20.dp)
+    ) {
+        photoList.forEach { uri ->
+            RemovableImageBox(140.dp, 4f / 3f, uri) { onRemoveClick(it) }
+            Spacer(Modifier.width(10.dp))
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun PhotoBeforeRentScreenPreview() {
+    var takenPhotoUris = listOf<Uri>()
+    RentItTheme {
+        PhotoBeforeRentScreen(
+            minPhotoCnt = 2,
+            maxPhotoCnt = 6,
+            isRegisterEnabled = true,
+            isMaxPhotoTaken = true,
+            takenPhotoUris = takenPhotoUris,
+            onTakePhotoSuccess = { uri -> takenPhotoUris = listOf(uri) + takenPhotoUris },
+            onRemovePhoto = { uri -> takenPhotoUris -= uri },
+        )
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/photobeforerent/components/TakePhotoButton.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/photobeforerent/components/TakePhotoButton.kt
@@ -1,0 +1,69 @@
+package com.example.rentit.presentation.rentaldetail.owner.photobeforerent.components
+
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.rentit.R
+import com.example.rentit.common.component.basicRoundedGrayBorder
+import com.example.rentit.common.theme.Gray300
+import com.example.rentit.common.theme.Gray400
+import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.presentation.rentaldetail.components.rememberTakePhotoLauncher
+
+private const val boxHeightFraction = 0.4f
+
+@Composable
+fun TakePhotoButton(isMaxPhotoTaken: Boolean = false, onTakePhotoSuccess: (Uri) -> Unit, onTakePhotoFail: () -> Unit) {
+    val launchCameraWithNewPhotoUri = rememberTakePhotoLauncher(onTakePhotoSuccess, onTakePhotoFail)
+    val btnContentDesc = stringResource(R.string.screen_photo_before_rent_take_photo_btn_content_description)
+
+    Box(
+        modifier = Modifier
+            .semantics { contentDescription = btnContentDesc }
+            .fillMaxWidth()
+            .fillMaxHeight(boxHeightFraction)
+            .clip(RoundedCornerShape(20.dp))
+            .basicRoundedGrayBorder()
+            .clickable(enabled = !isMaxPhotoTaken) { launchCameraWithNewPhotoUri() },
+        contentAlignment = Alignment.Center
+    ) {
+        if(isMaxPhotoTaken) {
+            Text(
+                stringResource(R.string.screen_photo_before_rent_take_photo_text_max_photo_taken),
+                color = Gray400
+            )
+        } else {
+            Icon(
+                painter = painterResource(R.drawable.ic_camera),
+                contentDescription = stringResource(R.string.content_description_for_ic_camera),
+                tint = Gray300
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun TakePhotoButtonPreview() {
+    RentItTheme {
+        TakePhotoButton(
+            onTakePhotoSuccess = {},
+            onTakePhotoFail = {}
+        )
+    }
+}

--- a/app/src/main/res/drawable/ic_camera.xml
+++ b/app/src/main/res/drawable/ic_camera.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="27dp"
+    android:height="28dp"
+    android:viewportWidth="27"
+    android:viewportHeight="28">
+  <path
+      android:pathData="M25.875,21.875C25.875,22.472 25.638,23.044 25.216,23.466C24.794,23.888 24.222,24.125 23.625,24.125H3.375C2.778,24.125 2.206,23.888 1.784,23.466C1.362,23.044 1.125,22.472 1.125,21.875V9.5C1.125,8.903 1.362,8.331 1.784,7.909C2.206,7.487 2.778,7.25 3.375,7.25H7.875L10.125,3.875H16.875L19.125,7.25H23.625C24.222,7.25 24.794,7.487 25.216,7.909C25.638,8.331 25.875,8.903 25.875,9.5V21.875Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#D0D0D0"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M13.5,19.625C15.985,19.625 18,17.61 18,15.125C18,12.64 15.985,10.625 13.5,10.625C11.015,10.625 9,12.64 9,15.125C9,17.61 11.015,19.625 13.5,19.625Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#D0D0D0"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,7 @@
     <string name="screen_rental_detail_owner_renting_overdue_info_reward_leading_text">지연 보상금</string>
     <string name="screen_rental_detail_owner_renting_overdue_info_reward_tail_text">이 지급될 예정이에요.</string>
 
+    <string name="toast_camera_launcher_fail">"사진 촬영에 문제가 발생했어요. 잠시 후 다시 시도해 주세요."</string>
     <!-- 결제 화면 -->
     <string name="screen_pay_title">결제하기</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,7 +222,18 @@
     <string name="screen_rental_detail_owner_renting_overdue_info_reward_leading_text">지연 보상금</string>
     <string name="screen_rental_detail_owner_renting_overdue_info_reward_tail_text">이 지급될 예정이에요.</string>
 
+    <!-- 대여 전 사진 등록 -->
+    <string name="screen_photo_before_rent_title">대여 전 사진 등록</string>
+    <string name="screen_photo_before_rent_guide">제품 상태를 정확히 증명하기 위해,\n방향에서 사진을 촬영해주세요. (최소 %d장, 최대 %d장)</string>
+    <string name="screen_photo_before_rent_btn_registration">등록하기</string>
+    <string name="toast_take_photo_fail">사진 촬영 실패</string>
+
+    <string name="screen_photo_before_rent_take_photo_btn_content_description">사진 촬영하기</string>
+    <string name="screen_photo_before_rent_take_photo_text_max_photo_taken">6장의 사진을 모두 촬영했어요.</string>
+
+    <!-- 카메라 Launcher -->
     <string name="toast_camera_launcher_fail">"사진 촬영에 문제가 발생했어요. 잠시 후 다시 시도해 주세요."</string>
+
     <!-- 결제 화면 -->
     <string name="screen_pay_title">결제하기</string>
 
@@ -261,6 +272,7 @@
     <string name="content_description_for_img_profile_placeholder">프로필 임시 이미지</string>
     <string name="content_description_for_img_empty_box">빈 박스 이미지</string>
     <string name="content_description_for_ic_check">확인 아이콘</string>
+    <string name="content_description_for_ic_camera">카메라 아이콘</string>
     <string name="content_description_for_ic_x_delete">삭제 아이콘</string>
 
     <string name="error_common_server">일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,7 @@
     <string name="content_description_for_img_profile_placeholder">프로필 임시 이미지</string>
     <string name="content_description_for_img_empty_box">빈 박스 이미지</string>
     <string name="content_description_for_ic_check">확인 아이콘</string>
+    <string name="content_description_for_ic_x_delete">삭제 아이콘</string>
 
     <string name="error_common_server">일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요.</string>
     <string name="error_common_cant_find_product">상품 정보를 찾을 수 없어요.</string>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="cache" path="."/>
+</paths>


### PR DESCRIPTION
# Pull Request

## Summary  
대여 전 사진 등록 화면의 카메라 촬영 기능 및 UI 구현

사진 촬영 로직: 
촬영할 사진을 저장할 **임시 파일을 Cache 디렉토리에 생성**   
-> 카메라에서 권한 없이 접근할 수 있도록 **파일을 FileProvider를 사용해 Content URI로 변환**   
-> **변환된 URI를 카메라에 전달**하여 촬영된 사진이 해당 위치에 저장되도록 함

## Related Issue  
- Close: #76 

## Changes  
- `CreatePost.kt`의 삭제 버튼이 있는 이미지 표시 Box를 `RemovableImageBox.kt`로 공통 컴포넌트 분리
- 사진 촬영을 위한 임시 파일 생성 및 카메라 실행을 위한 Launcher 함수 `rememberTakePhotoLauncher` 구현
- 대여 전 사진 등록용 촬영 버튼과 카메라 Launcher 함수 연결, 최대 촬영 개수 초과 시 비활성화 및 안내 텍스트 구현 
- 대여 전 사진 등록 화면 UI `PhotoBeforeRentScreen` 구현
- 화면 네비게이션과 UI 관련 데이터 처리를 담당하는 `PhotoBeforeRentRoute.kt` 파일 생성

## Screenshots (if applicable)  
- 구현 화면 UI 
   (촬영 전, 촬영 중(최소 개수 이상 - 등록 가능), 촬영 가능 개수 초과)
<div>
<img src="https://github.com/user-attachments/assets/d08d183c-650b-4ef4-b094-5f0606e56208", width="32%"/>
<img src="https://github.com/user-attachments/assets/d3ffd60b-72a4-453e-9f0a-8b3c41d7ce1a", width="32%"/>
<img src="https://github.com/user-attachments/assets/ce7062ec-eb35-4aaf-bb6c-5f020b7b0c91", width="32%"/>
</div>
