### PR TITLE
Feat/90 ui proof download screen

### DIFF
--- a/app/src/main/java/com/example/rentit/presentation/mypage/setting/transactionproof/TransactionProofDownloadRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/setting/transactionproof/TransactionProofDownloadRoute.kt
@@ -1,0 +1,15 @@
+package com.example.rentit.presentation.mypage.setting.transactionproof
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import com.example.rentit.common.theme.RentItTheme
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun TransactionProofDownloadRoute() {
+
+    RentItTheme {
+        TransactionProofDownloadScreen(emptyList())
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/mypage/setting/transactionproof/TransactionProofDownloadScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/setting/transactionproof/TransactionProofDownloadScreen.kt
@@ -1,0 +1,114 @@
+package com.example.rentit.presentation.mypage.setting.transactionproof
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.rentit.R
+import com.example.rentit.common.component.CommonDivider
+import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.component.RentalSummary
+import com.example.rentit.common.component.screenHorizontalPadding
+import com.example.rentit.common.model.RentalSummaryUiModel
+import com.example.rentit.common.theme.RentItTheme
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun TransactionProofDownloadScreen(
+    transactionRecords: List<RentalSummaryUiModel>,
+    onBackPressed: () -> Unit = {},
+    onDownloadClick: () -> Unit = {},
+) {
+    Scaffold(
+        topBar = { CommonTopAppBar(title = stringResource(R.string.screen_transaction_proof_title), onBackClick = onBackPressed) }
+    ) {
+        Column(Modifier
+            .padding(it)
+            .verticalScroll(rememberScrollState())) {
+            transactionRecords.forEach { record ->
+                CommonDivider()
+                TransactionProofDownloadListItem(record, onDownloadClick)
+            }
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun TransactionProofDownloadListItem(rentalSummary: RentalSummaryUiModel, onDownloadClick: () -> Unit) {
+
+    val downloadBtnDescription = stringResource(
+        R.string.screen_transaction_proof_download_btn_description,
+        rentalSummary.startDate,
+        rentalSummary.endDate,
+        rentalSummary.productTitle
+    )
+
+    Row(Modifier
+        .screenHorizontalPadding()
+        .padding(vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically) {
+        RentalSummary(
+            modifier = Modifier.weight(1f),
+            thumbnailImgUrl = rentalSummary.thumbnailImgUrl,
+            productTitle = rentalSummary.productTitle,
+            startDate = rentalSummary.startDate,
+            endDate = rentalSummary.endDate,
+            totalPrice = rentalSummary.totalPrice
+        )
+        IconButton(
+            onClick = onDownloadClick,
+            modifier = Modifier.semantics { contentDescription = downloadBtnDescription },
+        ) {
+            Icon(painterResource(R.drawable.ic_download), contentDescription = stringResource(R.string.content_description_for_ic_download))
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+@Preview
+fun TransactionProofDownloadScreenPreview() {
+    val sampleRentalSummaries = listOf(
+        RentalSummaryUiModel(
+            productTitle = "프리미엄 캠핑 텐트",
+            thumbnailImgUrl = "https://example.com/images/tent.jpg",
+            startDate = "2025-08-01",
+            endDate = "2025-08-03",
+            totalPrice = 50000
+        ),
+        RentalSummaryUiModel(
+            productTitle = "캐논 DSLR 카메라",
+            thumbnailImgUrl = "https://example.com/images/camera.jpg",
+            startDate = "2025-08-05",
+            endDate = "2025-08-07",
+            totalPrice = 75000
+        ),
+        RentalSummaryUiModel(
+            productTitle = "전동 킥보드",
+            thumbnailImgUrl = "https://example.com/images/kickboard.jpg",
+            startDate = "2025-08-10",
+            endDate = "2025-08-12",
+            totalPrice = 30000
+        )
+    )
+
+    RentItTheme {
+        TransactionProofDownloadScreen(sampleRentalSummaries)
+    }
+}

--- a/app/src/main/res/drawable/ic_download.xml
+++ b/app/src/main/res/drawable/ic_download.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="19dp"
+    android:viewportWidth="19"
+    android:viewportHeight="19">
+  <path
+      android:pathData="M17.375,12.125V15.625C17.375,16.089 17.191,16.534 16.862,16.862C16.534,17.191 16.089,17.375 15.625,17.375H3.375C2.911,17.375 2.466,17.191 2.138,16.862C1.809,16.534 1.625,16.089 1.625,15.625V12.125M5.125,7.75L9.5,12.125M9.5,12.125L13.875,7.75M9.5,12.125V1.625"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#1E1E1E"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,6 +167,10 @@
     <string name="screen_setting_label_logout">로그아웃</string>
     <string name="screen_setting_description_clickable_list_item">%s 바로가기</string>
 
+    <!-- 거래 증빙 서류 다운로드 -->
+    <string name="screen_transaction_proof_title">거래 증빙 서류 다운로드</string>
+    <string name="screen_transaction_proof_download_btn_description">%s부터 %s까지 %s 대여 내역에 대한 거래 증빙 서류 다운로드</string>
+
     <!-- 대여 상세 -->
     <string name="screen_rental_detail_task_check_box_icon_done">%s 완료</string>
     <string name="screen_rental_detail_task_check_box_icon_not_done">%s 미완료</string>
@@ -324,6 +328,7 @@
     <string name="content_description_for_ic_check">확인 아이콘</string>
     <string name="content_description_for_ic_camera">카메라 아이콘</string>
     <string name="content_description_for_ic_x_delete">삭제 아이콘</string>
+    <string name="content_description_for_ic_download">다운로드 아이콘</string>
 
     <string name="error_common_server">일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요.</string>
     <string name="error_common_cant_find_product">상품 정보를 찾을 수 없어요.</string>


### PR DESCRIPTION
# Pull Request

## Summary  
거래 증빙 서류 다운로드 화면 UI 구현

## Related Issue  
- Close: #90

## Changes  
- 공통 컴포저블 `RentalSummary`를 활용해 거래 증빙 서류 다운로드 화면 UI 구성

## Screenshots
<div>
<img width="33%", src="https://github.com/user-attachments/assets/cdb78a97-db37-4eaa-a605-dce9f967d431"/>
</div>

