### PR TITLE
Refactor/85 join to nicknamejoin

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/Paddings.kt
+++ b/app/src/main/java/com/example/rentit/common/component/Paddings.kt
@@ -8,3 +8,8 @@ import androidx.compose.ui.unit.dp
 fun Modifier.screenHorizontalPadding(): Modifier {
     return this.then(Modifier.padding(horizontal = 30.dp))
 }
+
+// 화면 하단에 Button이 고정으로 사용될 경우 필요한 하단 여백을 적용하는 Modifier
+fun Modifier.paddingForBottomBarButton(): Modifier {
+    return this.then(Modifier.padding(bottom = 30.dp))
+}

--- a/app/src/main/java/com/example/rentit/navigation/auth/AuthNavigation.kt
+++ b/app/src/main/java/com/example/rentit/navigation/auth/AuthNavigation.kt
@@ -6,7 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.example.rentit.presentation.auth.join.nickname.JoinNicknameScreen
+import com.example.rentit.presentation.auth.join.nickname.JoinNicknameRoute
 import com.example.rentit.presentation.auth.login.LoginScreen
 import com.example.rentit.presentation.main.MainView
 
@@ -49,7 +49,7 @@ fun NavGraphBuilder.authGraph(navHostController: NavHostController) {
 
     composable<AuthRoute.Join> { backStackEntry ->
         val items: AuthRoute.Join = backStackEntry.toRoute()
-        JoinNicknameScreen(navHostController, items.name, items.email)
+        JoinNicknameRoute(navHostController, items.name, items.email)
     }
 
     composable<AuthRoute.Main> { MainView() }

--- a/app/src/main/java/com/example/rentit/navigation/auth/AuthNavigation.kt
+++ b/app/src/main/java/com/example/rentit/navigation/auth/AuthNavigation.kt
@@ -6,7 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.example.rentit.presentation.auth.join.JoinScreen
+import com.example.rentit.presentation.auth.join.nickname.JoinNicknameScreen
 import com.example.rentit.presentation.auth.login.LoginScreen
 import com.example.rentit.presentation.main.MainView
 
@@ -49,7 +49,7 @@ fun NavGraphBuilder.authGraph(navHostController: NavHostController) {
 
     composable<AuthRoute.Join> { backStackEntry ->
         val items: AuthRoute.Join = backStackEntry.toRoute()
-        JoinScreen(navHostController, items.name, items.email)
+        JoinNicknameScreen(navHostController, items.name, items.email)
     }
 
     composable<AuthRoute.Main> { MainView() }

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/components/InputErrorMessage.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/components/InputErrorMessage.kt
@@ -1,0 +1,23 @@
+package com.example.rentit.presentation.auth.join.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.rentit.common.theme.AppRed
+
+/**
+ * 입력 필드 하단에 표시되는 에러 메세지
+ */
+
+@Composable
+fun InputErrorMessage(text: String) {
+    Text(
+        modifier = Modifier.padding(top = 10.dp, start = 12.dp, end = 12.dp),
+        text = text,
+        color = AppRed,
+        style = MaterialTheme.typography.labelLarge
+    )
+}

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameRoute.kt
@@ -1,0 +1,71 @@
+package com.example.rentit.presentation.auth.join.nickname
+
+import android.util.Log
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import com.example.rentit.R
+import com.example.rentit.navigation.auth.navigateToLogin
+
+private const val TAG = "Join"
+
+@Composable
+fun JoinNicknameRoute(navHostController: NavHostController, name: String?, email: String?) {
+
+    val joinNicknameViewModel: JoinNicknameViewModel = hiltViewModel()
+    var nickname by remember { mutableStateOf("") }
+    var showNicknameBlankError by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+
+    LaunchedEffect(email) {
+        if(email == null) {
+            Toast.makeText(context, context.getString(R.string.screen_join_error_email_null), Toast.LENGTH_SHORT).show()
+            navHostController.popBackStack()
+        }
+    }
+
+    SignUpResultHandler(joinNicknameViewModel, navHostController)
+
+    JoinNicknameScreen(
+        nickname = nickname,
+        showNicknameBlankError = showNicknameBlankError,
+        onBackPressed = { navHostController.popBackStack() },
+        onNicknameChange = { nickname = it },
+        onCompleteClick = {
+            if (nickname.isBlank()) {
+                showNicknameBlankError = true
+            } else if (email != null) {
+                joinNicknameViewModel.onSignUp(name ?: "", email, nickname)
+            }
+        }
+    )
+}
+
+
+
+@Composable
+private fun SignUpResultHandler(joinNicknameViewModel: JoinNicknameViewModel, navHostController: NavHostController) {
+    val context = LocalContext.current
+    val signUpResult = joinNicknameViewModel.signUpResult.collectAsStateWithLifecycle()
+
+    LaunchedEffect(signUpResult) {
+        signUpResult.value?.onSuccess {
+            Log.d(TAG, "Sign Up Success")
+            Toast.makeText(context, context.getString(R.string.screen_join_toast_complete), Toast.LENGTH_SHORT).show()
+            navHostController.navigateToLogin()
+        }?.onFailure { error ->
+            Log.d(TAG, "${error.message}")
+            Toast.makeText(context, context.getString(R.string.screen_join_toast_fail), Toast.LENGTH_SHORT).show()
+            navHostController.navigateToLogin()
+        }
+
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameScreen.kt
@@ -1,7 +1,5 @@
 package com.example.rentit.presentation.auth.join.nickname
 
-import android.util.Log
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -10,13 +8,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -24,10 +18,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonButton
 import com.example.rentit.common.component.CommonTextField
@@ -37,35 +27,19 @@ import com.example.rentit.common.theme.AppRed
 import com.example.rentit.common.theme.PretendardTextStyle
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.navigation.auth.navigateToLogin
-
-private const val TAG = "Join"
 
 @Composable
-fun JoinNicknameScreen(navHostController: NavHostController, name: String?, email: String?) {
-
-    val joinNicknameViewModel: JoinNicknameViewModel = hiltViewModel()
-    val nickname = remember { mutableStateOf("") }
-    val isButtonClicked = remember { mutableStateOf(false) }
-    val context = LocalContext.current
-
-    LaunchedEffect(email) {
-        if(email == null) {
-            Toast.makeText(
-                context,
-                context.getString(R.string.screen_join_error_email_null),
-                Toast.LENGTH_SHORT
-            ).show()
-            navHostController.popBackStack()
-        }
-    }
-
-    SignUpResultHandler(joinNicknameViewModel, navHostController)
-
+fun JoinNicknameScreen(
+    nickname: String,
+    showNicknameBlankError: Boolean,
+    onBackPressed: () -> Unit,
+    onNicknameChange: (String) -> Unit,
+    onCompleteClick: () -> Unit
+) {
     Column {
         CommonTopAppBar(
             title = stringResource(id = R.string.screen_join_title),
-        ) { navHostController.popBackStack() }
+        ) { onBackPressed() }
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -77,11 +51,11 @@ fun JoinNicknameScreen(navHostController: NavHostController, name: String?, emai
             Spacer(modifier = Modifier.weight(0.5f))
             HighlightedHeadline()
             CommonTextField(
-                value = nickname.value,
-                onValueChange = { nickname.value = it },
+                value = nickname,
+                onValueChange = onNicknameChange,
                 placeholder = stringResource(R.string.app_name)
             )
-            if (nickname.value.isBlank() && isButtonClicked.value) {
+            if (nickname.isBlank() && showNicknameBlankError) {
                 Text(
                     modifier = Modifier.padding(top = 6.dp, start = 6.dp),
                     text = stringResource(id = R.string.screen_join_nickname_empty_notification),
@@ -94,15 +68,7 @@ fun JoinNicknameScreen(navHostController: NavHostController, name: String?, emai
                 text = stringResource(R.string.screen_join_btn_text),
                 containerColor = PrimaryBlue500,
                 contentColor = Color.White
-            ) {
-                if (nickname.value.isEmpty()) {
-                    isButtonClicked.value = true
-                } else if(email == null){
-                    navHostController.popBackStack()
-                } else {
-                    joinNicknameViewModel.onSignUp(name ?: "", email, nickname.value)
-                }
-            }
+            ) { onCompleteClick() }
         }
     }
 }
@@ -123,29 +89,16 @@ fun HighlightedHeadline() {
     )
 }
 
-@Composable
-fun SignUpResultHandler(joinNicknameViewModel: JoinNicknameViewModel, navHostController: NavHostController) {
-    val context = LocalContext.current
-    val signUpResult = joinNicknameViewModel.signUpResult.collectAsStateWithLifecycle()
-
-    LaunchedEffect(signUpResult) {
-        signUpResult.value?.onSuccess {
-            Log.d(TAG, "Sign Up Success")
-            Toast.makeText(context, context.getString(R.string.screen_join_toast_complete), Toast.LENGTH_SHORT).show()
-            navHostController.navigateToLogin()
-        }?.onFailure { error ->
-            Log.d(TAG, "${error.message}")
-            Toast.makeText(context, context.getString(R.string.screen_join_toast_fail), Toast.LENGTH_SHORT).show()
-            navHostController.navigateToLogin()
-        }
-
-    }
-}
-
 @Preview
 @Composable
-fun JoinPreview() {
+fun JoinNicknameScreenPreview() {
     RentItTheme {
-        JoinNicknameScreen(rememberNavController(), "", "")
+        JoinNicknameScreen(
+            nickname = "",
+            showNicknameBlankError = true,
+            onNicknameChange = {},
+            onBackPressed = {},
+            onCompleteClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,11 +22,12 @@ import com.example.rentit.R
 import com.example.rentit.common.component.CommonButton
 import com.example.rentit.common.component.CommonTextField
 import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.component.paddingForBottomBarButton
 import com.example.rentit.common.component.screenHorizontalPadding
-import com.example.rentit.common.theme.AppRed
 import com.example.rentit.common.theme.PretendardTextStyle
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.presentation.auth.join.components.InputErrorMessage
 
 @Composable
 fun JoinNicknameScreen(
@@ -36,46 +37,53 @@ fun JoinNicknameScreen(
     onNicknameChange: (String) -> Unit,
     onCompleteClick: () -> Unit
 ) {
-    Column {
-        CommonTopAppBar(
-            title = stringResource(id = R.string.screen_join_title),
-        ) { onBackPressed() }
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color.White)
-                .screenHorizontalPadding()
-                .padding(bottom = 60.dp),
-            horizontalAlignment = Alignment.Start
-        ) {
-            Spacer(modifier = Modifier.weight(0.5f))
-            HighlightedHeadline()
-            CommonTextField(
-                value = nickname,
-                onValueChange = onNicknameChange,
-                placeholder = stringResource(R.string.app_name)
-            )
-            if (nickname.isBlank() && showNicknameBlankError) {
-                Text(
-                    modifier = Modifier.padding(top = 6.dp, start = 6.dp),
-                    text = stringResource(id = R.string.screen_join_nickname_empty_notification),
-                    color = AppRed,
-                    style = MaterialTheme.typography.labelLarge
-                )
-            }
-            Spacer(modifier = Modifier.weight(1f))
+    Scaffold(
+        topBar = {
+            CommonTopAppBar(
+                title = stringResource(id = R.string.screen_join_title),
+            ) { onBackPressed() }
+        },
+        bottomBar = {
             CommonButton(
+                modifier = Modifier
+                    .screenHorizontalPadding()
+                    .paddingForBottomBarButton(),
                 text = stringResource(R.string.screen_join_btn_text),
                 containerColor = PrimaryBlue500,
                 contentColor = Color.White
             ) { onCompleteClick() }
         }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+                .screenHorizontalPadding()
+                .padding(it),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Spacer(modifier = Modifier.weight(0.5f))
+
+            HighlightedHeadline()
+
+            CommonTextField(
+                value = nickname,
+                onValueChange = onNicknameChange,
+                placeholder = stringResource(R.string.app_name)
+            )
+
+            if (nickname.isBlank() && showNicknameBlankError) {
+                InputErrorMessage( stringResource(id = R.string.screen_join_nickname_empty_notification))
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+        }
     }
 }
 
-
 @Composable
-fun HighlightedHeadline() {
+private fun HighlightedHeadline() {
     Text(
         modifier = Modifier.padding(bottom = 27.dp),
         text = buildAnnotatedString {

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameScreen.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.auth.join
+package com.example.rentit.presentation.auth.join.nickname
 
 import android.util.Log
 import android.widget.Toast
@@ -42,9 +42,9 @@ import com.example.rentit.navigation.auth.navigateToLogin
 private const val TAG = "Join"
 
 @Composable
-fun JoinScreen(navHostController: NavHostController, name: String?, email: String?) {
+fun JoinNicknameScreen(navHostController: NavHostController, name: String?, email: String?) {
 
-    val joinViewModel: JoinViewModel = hiltViewModel()
+    val joinNicknameViewModel: JoinNicknameViewModel = hiltViewModel()
     val nickname = remember { mutableStateOf("") }
     val isButtonClicked = remember { mutableStateOf(false) }
     val context = LocalContext.current
@@ -60,7 +60,7 @@ fun JoinScreen(navHostController: NavHostController, name: String?, email: Strin
         }
     }
 
-    SignUpResultHandler(joinViewModel, navHostController)
+    SignUpResultHandler(joinNicknameViewModel, navHostController)
 
     Column {
         CommonTopAppBar(
@@ -100,7 +100,7 @@ fun JoinScreen(navHostController: NavHostController, name: String?, email: Strin
                 } else if(email == null){
                     navHostController.popBackStack()
                 } else {
-                    joinViewModel.onSignUp(name ?: "", email, nickname.value)
+                    joinNicknameViewModel.onSignUp(name ?: "", email, nickname.value)
                 }
             }
         }
@@ -124,9 +124,9 @@ fun HighlightedHeadline() {
 }
 
 @Composable
-fun SignUpResultHandler(joinViewModel: JoinViewModel, navHostController: NavHostController) {
+fun SignUpResultHandler(joinNicknameViewModel: JoinNicknameViewModel, navHostController: NavHostController) {
     val context = LocalContext.current
-    val signUpResult = joinViewModel.signUpResult.collectAsStateWithLifecycle()
+    val signUpResult = joinNicknameViewModel.signUpResult.collectAsStateWithLifecycle()
 
     LaunchedEffect(signUpResult) {
         signUpResult.value?.onSuccess {
@@ -146,6 +146,6 @@ fun SignUpResultHandler(joinViewModel: JoinViewModel, navHostController: NavHost
 @Composable
 fun JoinPreview() {
     RentItTheme {
-        JoinScreen(rememberNavController(), "", "")
+        JoinNicknameScreen(rememberNavController(), "", "")
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.auth.join
+package com.example.rentit.presentation.auth.join.nickname
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class JoinViewModel @Inject constructor(
+class JoinNicknameViewModel @Inject constructor(
     private val repository: UserRepository
 ) : ViewModel() {
 


### PR DESCRIPTION
# Pull Request

## Summary  
회원가입 로직에서 휴대폰 인증이 추가되었기 때문에 기존의 닉네임 설정(회원가입) 화면을 `JoinScreen`에서 `JoinNicknameScreen`으로 변경하고, 해당 화면을 UI 로직과 Navigation, 상태 관리 로직 각각 Screen과 Route로 분리하고 리팩토링 함

## Related Issue  
- Close: #85 

## Changes  
- `join` 패키지 아래 `nickname` 패키지를 생성하고 닉네임 설정(회원가입) 관련 파일 `JoinNicknameScreen.kt`, `JoinNicknameRoute.kt`, 'JoinNicknameViewModel.kt`을 넣음
- 수정된 패키지와 파일 이름에 따라 `AuthNavigation.kt` 수정
- 기존의 `JoinScreen`의 UI 로직과 Navigation, 상태 관리 로직 각각 Screen과 Route로 분리
- 입력 필드 하위의 에러메세지 'join/components/InputErrorMessage.kt'로 분리하여 추후 휴대폰 인증 UI에서도 사용할 수 있도록 함
- `JoinNicknameScreen.kt`를 기존 Column을 사용한 구조에서 Scaffold를 사용하도록 리팩토링하여 화면 상단/하단/본문 영역을 명확히 분리함

**[변경된 구조]**
```
📂auth/
┣ 📂join/
┃ ┣ 📂components/
┃ ┣ 📂nickname/
┃ ┃ ┣ JoinNicknameScreen.kt
┃ ┃ ┣ JoinNicknameRoute.kt
┃ ┃ ┗ JoinNicknameViewModel.kt
┃ ┣ 📂phoneverification/ (예정)
...
```
