### PR TITLE
Feat/82 screen phone verification

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/TextField.kt
+++ b/app/src/main/java/com/example/rentit/common/component/TextField.kt
@@ -42,6 +42,7 @@ private object CommonTextFieldDefaults {
 fun CommonTextField(
     modifier: Modifier = Modifier,
     value: String,
+    enabled: Boolean = true,
     onValueChange: (String) -> Unit,
     placeholder: String = "",
     minLines: Int = 1,
@@ -57,6 +58,7 @@ fun CommonTextField(
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
+        enabled = enabled,
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(CommonTextFieldDefaults.BorderRadius))
@@ -98,6 +100,7 @@ fun CommonTextField(
     modifier: Modifier = Modifier,
     value: TextFieldValue,
     onValueChange: (TextFieldValue) -> Unit,
+    enabled: Boolean = true,
     placeholder: String = "",
     minLines: Int = 1,
     maxLines: Int = 1,
@@ -112,6 +115,7 @@ fun CommonTextField(
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
+        enabled = enabled,
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(CommonTextFieldDefaults.BorderRadius))

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameRoute.kt
@@ -27,7 +27,7 @@ fun JoinNicknameRoute(navHostController: NavHostController, name: String?, email
 
     LaunchedEffect(email) {
         if(email == null) {
-            Toast.makeText(context, context.getString(R.string.screen_join_error_email_null), Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, context.getString(R.string.screen_join_nickname_error_email_null), Toast.LENGTH_SHORT).show()
             navHostController.popBackStack()
         }
     }
@@ -59,11 +59,11 @@ private fun SignUpResultHandler(joinNicknameViewModel: JoinNicknameViewModel, na
     LaunchedEffect(signUpResult) {
         signUpResult.value?.onSuccess {
             Log.d(TAG, "Sign Up Success")
-            Toast.makeText(context, context.getString(R.string.screen_join_toast_complete), Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, context.getString(R.string.screen_join_nickname_toast_complete), Toast.LENGTH_SHORT).show()
             navHostController.navigateToLogin()
         }?.onFailure { error ->
             Log.d(TAG, "${error.message}")
-            Toast.makeText(context, context.getString(R.string.screen_join_toast_fail), Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, context.getString(R.string.screen_join_nickname_toast_fail), Toast.LENGTH_SHORT).show()
             navHostController.navigateToLogin()
         }
 

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameScreen.kt
@@ -48,7 +48,7 @@ fun JoinNicknameScreen(
                 modifier = Modifier
                     .screenHorizontalPadding()
                     .paddingForBottomBarButton(),
-                text = stringResource(R.string.screen_join_btn_text),
+                text = stringResource(R.string.screen_join_nickname_btn_text),
                 containerColor = PrimaryBlue500,
                 contentColor = Color.White
             ) { onCompleteClick() }
@@ -90,7 +90,7 @@ private fun HighlightedHeadline() {
             withStyle(style = SpanStyle(color = PrimaryBlue500)) {
                 append(stringResource(R.string.app_name))
             }
-            append(stringResource(R.string.screen_join_headline))
+            append(stringResource(R.string.screen_join_nickname_headline))
         },
         style = PretendardTextStyle.headline_bold,
         textAlign = TextAlign.Start

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/phoneverification/JoinPhoneVerificationRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/phoneverification/JoinPhoneVerificationRoute.kt
@@ -1,0 +1,42 @@
+package com.example.rentit.presentation.auth.join.phoneverification
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.example.rentit.common.theme.RentItTheme
+
+private const val PHONE_NUMBER_TOTAL_LENGTH = 13
+
+@Composable
+fun JoinPhoneVerificationRoute() {
+    var phoneNumber by remember { mutableStateOf("") }
+    var code by remember { mutableStateOf("") }
+    var showCodeError by remember { mutableStateOf(false) }
+    var isCodeFieldEnabled by remember { mutableStateOf(true) }
+
+    val isRequestEnabled by remember(phoneNumber) { mutableStateOf(phoneNumber.length == PHONE_NUMBER_TOTAL_LENGTH) }
+    val isConfirmEnabled by remember(code) { mutableStateOf(code.isNotBlank()) }
+
+    RentItTheme {
+        JoinPhoneVerificationScreen(
+            phoneNumber = phoneNumber,
+            code = code,
+            isRequestEnabled = isRequestEnabled,
+            isCodeFieldEnabled = isCodeFieldEnabled,
+            isConfirmEnabled = isConfirmEnabled,
+            showCodeError = showCodeError,
+            onPhoneNumberChange = { phoneNumber = it },
+            onCodeChange = {
+                code = it
+                showCodeError = false
+            },
+            onRequestCode = { },
+            onBackPressed = { },
+            onConfirm = {
+                if (code.isBlank()) showCodeError = true
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/phoneverification/JoinPhoneVerificationScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/phoneverification/JoinPhoneVerificationScreen.kt
@@ -1,0 +1,185 @@
+package com.example.rentit.presentation.auth.join.phoneverification
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.rentit.R
+import com.example.rentit.common.component.CommonButton
+import com.example.rentit.common.component.CommonTextField
+import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.component.paddingForBottomBarButton
+import com.example.rentit.common.component.screenHorizontalPadding
+import com.example.rentit.common.theme.PretendardTextStyle
+import com.example.rentit.common.theme.PrimaryBlue500
+import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.common.theme.White
+import com.example.rentit.presentation.auth.join.components.InputErrorMessage
+
+const val PHONE_NUMBER_DIGITS_LENGTH = 11
+const val PHONE_NUMBER_SECOND_SPLIT_MIN = 8
+const val PHONE_NUMBER_FIRST_SPLIT_MIN = 4
+
+@Composable
+fun JoinPhoneVerificationScreen(
+    phoneNumber: String,
+    code: String,
+    isRequestEnabled: Boolean,
+    isCodeFieldEnabled: Boolean,
+    isConfirmEnabled: Boolean,
+    showCodeError: Boolean,
+    onBackPressed: () -> Unit,
+    onPhoneNumberChange: (String) -> Unit,
+    onCodeChange: (String) -> Unit,
+    onRequestCode: () -> Unit,
+    onConfirm: () -> Unit,
+    ) {
+    Scaffold(
+        topBar = { CommonTopAppBar(title = stringResource(R.string.screen_join_title)) { onBackPressed() } },
+        bottomBar = { CommonButton(
+            modifier = Modifier
+                .screenHorizontalPadding()
+                .paddingForBottomBarButton(),
+            text = stringResource(R.string.screen_join_phone_verification_btn_check_code),
+            enabled = isConfirmEnabled,
+            containerColor = PrimaryBlue500,
+            contentColor = White
+        ) { onConfirm() } }
+    ) {
+        Column(Modifier
+            .padding(it)
+            .screenHorizontalPadding()) {
+
+            Spacer(Modifier.weight(0.8f))
+
+            PhoneVerificationGuideText()
+
+            PhoneVerificationForm(
+                phoneNumber = phoneNumber,
+                code = code,
+                isRequestEnabled = isRequestEnabled,
+                isCodeFieldEnabled = isCodeFieldEnabled,
+                onPhoneNumberChange = onPhoneNumberChange,
+                onCodeChange = onCodeChange,
+                onRequestCode = onRequestCode
+            )
+
+            if (showCodeError) {
+                InputErrorMessage(stringResource(R.string.screen_join_phone_verification_error_invalid_code))
+            }
+
+            Spacer(Modifier.weight(2f))
+        }
+    }
+}
+
+@Composable
+private fun PhoneVerificationGuideText() {
+    Text(
+        modifier = Modifier.padding(bottom = 8.dp),
+        text = stringResource(R.string.screen_join_phone_verification_title),
+        style = PretendardTextStyle.headline_bold,
+    )
+    Text(
+        modifier = Modifier.padding(bottom = 27.dp),
+        text = stringResource(R.string.screen_join_phone_verification_guide),
+        style = MaterialTheme.typography.labelMedium,
+    )
+}
+
+@Composable
+private fun PhoneVerificationForm(
+    phoneNumber: String,
+    code: String,
+    isRequestEnabled: Boolean = true,
+    isCodeFieldEnabled: Boolean = true,
+    onPhoneNumberChange: (String) -> Unit = {},
+    onCodeChange: (String) -> Unit = {},
+    onRequestCode: () -> Unit = {},
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+        CommonTextField(
+            modifier = Modifier.weight(1f),
+            value = TextFieldValue(phoneNumber, TextRange(phoneNumber.length)), // 맨 뒤로 커서 조정
+            onValueChange = {
+                val formatted = formatPhoneNumber(it.text)
+                onPhoneNumberChange(formatted)
+            },
+            placeholder = stringResource(R.string.screen_join_phone_verification_placeholder_phone_number),
+            keyboardType = KeyboardType.Number,
+        )
+        Button(
+            onClick = onRequestCode,
+            enabled = isRequestEnabled,
+            colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue500),
+            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 14.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.screen_join_phone_verification_btn_request_code),
+                style = MaterialTheme.typography.labelLarge,
+            )
+        }
+    }
+    CommonTextField(
+        modifier = Modifier.padding(top = 10.dp),
+        value = code,
+        enabled = isCodeFieldEnabled,
+        onValueChange = onCodeChange,
+        placeholder = stringResource(R.string.screen_join_phone_verification_placeholder_code),
+        keyboardType = KeyboardType.Number,
+    )
+}
+
+
+private fun formatPhoneNumber(phoneNumber: String): String {
+    val digits = phoneNumber.filter { c -> c.isDigit() }.take(PHONE_NUMBER_DIGITS_LENGTH)
+    return when (digits.length) {
+        in PHONE_NUMBER_SECOND_SPLIT_MIN..PHONE_NUMBER_DIGITS_LENGTH -> digits.replaceFirst(
+            Regex("(\\d{3})(\\d{4})(\\d+)"),
+            "$1-$2-$3"
+        )
+
+        in PHONE_NUMBER_FIRST_SPLIT_MIN..<PHONE_NUMBER_SECOND_SPLIT_MIN -> digits.replaceFirst(
+            Regex("(\\d{3})(\\d+)"),
+            "$1-$2"
+        )
+
+        else -> digits
+    }
+}
+
+@Preview
+@Composable
+fun JoinPhoneVerificationScreenPreview() {
+    RentItTheme {
+        JoinPhoneVerificationScreen(
+            phoneNumber = "",
+            code = "",
+            isRequestEnabled = true,
+            isCodeFieldEnabled = true,
+            isConfirmEnabled = true,
+            showCodeError = true,
+            onPhoneNumberChange = {},
+            onCodeChange = {},
+            onRequestCode = {},
+            onBackPressed = {},
+            onConfirm = {},
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,14 @@
     <!-- 회원가입 -->
     <string name="screen_join_title">회원가입</string>
 
+    <string name="screen_join_phone_verification_title">전화번호 인증</string>
+    <string name="screen_join_phone_verification_guide">안전한 서비스 이용을 위해, 본인 인증이 필요해요.</string>
+    <string name="screen_join_phone_verification_placeholder_phone_number">휴대폰 11자리</string>
+    <string name="screen_join_phone_verification_btn_request_code">인증 요청</string>
+    <string name="screen_join_phone_verification_placeholder_code">인증번호 입력</string>
+    <string name="screen_join_phone_verification_error_invalid_code">입력하신 인증번호가 올바르지 않아요. 다시 시도해 주세요.</string>
+    <string name="screen_join_phone_verification_btn_check_code">인증번호 확인</string>
+
     <string name="screen_join_nickname_headline">에서 사용할\n닉네임을 정해주세요.</string>
     <string name="screen_join_nickname_empty_notification">닉네임을 1자 이상 입력해 주세요.</string>
     <string name="screen_join_nickname_error_email_null">회원가입을 진행할 수 없어요.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,34 +32,43 @@
     <string name="common_dialog_accept_request_label_total_price">예상 수익</string>
     <string name="common_dialog_accept_request_btn_accept">수락하기</string>
 
+    <string name="common_calendar_left_chevron_description">다음달로 이동</string>
+    <string name="common_calendar_right_chevron_description">이전달로 이동</string>
+
     <string name="util_formatted_period">%s (%s) ~ %s (%s) · %d일</string>
     <string name="util_error_rental_period_unavailable">기간 정보 없음</string>
 
+    <!-- 로그인 -->
     <string name="screen_login_app_logo_description">랜팃 로고</string>
     <string name="screen_login_google_logo_description">구글 로고</string>
     <string name="screen_login_label">중고 거래와 렌탈의 새로운 기준</string>
     <string name="screen_login_google_login_btn_text">Google 계정으로 로그인</string>
 
+    <!-- 회원가입 -->
     <string name="screen_join_title">회원가입</string>
-    <string name="screen_join_btn_text">RentIt 시작하기</string>
-    <string name="screen_join_headline">에서 사용할\n닉네임을 정해주세요.</string>
-    <string name="screen_join_nickname_empty_notification">닉네임을 1자 이상 입력해 주세요.</string>
-    <string name="screen_join_error_email_null">회원가입을 진행할 수 없어요.</string>
-    <string name="screen_join_toast_complete">회원가입이 완료되었어요. 이제 로그인이 가능해요.</string>
-    <string name="screen_join_toast_fail">회원가입에 실패했어요. 잠시 후 다시 시도해주세요.</string>
 
+    <string name="screen_join_nickname_headline">에서 사용할\n닉네임을 정해주세요.</string>
+    <string name="screen_join_nickname_empty_notification">닉네임을 1자 이상 입력해 주세요.</string>
+    <string name="screen_join_nickname_error_email_null">회원가입을 진행할 수 없어요.</string>
+    <string name="screen_join_nickname_toast_complete">회원가입이 완료되었어요. 이제 로그인이 가능해요.</string>
+    <string name="screen_join_nickname_toast_fail">회원가입에 실패했어요. 잠시 후 다시 시도해주세요.</string>
+    <string name="screen_join_nickname_btn_text">RentIt 시작하기</string>
+
+    <!-- 게시글 리스트 아이템 -->
     <string name="product_list_item_period_text_more_and_less_than_day">%d일 ~ %d일</string>
     <string name="product_list_item_period_text_more_than_day">%d일 이상</string>
     <string name="product_list_item_period_text_less_than_day">%d일 이하</string>
     <string name="product_list_item_period_text_more_than_zero">0일 이상</string>
     <string name="product_list_item_period_btn_check_request">요청 확인하기</string>
 
+    <!-- 홈 -->
     <string name="screen_home_logo_img_placeholder_description">렌팃 로고</string>
     <string name="screen_home_search_img_placeholder_description">검색</string>
 
     <string name="screen_home_label_btn_filter_rent_possibility">대여 가능</string>
     <string name="screen_home_label_btn_filter_category">카테고리</string>
 
+    <!-- 게시글 상세 -->
     <string name="screen_product_detail_img_placeholder_description">상품 임시 이미지</string>
     <string name="screen_product_detail_img_description">상품 이미지</string>
     <string name="screen_product_like_icon_description">상품 좋아요</string>
@@ -69,20 +78,20 @@
     <string name="screen_product_btn_chatting">채팅하기</string>
     <string name="screen_product_btn_reserve">예약하기</string>
 
-    <string name="common_calendar_left_chevron_description">다음달로 이동</string>
-    <string name="common_calendar_right_chevron_description">이전달로 이동</string>
-
+    <!-- 대여 예약 요청 -->
     <string name="screen_resv_request_app_bar_title">예약 기간을 설정해주세요.</string>
     <string name="screen_resv_request_label_total_rental_fee">총 대여 비용</string>
     <string name="screen_resv_request_label_deposit">보증금</string>
     <string name="screen_resv_request_label_total_fee">합계</string>
     <string name="screen_resv_request_btn_resv_request">예약 요청</string>
 
+    <!-- 예약 요청 확인 -->
     <string name="screen_request_confirm_title">요청이 전달되었어요!</string>
     <string name="screen_request_confirm_resv_period">예약 기간</string>
     <string name="screen_request_confirm_total_price">총 금액</string>
     <string name="screen_request_confirm_btn_complete">완료</string>
 
+    <!-- 게시글 생성 -->
     <string name="screen_product_create_image_label">이미지</string>
     <string name="screen_product_create_add_image_text">+ 이미지 추가</string>
     <string name="screen_product_create_selected_image_description">선택된 이미지</string>
@@ -96,9 +105,11 @@
     <string name="screen_product_create_rental_period_text">최소 %d일 ~ 최대 %d일</string>
     <string name="screen_product_create_price_label">가격</string>
     <string name="screen_product_create_complete_btn_text">등록하기</string>
-    
+
+    <!-- 채팅 리스트 -->
     <string name="screen_chat_list_btn_up_to_date_order">최신순</string>
 
+    <!-- 채팅방 -->
     <string name="auto_msg_type_request_accept_title">[렌팃] 요청이 수락되었습니다.</string>
     <string name="auto_msg_type_request_accept_content">결제는 아래 버튼으로\n간편하게 진행하실 수 있어요 :)</string>
     <string name="auto_msg_type_request_accept_btn_text">결제 진행하기</string>
@@ -125,6 +136,7 @@
     <string name="screen_accept_confirm_title">요청이 수락되었어요!</string>
     <string name="screen_accept_confirm_btn_complete">완료</string>
 
+    <!-- 마이페이지 -->
     <string name="screen_mypage_btn_my_activity">나의 활동 내역</string>
     <string name="screen_mypage_btn_new">NEW</string>
     <string name="screen_mypage_info_text_start">내가 대여한 %s의 반납일이</string>
@@ -137,10 +149,10 @@
     <string name="screen_mypage_my_rental_list_item_label_renting">대여중</string>
     <string name="screen_mypage_my_rental_list_item_label_request_at">요청일: </string>
 
+    <!-- 대여 상세 -->
     <string name="screen_rental_detail_task_check_box_icon_done">%s 완료</string>
     <string name="screen_rental_detail_task_check_box_icon_not_done">%s 미완료</string>
 
-    <!-- 대여 상세 -->
     <string name="screen_rental_detail_title">대여 상세</string>
     <string name="screen_rental_detail_request_btn_cancel_rent">대여 취소하기</string>
     <string name="screen_rental_detail_returned_check_photo_btn">대여 전/후 사진 확인하기</string>


### PR DESCRIPTION
# Pull Request

## Summary  
전화번호 포맷팅, 인증 실패 메세지를 포함한 휴대폰 인증 화면 UI 구현 (API 연결 제외)

## Related Issue  
- Close: #82 

## Changes  
- 문자열 리소스를 라벨링하여 알아보기 쉽게 정리하고, 기존 가입 화면 관련 문자열 리소스를 join_nickname으로 변경
- 휴대폰 인증 화면 관련 문자열 리소스 추가
- 전화번호 포맷팅 함수 작성 
   - 문자열 -> 숫자 필터링, 길이 제한, 하이픈(-) 추가 -> '000-0000-0000' 형식으로 포맷팅
- 문자열 입력에 따른 버튼 활성화 처리 
   - 전화번호 11자리(하이픈 포함 13자리) 모두 입력 시 인증 요청 버튼 활성화
   - 인증번호 1자 이상 입력시 인증번호 확인 버튼 활성화
- Route에 화면 관련 상태 작성

## Screenshots
- 구현된 UI 영상

[휴대폰 인증 화면](https://github.com/user-attachments/assets/71b71998-182c-4480-8d34-2f8a255d692e)




