### PR TITLE
Refactor/93 sharedprefs backup exclude

### DIFF
--- a/app/src/main/java/com/example/rentit/common/storage/TokenStorage.kt
+++ b/app/src/main/java/com/example/rentit/common/storage/TokenStorage.kt
@@ -11,34 +11,27 @@ private const val PREFS_NAME = "secure_prefs"
 private const val ACCESS_TOKEN_KEY = "access_token"
 private const val TAG = "SecurePrefs"
 
-private fun getEncryptedSharedPreference(context: Context): SharedPreferences? {
-    return try {
-        val masterKey = MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
+private fun getEncryptedSharedPreference(context: Context): SharedPreferences {
+    val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
 
-        EncryptedSharedPreferences.create(
-            context,
-            PREFS_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
-    } catch(e: Exception) {
-        Log.e(TAG, "[${e::class.simpleName}] Failed to create EncryptedSharedPreferences")
-        context.deleteSharedPreferences(PREFS_NAME)
-        null
-    }
+    return EncryptedSharedPreferences.create(
+        context,
+        PREFS_NAME,
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
 }
 
 fun saveToken(context: Context, token: String) {
     val sharedPreferences = getEncryptedSharedPreference(context)
-    sharedPreferences?.edit { putString(ACCESS_TOKEN_KEY, token) }
-        ?: Log.w(TAG, "Token not saved due to preference error")
+    sharedPreferences.edit { putString(ACCESS_TOKEN_KEY, token) }
 }
 
 fun getToken(context: Context): String? {
     val sharedPreferences = getEncryptedSharedPreference(context)
-    if(sharedPreferences == null) Log.w(TAG, "Failed to read token due to preference error")
-    return sharedPreferences?.getString(ACCESS_TOKEN_KEY, null)
+    Log.w(TAG, "Failed to read token due to preference error")
+    return sharedPreferences.getString(ACCESS_TOKEN_KEY, null)
 }

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,8 +6,5 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+   <exclude domain="sharedpref" path="."/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -4,11 +4,8 @@
    for details.
 -->
 <data-extraction-rules>
-    <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+    <cloud-backup disableIfNoEncryptionCapabilities="true|false">
+        <exclude domain="sharedpref" path="."/>
     </cloud-backup>
     <!--
     <device-transfer>


### PR DESCRIPTION
# Pull Request

## Summary  
`SharedPreferences`를 백업에서 제외하여 `EncryptedSharedPreferences`의 암호화 무결성 오류를 방지하고, 기존의 `try-catch` 방식의 에러 핸들링을 제거함

## Related Issue  
- Close: #93 

## Changes  
- Android 12(API 31) 이상: data_extraction_rules.xml `sharedpref` 도메인의 모든 파일 백업 제외
- Android 6(API 23) 이상: backup_rules.xml `sharedpref` 도메인의 모든 파일 백업 제외
- `TokenStorage.kt`의 `EncryptedSharedPreferences` 관련 에러 헨들링 코드 제거

## Notes  
- 추후 백업이 필요한 `SharedPreferences`가 생기는 경우, 백업 제외 범위를 수정해야 함
