### PR TITLE
Fix/83 textfield cursor position

### DIFF
--- a/app/src/main/java/com/example/rentit/common/Constants.kt
+++ b/app/src/main/java/com/example/rentit/common/Constants.kt
@@ -1,3 +1,4 @@
 package com.example.rentit.common
 
 const val DEPOSIT_BASIS_DAYS = 3
+const val PRICE_LIMIT = 5_000_000

--- a/app/src/main/java/com/example/rentit/common/component/TextField.kt
+++ b/app/src/main/java/com/example/rentit/common/component/TextField.kt
@@ -1,6 +1,7 @@
 package com.example.rentit.common.component
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -28,9 +29,19 @@ import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
 
+
+private object CommonTextFieldDefaults {
+    val BorderRadius = 20.dp
+    val InnerPaddingValue = PaddingValues(20.dp, 12.dp)
+    val BorderColorFocused = PrimaryBlue500
+    val BorderColorDefault = Gray200
+    val PlaceHolderTextColor = Gray400
+}
+
 @Composable
 fun CommonTextField(
-    value: TextFieldValue,
+    modifier: Modifier = Modifier,
+    value: String,
     onValueChange: (String) -> Unit,
     placeholder: String = "",
     minLines: Int = 1,
@@ -40,19 +51,19 @@ fun CommonTextField(
     imeAction: ImeAction = ImeAction.Done,
     textStyle: TextStyle = MaterialTheme.typography.bodyMedium,
     placeholderAlignment: Alignment = Alignment.CenterStart,
-    modifier: Modifier = Modifier.fillMaxWidth(),
 ) {
-    var borderColor by remember { mutableStateOf(Gray200) }
+    var borderColor by remember { mutableStateOf(CommonTextFieldDefaults.BorderColorDefault) }
 
     BasicTextField(
-        value = value.text,
+        value = value,
         onValueChange = onValueChange,
         modifier = modifier
-            .clip(RoundedCornerShape(20.dp))  // 20dp 반경을 가진 둥근 모서리
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(CommonTextFieldDefaults.BorderRadius))
             .onFocusChanged {
-                borderColor = if(it.isFocused) PrimaryBlue500 else Gray200
+                borderColor = if (it.isFocused) CommonTextFieldDefaults.BorderColorFocused else CommonTextFieldDefaults.BorderColorDefault
             },
-        textStyle = textStyle,  // 텍스트 스타일
+        textStyle = textStyle,
         keyboardOptions = KeyboardOptions(
             keyboardType = keyboardType,
             imeAction = imeAction  // 키보드 오른쪽 하단 버튼 설정
@@ -65,14 +76,69 @@ fun CommonTextField(
             Box(
                 modifier = Modifier
                     .basicRoundedGrayBorder(color = borderColor)
-                    .padding(20.dp, 12.dp),
+                    .padding(CommonTextFieldDefaults.InnerPaddingValue),
+                contentAlignment = placeholderAlignment
+            ) {
+                if (value.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = CommonTextFieldDefaults.PlaceHolderTextColor
+                    )
+                }
+                innerTextField()  // 실제 입력 텍스트를 보여주는 부분
+            }
+        }
+    )
+}
+
+
+@Composable
+fun CommonTextField(
+    modifier: Modifier = Modifier,
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    placeholder: String = "",
+    minLines: Int = 1,
+    maxLines: Int = 1,
+    isSingleLine: Boolean = true,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    imeAction: ImeAction = ImeAction.Done,
+    textStyle: TextStyle = MaterialTheme.typography.bodyMedium,
+    placeholderAlignment: Alignment = Alignment.CenterStart,
+) {
+    var borderColor by remember { mutableStateOf(CommonTextFieldDefaults.BorderColorDefault) }
+
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(CommonTextFieldDefaults.BorderRadius))
+            .onFocusChanged {
+                borderColor = if (it.isFocused) CommonTextFieldDefaults.BorderColorFocused else CommonTextFieldDefaults.BorderColorDefault
+            },
+        textStyle = textStyle,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = keyboardType,
+            imeAction = imeAction  // 키보드 오른쪽 하단 버튼 설정
+        ),
+        minLines = minLines,
+        maxLines = maxLines,
+        singleLine = isSingleLine,
+        decorationBox = { innerTextField ->
+            // 텍스트 필드 테두리와 배경 설정
+            Box(
+                modifier = Modifier
+                    .basicRoundedGrayBorder(color = borderColor)
+                    .padding(CommonTextFieldDefaults.InnerPaddingValue),
                 contentAlignment = placeholderAlignment
             ) {
                 if (value.text.isEmpty()) {
                     Text(
                         text = placeholder,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = Gray400
+                        color = CommonTextFieldDefaults.PlaceHolderTextColor
                     )
                 }
                 innerTextField()  // 실제 입력 텍스트를 보여주는 부분
@@ -86,7 +152,7 @@ fun CommonTextField(
 fun PreviewBaseTextField() {
     RentItTheme {
         CommonTextField(
-            value = TextFieldValue(""),
+            value = "",
             onValueChange = { },
             placeholder = "Place Holder",
         )

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/JoinScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/JoinScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -78,7 +77,7 @@ fun JoinScreen(navHostController: NavHostController, name: String?, email: Strin
             Spacer(modifier = Modifier.weight(0.5f))
             HighlightedHeadline()
             CommonTextField(
-                value = TextFieldValue(nickname.value),
+                value = nickname.value,
                 onValueChange = { nickname.value = it },
                 placeholder = stringResource(R.string.app_name)
             )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/TrackingRegistrationDialog.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/TrackingRegistrationDialog.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.rentit.R
@@ -65,7 +64,7 @@ fun TrackingRegistrationDialog(
         )
         CommonTextField(
             modifier = Modifier.fillMaxWidth().padding(bottom = 10.dp),
-            value = TextFieldValue(trackingNum),
+            value = trackingNum,
             onValueChange = onTrackingNumChange,
             placeholder = stringResource(R.string.dialog_rental_detail_tracking_regs_placeholder_tracking_num),
             keyboardType = KeyboardType.Number,
@@ -95,7 +94,7 @@ fun DeliveryCompanyDropDown(
     ) {
         BasicTextField(
             readOnly = true,
-            value = TextFieldValue(selectedCompanyText),
+            value = selectedCompanyText,
             onValueChange = {},
             modifier = Modifier.menuAnchor().fillMaxWidth(),
             decorationBox = { innerTextField ->


### PR DESCRIPTION
# Pull Request

## Summary  
- 공통 텍스트필드인 `CommonTextField` 사용 시 전화번호나 금액 입력 값의 경우 포맷팅 후 커서를 맨 뒤로 이동시키기 위해 `TextFieldValue(formatted, formatted.length)`를 사용했으나, 커서 위치가 반영되지 않는 문제가 발생  
- 문제의 발생 원인이 `CommonTextField`가 내부적으로 사용하는 `BasicTextField`의 `value` 파라미터 타입이 `String`이고 해당 `value`는 내부 `TextFieldValue`의 `text`에만 영향을 주어 포맷팅 과정에서 `-`나 `,` 등의 문자가 추가되어도 커서 위치를 조정하는 `selection` 속성에 영향을 주지 않았기 때문임 
- 따라서 `value`파라미터 타입이 `TextFieldValue`인 `BasicTextField`를 사용한 `CommonTextField`를 오버로딩하여 포맷팅이 필요한 경우 선택적으로 사용할 수 있도록 함

## Related Issue  
- Close: #83 

## Changes  
- 기존의 `CommonTextField`의 불필요한 `TextFieldValue`타입 value를 `String`타입으로 변경
- 해당 공통 컴포넌트가 사용된 코드 수정
- `TextFieldValue`-based `BasicTextField`를 사용한 `CommonTextField` 오버로딩
- `CreatePostScreen.kt`의 가격 입력 필드의 포맷팅 로직을 리팩토링하고 `TextFieldValue`-based `CommonTextField`를 사용하여 포맷팅에 따라 커서 위치를 조정하도록 수정함
- 두 `CommonTextField`에서 공통으로 사용되는 값을 private object `CommonTextFieldDefaults`로 분리하여 관리하기 편하도록 함

## Screen Recordings
- Before Cursor Fix

[Before](https://github.com/user-attachments/assets/e04dfc53-3b06-4a62-915f-41d299acebb4)

- After Cursor Fix

[After](https://github.com/user-attachments/assets/664a9944-42f6-4d91-9756-3cebe1c2d633)

