### PR TITLE
Feat/100 renter rental detail api

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/layout/LoadingScreen.kt
+++ b/app/src/main/java/com/example/rentit/common/component/layout/LoadingScreen.kt
@@ -1,0 +1,30 @@
+package com.example.rentit.common.component.layout
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.example.rentit.common.theme.PrimaryBlue500
+
+@Composable
+fun LoadingScreen(isLoading: Boolean = true) {
+    AnimatedVisibility(
+        visible = isLoading,
+        enter = EnterTransition.None,
+        exit = ExitTransition.None
+    ) {
+        Box(Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(
+                modifier = Modifier.fillMaxWidth(0.08f),
+                color = PrimaryBlue500
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/common/di/ApiModule.kt
+++ b/app/src/main/java/com/example/rentit/common/di/ApiModule.kt
@@ -2,6 +2,7 @@ package com.example.rentit.common.di
 
 import com.example.rentit.data.chat.remote.ChatApiService
 import com.example.rentit.data.product.remote.ProductApiService
+import com.example.rentit.data.rental.remote.RentalApiService
 import com.example.rentit.data.user.remote.UserApiService
 import dagger.Module
 import dagger.Provides
@@ -25,5 +26,10 @@ object ApiModule {
     @Provides
     fun provideProductApiService(retrofit: Retrofit): ProductApiService {
         return retrofit.create(ProductApiService::class.java)
+    }
+
+    @Provides
+    fun provideRentalApiService(retrofit: Retrofit): RentalApiService {
+        return retrofit.create(RentalApiService::class.java)
     }
 }

--- a/app/src/main/java/com/example/rentit/common/exception/rental/EmptyBodyException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/rental/EmptyBodyException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.common.exception.rental
+
+class EmptyBodyException: Exception()

--- a/app/src/main/java/com/example/rentit/common/model/RentalSummaryUiModel.kt
+++ b/app/src/main/java/com/example/rentit/common/model/RentalSummaryUiModel.kt
@@ -2,7 +2,7 @@ package com.example.rentit.common.model
 
 data class RentalSummaryUiModel(
     val productTitle: String,
-    val thumbnailImgUrl: String,
+    val thumbnailImgUrl: String?,
     val startDate: String,
     val endDate: String,
     val totalPrice: Int

--- a/app/src/main/java/com/example/rentit/data/rental/dto/RentalDetailResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/dto/RentalDetailResponseDto.kt
@@ -1,62 +1,100 @@
 package com.example.rentit.data.rental.dto
 
-import kotlinx.serialization.Serializable
+import com.google.gson.annotations.SerializedName
 
-@Serializable
 data class RentalDetailResponseDto(
-    val rental: Rental,
-    val statusHistory: List<StatusHistory>
+    @SerializedName("rental")
+    val rental: RentalDto,
+
+    @SerializedName("statusHistory")
+    val statusHistory: List<StatusHistoryDto>
 )
 
-@Serializable
-data class Rental(
-    val reservationId: Int,
-    val renter: Renter,
+data class RentalDto(
+    @SerializedName("reservationId")
+    val reservationId: Long,
+
+    @SerializedName("renter")
+    val renter: RenterDto,
+
+    @SerializedName("status")
     val status: String,
-    val product: Product,
+
+    @SerializedName("product")
+    val product: ProductDto,
+
+    @SerializedName("startDate")
     val startDate: String,
+
+    @SerializedName("endDate")
     val endDate: String,
+
+    @SerializedName("totalAmount")
     val totalAmount: Int,
+
+    @SerializedName("depositAmount")
     val depositAmount: Int,
-    val rentalTrackingNumber: String? = null,
-    val returnTrackingNumber: String? = null,
-    val deliveryStatus: DeliveryStatus,
-    val returnStatus: ReturnStatus
+
+    @SerializedName("rentalTrackingNumber")
+    val rentalTrackingNumber: String?,
+
+    @SerializedName("returnTrackingNumber")
+    val returnTrackingNumber: String?,
+
+    @SerializedName("deliveryStatus")
+    val deliveryStatus: DeliveryStatusDto,
+
+    @SerializedName("returnStatus")
+    val returnStatus: ReturnStatusDto
 )
 
-@Serializable
-data class Renter(
-    val userId: Int,
+data class RenterDto(
+    @SerializedName("userId")
+    val userId: Long,
+
+    @SerializedName("nickname")
     val nickname: String
 )
 
-@Serializable
-data class Product(
+data class ProductDto(
+    @SerializedName("title")
     val title: String,
-    val thumbnailImgUrl: String
+
+    @SerializedName("thumbnailImgUrl")
+    val thumbnailImgUrl: String?
 )
 
-@Serializable
-data class DeliveryStatus(
+data class DeliveryStatusDto(
+    @SerializedName("isPhotoRegistered")
     val isPhotoRegistered: Boolean,
+
+    @SerializedName("isTrackingNumberRegistered")
     val isTrackingNumberRegistered: Boolean
 )
 
-@Serializable
-data class ReturnStatus(
+data class ReturnStatusDto(
+    @SerializedName("isPhotoRegistered")
     val isPhotoRegistered: Boolean,
+
+    @SerializedName("isTrackingNumberRegistered")
     val isTrackingNumberRegistered: Boolean
 )
 
-@Serializable
-data class StatusHistory(
+data class StatusHistoryDto(
+    @SerializedName("status")
     val status: String,
+
+    @SerializedName("changedAt")
     val changedAt: String,
-    val changedBy: ChangedBy
+
+    @SerializedName("changedBy")
+    val changedBy: ChangedByDto
 )
 
-@Serializable
-data class ChangedBy(
-    val userId: Int? = null,
-    val nickname: String? = null
+data class ChangedByDto(
+    @SerializedName("userId")
+    val userId: Long,
+
+    @SerializedName("nickname")
+    val nickname: String
 )

--- a/app/src/main/java/com/example/rentit/data/rental/remote/RentalApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/remote/RentalApiService.kt
@@ -1,0 +1,16 @@
+package com.example.rentit.data.rental.remote
+
+import com.example.rentit.data.rental.dto.RentalDetailResponseDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.Path
+
+interface RentalApiService {
+    @GET("api/v1/products/{productId}/reservations/{reservationId}")
+    @Headers("Content-Type: application/json")
+    suspend fun getRentalDetail(
+        @Path("productId") productId: Int,
+        @Path("reservationId") reservationId: Int,
+    ): Response<RentalDetailResponseDto>
+}

--- a/app/src/main/java/com/example/rentit/data/rental/remote/RentalRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/remote/RentalRemoteDataSource.kt
@@ -1,0 +1,13 @@
+package com.example.rentit.data.rental.remote
+
+import com.example.rentit.data.rental.dto.RentalDetailResponseDto
+import retrofit2.Response
+import javax.inject.Inject
+
+class RentalRemoteDataSource @Inject constructor(
+    private val rentalApiService: RentalApiService
+) {
+    suspend fun getRentalDetail(productId: Int, reservationId: Int): Response<RentalDetailResponseDto> {
+        return rentalApiService.getRentalDetail(productId, reservationId)
+    }
+}

--- a/app/src/main/java/com/example/rentit/data/rental/repository/RentalRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/repository/RentalRepository.kt
@@ -1,0 +1,22 @@
+package com.example.rentit.data.rental.repository
+
+import com.example.rentit.common.exception.ServerException
+import com.example.rentit.common.exception.rental.EmptyBodyException
+import com.example.rentit.data.rental.dto.RentalDetailResponseDto
+import com.example.rentit.data.rental.remote.RentalRemoteDataSource
+import javax.inject.Inject
+
+class RentalRepository @Inject constructor(
+    private val rentalRemoteDataSource: RentalRemoteDataSource
+){
+    suspend fun getRentalDetail(productId: Int, reservationId: Int): Result<RentalDetailResponseDto> {
+        return runCatching {
+            val response = rentalRemoteDataSource.getRentalDetail(productId, reservationId)
+            if (response.isSuccessful) {
+                response.body() ?: throw EmptyBodyException()
+            } else {
+                throw ServerException()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalTaskSection.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalTaskSection.kt
@@ -23,6 +23,8 @@ fun RentalTaskSection(
     isTaskAvailable: Boolean,
     isPhotoRegistered: Boolean,
     isTrackingNumRegistered: Boolean,
+    onPhotoTaskClick: () -> Unit = {},
+    onTrackingNumTaskClick: () -> Unit = {},
     content: @Composable () -> Unit
 ) {
     val returnRegCountText = listOf(isPhotoRegistered, isTrackingNumRegistered)
@@ -44,11 +46,13 @@ fun RentalTaskSection(
             taskText = photoTaskLabel,
             isTaskEnable = isTaskAvailable,
             isDone = isPhotoRegistered,
+            onClick = onPhotoTaskClick
         )
         TaskCheckBox(
             taskText = trackingNumTaskLabel,
             isTaskEnable = isTaskAvailable,
-            isDone = isTrackingNumRegistered
+            isDone = isTrackingNumRegistered,
+            onClick = onTrackingNumTaskClick
         )
         if (!policyText.isNullOrEmpty())
             Text(

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.presentation.rentaldetail
+package com.example.rentit.presentation.rentaldetail.owner
 
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -8,16 +8,15 @@ import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
-import com.example.rentit.presentation.rentaldetail.renter.RentalDetailRenterScreen
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RentalDetailRoute(navHostController: NavHostController) {
+fun OwnerRentalDetailRoute(navHostController: NavHostController) {
 
-    val viewModel: RentalDetailViewModel = hiltViewModel()
+    val viewModel: OwnerRentalDetailViewModel = hiltViewModel()
     val uiModel by viewModel.uiModel.collectAsStateWithLifecycle()
 
     val scrollState = rememberScrollState()
 
-    RentalDetailRenterScreen(uiModel, scrollState) { navHostController.popBackStack() }
+    OwnerRentalDetailScreen(uiModel, scrollState) { navHostController.popBackStack() }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailScreen.kt
@@ -15,12 +15,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonTopAppBar
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.data.rental.dto.DeliveryStatus
-import com.example.rentit.data.rental.dto.Product
-import com.example.rentit.data.rental.dto.Rental
+import com.example.rentit.data.rental.dto.DeliveryStatusDto
+import com.example.rentit.data.rental.dto.ProductDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
-import com.example.rentit.data.rental.dto.Renter
-import com.example.rentit.data.rental.dto.ReturnStatus
+import com.example.rentit.data.rental.dto.RentalDto
+import com.example.rentit.data.rental.dto.RenterDto
+import com.example.rentit.data.rental.dto.ReturnStatusDto
 import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerPaidContent
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
@@ -56,11 +56,11 @@ fun OwnerRentalDetailScreen(uiModel: OwnerRentalStatusUiModel, scrollState: Scro
 @Preview(showBackground = true)
 private fun Preview() {
     val sample1 = RentalDetailResponseDto(
-        rental = Rental(
+        rental = RentalDto(
             reservationId = 1001,
-            renter = Renter(userId = 101, nickname = "김철수"),
+            renter = RenterDto(userId = 101, nickname = "김철수"),
             status = "RENTING",
-            product = Product(
+            product = ProductDto(
                 title = "캐논 EOS R6 카메라",
                 thumbnailImgUrl = "https://example.com/image/123.jpg"
             ),
@@ -70,8 +70,8 @@ private fun Preview() {
             depositAmount = 45000,
             rentalTrackingNumber = "1234567890",
             returnTrackingNumber = null,
-            deliveryStatus = DeliveryStatus(isPhotoRegistered = true, isTrackingNumberRegistered = true),
-            returnStatus = ReturnStatus(isPhotoRegistered = false, isTrackingNumberRegistered = false)
+            deliveryStatus = DeliveryStatusDto(isPhotoRegistered = true, isTrackingNumberRegistered = true),
+            returnStatus = ReturnStatusDto(isPhotoRegistered = false, isTrackingNumberRegistered = false)
         ),
         statusHistory = listOf(/* 생략 */)
     )
@@ -80,7 +80,7 @@ private fun Preview() {
         rental = sample1.rental.copy(
             status = "RETURNED",
             endDate = "2025-07-28",
-            returnStatus = ReturnStatus(isPhotoRegistered = false, isTrackingNumberRegistered = true)
+            returnStatus = ReturnStatusDto(isPhotoRegistered = false, isTrackingNumberRegistered = true)
         )
     )
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -1,0 +1,83 @@
+package com.example.rentit.presentation.rentaldetail.owner
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.rentit.data.rental.dto.ChangedByDto
+import com.example.rentit.data.rental.dto.DeliveryStatusDto
+import com.example.rentit.data.rental.dto.ProductDto
+import com.example.rentit.data.rental.dto.RentalDetailResponseDto
+import com.example.rentit.data.rental.dto.RentalDto
+import com.example.rentit.data.rental.dto.RenterDto
+import com.example.rentit.data.rental.dto.ReturnStatusDto
+import com.example.rentit.data.rental.dto.StatusHistoryDto
+import com.example.rentit.data.rental.repository.RentalRepository
+import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class OwnerRentalDetailViewModel @Inject constructor(
+    private val rentalRepository: RentalRepository,
+) : ViewModel() {
+    private val sampleRentalDetail = RentalDetailResponseDto(
+        rental = RentalDto(
+            reservationId = 1001,
+            renter = RenterDto(
+                userId = 101,
+                nickname = "김철수"
+            ),
+            status = "RENTING",
+            product = ProductDto(
+                title = "캐논 EOS R6 카메라",
+                thumbnailImgUrl = "https://example.com/image/123.jpg"
+            ),
+            startDate = "2025-04-15",
+            endDate = "2025-04-17",
+            totalAmount = 90000,
+            depositAmount = 45000,
+            rentalTrackingNumber = "1234567890",
+            returnTrackingNumber = null,
+            deliveryStatus = DeliveryStatusDto(
+                isPhotoRegistered = true,
+                isTrackingNumberRegistered = true
+            ),
+            returnStatus = ReturnStatusDto(
+                isPhotoRegistered = false,
+                isTrackingNumberRegistered = false
+            )
+        ),
+        statusHistory = listOf(
+            StatusHistoryDto(
+                status = "PENDING",
+                changedAt = "2025-03-25T09:00:00Z",
+                changedBy = ChangedByDto(
+                    userId = 1,
+                    nickname = "김숙명"
+                )
+            )
+        )
+    )
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private val _uiModel = MutableStateFlow(sampleRentalDetail.toOwnerUiModel())
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    val uiModel: StateFlow<OwnerRentalStatusUiModel> = _uiModel
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun getRentalDetail(productId: Int, reservationId: Int) {
+        viewModelScope.launch {
+            rentalRepository.getRentalDetail(productId, reservationId)
+                .onSuccess {
+                    _uiModel.value = it.toOwnerUiModel()
+                }.onFailure {
+
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
@@ -4,28 +4,78 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
+import com.example.rentit.presentation.rentaldetail.dialog.RentalCancelDialog
+import com.example.rentit.presentation.rentaldetail.dialog.TrackingRegistrationDialog
+import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RenterRentalDetailRoute(navHostController: NavHostController) {
+fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int, reservationId: Int) {
 
+    val lifecycleOwner = LocalLifecycleOwner.current
     val viewModel: RenterRentalDetailViewModel = hiltViewModel()
-    val uiModel by viewModel.uiModel.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val rentalDetailUiModel by viewModel.rentalDetailUiModel.collectAsStateWithLifecycle()
 
     val scrollState = rememberScrollState()
 
+    LaunchedEffect(Unit) {
+        viewModel.setLoading(true)
+        viewModel.getRentalDetail(productId, reservationId)
+        viewModel.setLoading(false)
+    }
+
+    LaunchedEffect(Unit) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.sideEffect.collect {
+                when(it) {
+                    is RenterRentalDetailSideEffect.NavigateToPay -> { println("NavigateToPay") }
+                    is RenterRentalDetailSideEffect.NavigateToPhotoBeforeReturn -> { println("NavigateToPhotoBeforeReturn") }
+                    is RenterRentalDetailSideEffect.NavigateToRentalPhotoCheck -> { println("NavigateToRentalPhotoCheck") }
+                }
+            }
+        }
+    }
+
     RentalDetailRenterScreen(
-        uiModel = uiModel,
+        uiModel = rentalDetailUiModel,
         scrollState = scrollState,
-        onBackPressed =  { navHostController.popBackStack() },
-        onPayClick = { },
-        onCancelClick = { },
-        onTrackingNumTaskClick = { },
-        onPhotoTaskClick = { },
-        onCheckPhotoClick = { }
+        onBackPressed = { navHostController.popBackStack() },
+        onPayClick = viewModel::navigateToPay,
+        onCancelClick = viewModel::showCancelDialog,
+        onTrackingNumTaskClick = viewModel::showTrackingRegDialog,
+        onPhotoTaskClick = viewModel::navigateToPhotoBeforeReturn,
+        onCheckPhotoClick = viewModel::navigateToRentalPhotoCheck
     )
+
+    if(uiState.showCancelDialog){
+        RentalCancelDialog(
+            onClose = viewModel::dismissCancelDialog,
+            onCancelAccept = viewModel::confirmCancel
+        )
+    }
+
+    if(uiState.showTrackingRegDialog){
+        TrackingRegistrationDialog(
+            companyList = emptyList(),
+            selectedCompany = "",
+            onSelectCompany = { },
+            trackingNum = "",
+            onTrackingNumChange = { },
+            onClose = viewModel::dismissTrackingRegDialog,
+            onConfirm = viewModel::confirmTrackingReg
+        )
+    }
+
+    if(uiState.showUnknownStatusDialog){
+        UnknownStatusDialog { navHostController.popBackStack() }
+    }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
@@ -48,6 +48,7 @@ fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int
     RentalDetailRenterScreen(
         uiModel = rentalDetailUiModel,
         scrollState = scrollState,
+        isLoading = uiState.isLoading,
         onBackPressed = { navHostController.popBackStack() },
         onPayClick = viewModel::navigateToPay,
         onCancelClick = viewModel::showCancelDialog,

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
@@ -18,5 +18,14 @@ fun RenterRentalDetailRoute(navHostController: NavHostController) {
 
     val scrollState = rememberScrollState()
 
-    RentalDetailRenterScreen(uiModel, scrollState) { navHostController.popBackStack() }
+    RentalDetailRenterScreen(
+        uiModel = uiModel,
+        scrollState = scrollState,
+        onBackPressed =  { navHostController.popBackStack() },
+        onPayClick = { },
+        onCancelClick = { },
+        onTrackingNumTaskClick = { },
+        onPhotoTaskClick = { },
+        onCheckPhotoClick = { }
+    )
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
@@ -1,0 +1,22 @@
+package com.example.rentit.presentation.rentaldetail.renter
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun RenterRentalDetailRoute(navHostController: NavHostController) {
+
+    val viewModel: RenterRentalDetailViewModel = hiltViewModel()
+    val uiModel by viewModel.uiModel.collectAsStateWithLifecycle()
+
+    val scrollState = rememberScrollState()
+
+    RentalDetailRenterScreen(uiModel, scrollState) { navHostController.popBackStack() }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
@@ -15,12 +15,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonTopAppBar
 import com.example.rentit.common.theme.RentItTheme
-import com.example.rentit.data.rental.dto.DeliveryStatus
-import com.example.rentit.data.rental.dto.Product
-import com.example.rentit.data.rental.dto.Rental
+import com.example.rentit.data.rental.dto.DeliveryStatusDto
+import com.example.rentit.data.rental.dto.ProductDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
-import com.example.rentit.data.rental.dto.Renter
-import com.example.rentit.data.rental.dto.ReturnStatus
+import com.example.rentit.data.rental.dto.RentalDto
+import com.example.rentit.data.rental.dto.RenterDto
+import com.example.rentit.data.rental.dto.ReturnStatusDto
 import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterPaidContent
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRequestContent
@@ -56,11 +56,11 @@ fun RentalDetailRenterScreen(uiModel: RenterRentalStatusUiModel, scrollState: Sc
 @Preview(showBackground = true)
 private fun Preview() {
     val sample1 = RentalDetailResponseDto(
-        rental = Rental(
+        rental = RentalDto(
             reservationId = 1001,
-            renter = Renter(userId = 101, nickname = "김철수"),
+            renter = RenterDto(userId = 101, nickname = "김철수"),
             status = "RENTING",
-            product = Product(
+            product = ProductDto(
                 title = "캐논 EOS R6 카메라",
                 thumbnailImgUrl = "https://example.com/image/123.jpg"
             ),
@@ -70,8 +70,8 @@ private fun Preview() {
             depositAmount = 45000,
             rentalTrackingNumber = "1234567890",
             returnTrackingNumber = null,
-            deliveryStatus = DeliveryStatus(isPhotoRegistered = true, isTrackingNumberRegistered = true),
-            returnStatus = ReturnStatus(isPhotoRegistered = false, isTrackingNumberRegistered = false)
+            deliveryStatus = DeliveryStatusDto(isPhotoRegistered = true, isTrackingNumberRegistered = true),
+            returnStatus = ReturnStatusDto(isPhotoRegistered = false, isTrackingNumberRegistered = false)
         ),
         statusHistory = listOf(/* 생략 */)
     )
@@ -80,7 +80,7 @@ private fun Preview() {
         rental = sample1.rental.copy(
             status = "RETURNED",
             endDate = "2025-07-28",
-            returnStatus = ReturnStatus(isPhotoRegistered = false, isTrackingNumberRegistered = true)
+            returnStatus = ReturnStatusDto(isPhotoRegistered = false, isTrackingNumberRegistered = true)
         )
     )
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.component.layout.LoadingScreen
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.data.rental.dto.DeliveryStatusDto
 import com.example.rentit.data.rental.dto.ProductDto
@@ -32,6 +33,7 @@ import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterReturne
 fun RentalDetailRenterScreen(
     uiModel: RenterRentalStatusUiModel,
     scrollState: ScrollState,
+    isLoading: Boolean,
     onBackPressed: () -> Unit,
     onPayClick: () -> Unit,
     onCancelClick: () -> Unit,
@@ -55,6 +57,7 @@ fun RentalDetailRenterScreen(
                 is RenterRentalStatusUiModel.Unknown -> Unit
             }
         }
+        LoadingScreen(isLoading)
     }
 }
 
@@ -95,6 +98,7 @@ private fun Preview() {
         RentalDetailRenterScreen(
             uiModel = sample2.toRenterUiModel(),
             scrollState = rememberScrollState(),
+            isLoading = true,
             onBackPressed =  { },
             onPayClick = { },
             onCancelClick = { },

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
@@ -30,22 +30,31 @@ import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterReturne
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun RentalDetailRenterScreen(uiModel: RenterRentalStatusUiModel, scrollState: ScrollState, onBackClick: () -> Unit) {
+fun RentalDetailRenterScreen(
+    uiModel: RenterRentalStatusUiModel,
+    scrollState: ScrollState,
+    onBackPressed: () -> Unit,
+    onPayClick: () -> Unit,
+    onCancelClick: () -> Unit,
+    onTrackingNumTaskClick: () -> Unit,
+    onPhotoTaskClick: () -> Unit,
+    onCheckPhotoClick: () -> Unit,
+) {
     Scaffold(
-        topBar = { CommonTopAppBar(title = stringResource(R.string.screen_rental_detail_title)) { onBackClick() } }
+        topBar = { CommonTopAppBar(title = stringResource(R.string.screen_rental_detail_title), onBackClick = onBackPressed) }
     ) {
         Column(modifier = Modifier.padding(it).verticalScroll(scrollState)) {
             when(uiModel) {
                 is RenterRentalStatusUiModel.Request ->
-                    RenterRequestContent(uiModel)
+                    RenterRequestContent(uiModel, onPayClick, onCancelClick)
                 is RenterRentalStatusUiModel.Paid ->
                     RenterPaidContent(uiModel)
                 is RenterRentalStatusUiModel.Renting ->
-                    RenterRentingContent(uiModel)
+                    RenterRentingContent(uiModel, onPhotoTaskClick, onTrackingNumTaskClick)
                 is RenterRentalStatusUiModel.Returned ->
-                    RenterReturnedContent(uiModel)
+                    RenterReturnedContent(uiModel, onCheckPhotoClick)
                 is RenterRentalStatusUiModel.Unknown ->
-                    UnknownStatusDialog { onBackClick() }
+                    UnknownStatusDialog(onBackPressed)
             }
         }
     }
@@ -86,8 +95,14 @@ private fun Preview() {
 
     RentItTheme {
         RentalDetailRenterScreen(
-            sample2.toRenterUiModel(),
-            rememberScrollState()
-        ) {}
+            uiModel = sample2.toRenterUiModel(),
+            scrollState = rememberScrollState(),
+            onBackPressed =  { },
+            onPayClick = { },
+            onCancelClick = { },
+            onTrackingNumTaskClick = { },
+            onPhotoTaskClick = { },
+            onCheckPhotoClick = { }
+        )
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
@@ -21,7 +21,6 @@ import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.RentalDto
 import com.example.rentit.data.rental.dto.RenterDto
 import com.example.rentit.data.rental.dto.ReturnStatusDto
-import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterPaidContent
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRequestContent
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
@@ -53,8 +52,7 @@ fun RentalDetailRenterScreen(
                     RenterRentingContent(uiModel, onPhotoTaskClick, onTrackingNumTaskClick)
                 is RenterRentalStatusUiModel.Returned ->
                     RenterReturnedContent(uiModel, onCheckPhotoClick)
-                is RenterRentalStatusUiModel.Unknown ->
-                    UnknownStatusDialog(onBackPressed)
+                is RenterRentalStatusUiModel.Unknown -> Unit
             }
         }
     }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailSideEffect.kt
@@ -1,0 +1,7 @@
+package com.example.rentit.presentation.rentaldetail.renter
+
+sealed class RenterRentalDetailSideEffect {
+    data object NavigateToPay: RenterRentalDetailSideEffect()
+    data object NavigateToPhotoBeforeReturn: RenterRentalDetailSideEffect()
+    data object NavigateToRentalPhotoCheck: RenterRentalDetailSideEffect()
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailState.kt
@@ -1,0 +1,8 @@
+package com.example.rentit.presentation.rentaldetail.renter
+
+data class RenterRentalDetailState(
+    val isLoading: Boolean = false,
+    val showCancelDialog: Boolean = false,
+    val showTrackingRegDialog: Boolean = false,
+    val showUnknownStatusDialog: Boolean = false,
+)

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
@@ -1,35 +1,38 @@
-package com.example.rentit.presentation.rentaldetail
+package com.example.rentit.presentation.rentaldetail.renter
 
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
-import com.example.rentit.data.rental.dto.ChangedBy
-import com.example.rentit.data.rental.dto.DeliveryStatus
-import com.example.rentit.data.rental.dto.Product
-import com.example.rentit.data.rental.dto.Rental
+import androidx.lifecycle.viewModelScope
+import com.example.rentit.data.rental.dto.ChangedByDto
+import com.example.rentit.data.rental.dto.DeliveryStatusDto
+import com.example.rentit.data.rental.dto.ProductDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
-import com.example.rentit.data.rental.dto.Renter
-import com.example.rentit.data.rental.dto.ReturnStatus
-import com.example.rentit.data.rental.dto.StatusHistory
+import com.example.rentit.data.rental.dto.RentalDto
+import com.example.rentit.data.rental.dto.RenterDto
+import com.example.rentit.data.rental.dto.ReturnStatusDto
+import com.example.rentit.data.rental.dto.StatusHistoryDto
+import com.example.rentit.data.rental.repository.RentalRepository
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
-import com.example.rentit.presentation.rentaldetail.renter.toRenterUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class RentalDetailViewModel @Inject constructor(
-): ViewModel() {
+class RenterRentalDetailViewModel @Inject constructor(
+    private val rentalRepository: RentalRepository,
+) : ViewModel() {
     private val sampleRentalDetail = RentalDetailResponseDto(
-        rental = Rental(
+        rental = RentalDto(
             reservationId = 1001,
-            renter = Renter(
+            renter = RenterDto(
                 userId = 101,
                 nickname = "김철수"
             ),
             status = "RENTING",
-            product = Product(
+            product = ProductDto(
                 title = "캐논 EOS R6 카메라",
                 thumbnailImgUrl = "https://example.com/image/123.jpg"
             ),
@@ -39,46 +42,22 @@ class RentalDetailViewModel @Inject constructor(
             depositAmount = 45000,
             rentalTrackingNumber = "1234567890",
             returnTrackingNumber = null,
-            deliveryStatus = DeliveryStatus(
+            deliveryStatus = DeliveryStatusDto(
                 isPhotoRegistered = true,
                 isTrackingNumberRegistered = true
             ),
-            returnStatus = ReturnStatus(
+            returnStatus = ReturnStatusDto(
                 isPhotoRegistered = false,
                 isTrackingNumberRegistered = false
             )
         ),
         statusHistory = listOf(
-            StatusHistory(
+            StatusHistoryDto(
                 status = "PENDING",
                 changedAt = "2025-03-25T09:00:00Z",
-                changedBy = ChangedBy(
+                changedBy = ChangedByDto(
                     userId = 1,
                     nickname = "김숙명"
-                )
-            ),
-            StatusHistory(
-                status = "ACCEPTED",
-                changedAt = "2025-03-25T10:00:00Z",
-                changedBy = ChangedBy(
-                    userId = 2,
-                    nickname = "홍길동"
-                )
-            ),
-            StatusHistory(
-                status = "COMPLETED",
-                changedAt = "2025-03-25T10:30:00Z",
-                changedBy = ChangedBy(
-                    userId = 1,
-                    nickname = "김숙명"
-                )
-            ),
-            StatusHistory(
-                status = "RENTING",
-                changedAt = "2025-04-15T00:00:00Z",
-                changedBy = ChangedBy(
-                    userId = 0,
-                    nickname = "SYSTEM"
                 )
             )
         )
@@ -90,4 +69,15 @@ class RentalDetailViewModel @Inject constructor(
     @RequiresApi(Build.VERSION_CODES.O)
     val uiModel: StateFlow<RenterRentalStatusUiModel> = _uiModel
 
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun getRentalDetail(productId: Int, reservationId: Int) {
+        viewModelScope.launch {
+            rentalRepository.getRentalDetail(productId, reservationId)
+                .onSuccess {
+                    _uiModel.value = it.toRenterUiModel()
+                }.onFailure {
+
+                }
+        }
+    }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
@@ -4,18 +4,12 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.data.rental.dto.ChangedByDto
-import com.example.rentit.data.rental.dto.DeliveryStatusDto
-import com.example.rentit.data.rental.dto.ProductDto
-import com.example.rentit.data.rental.dto.RentalDetailResponseDto
-import com.example.rentit.data.rental.dto.RentalDto
-import com.example.rentit.data.rental.dto.RenterDto
-import com.example.rentit.data.rental.dto.ReturnStatusDto
-import com.example.rentit.data.rental.dto.StatusHistoryDto
 import com.example.rentit.data.rental.repository.RentalRepository
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -24,60 +18,83 @@ import javax.inject.Inject
 class RenterRentalDetailViewModel @Inject constructor(
     private val rentalRepository: RentalRepository,
 ) : ViewModel() {
-    private val sampleRentalDetail = RentalDetailResponseDto(
-        rental = RentalDto(
-            reservationId = 1001,
-            renter = RenterDto(
-                userId = 101,
-                nickname = "김철수"
-            ),
-            status = "RENTING",
-            product = ProductDto(
-                title = "캐논 EOS R6 카메라",
-                thumbnailImgUrl = "https://example.com/image/123.jpg"
-            ),
-            startDate = "2025-04-15",
-            endDate = "2025-04-17",
-            totalAmount = 90000,
-            depositAmount = 45000,
-            rentalTrackingNumber = "1234567890",
-            returnTrackingNumber = null,
-            deliveryStatus = DeliveryStatusDto(
-                isPhotoRegistered = true,
-                isTrackingNumberRegistered = true
-            ),
-            returnStatus = ReturnStatusDto(
-                isPhotoRegistered = false,
-                isTrackingNumberRegistered = false
-            )
-        ),
-        statusHistory = listOf(
-            StatusHistoryDto(
-                status = "PENDING",
-                changedAt = "2025-03-25T09:00:00Z",
-                changedBy = ChangedByDto(
-                    userId = 1,
-                    nickname = "김숙명"
-                )
-            )
-        )
-    )
+
+    private val _uiState = MutableStateFlow(RenterRentalDetailState())
+    val uiState: StateFlow<RenterRentalDetailState> = _uiState
+
+    private val _sideEffect = MutableSharedFlow<RenterRentalDetailSideEffect>()
+    val sideEffect: SharedFlow<RenterRentalDetailSideEffect> = _sideEffect
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private val _uiModel = MutableStateFlow(sampleRentalDetail.toRenterUiModel())
-
+    private val _rentalDetailUiModel = MutableStateFlow<RenterRentalStatusUiModel>(RenterRentalStatusUiModel.Unknown)
     @RequiresApi(Build.VERSION_CODES.O)
-    val uiModel: StateFlow<RenterRentalStatusUiModel> = _uiModel
+    val rentalDetailUiModel: StateFlow<RenterRentalStatusUiModel> = _rentalDetailUiModel
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun getRentalDetail(productId: Int, reservationId: Int) {
         viewModelScope.launch {
             rentalRepository.getRentalDetail(productId, reservationId)
                 .onSuccess {
-                    _uiModel.value = it.toRenterUiModel()
+                    if(it.toRenterUiModel() != RenterRentalStatusUiModel.Unknown){
+                        _rentalDetailUiModel.value = it.toRenterUiModel()
+                    } else {
+                        showUnknownStatusDialog()
+                    }
                 }.onFailure {
-
+                    showUnknownStatusDialog()
                 }
+        }
+    }
+
+    fun setLoading(isLoading: Boolean) {
+        _uiState.value = _uiState.value.copy(isLoading = isLoading)
+    }
+
+    private fun showUnknownStatusDialog() {
+        _uiState.value = _uiState.value.copy(showUnknownStatusDialog = true)
+    }
+
+    fun showCancelDialog() {
+        _uiState.value = _uiState.value.copy(showCancelDialog = true)
+    }
+
+    fun dismissCancelDialog() {
+        _uiState.value = _uiState.value.copy(showCancelDialog = false)
+    }
+
+    fun confirmCancel() {
+        /* 대여 취소 로직 추가, 성공 시 닫기 */
+        _uiState.value = _uiState.value.copy(showCancelDialog = false)
+    }
+
+    fun showTrackingRegDialog() {
+        _uiState.value = _uiState.value.copy(showTrackingRegDialog = true)
+    }
+
+    fun dismissTrackingRegDialog() {
+        _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
+    }
+
+    fun confirmTrackingReg() {
+        /* 대여 취소 로직 추가, 성공 시 닫기 */
+        _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
+    }
+
+    fun navigateToPay() {
+        viewModelScope.launch {
+            _sideEffect.emit(RenterRentalDetailSideEffect.NavigateToPay)
+        }
+    }
+
+    fun navigateToPhotoBeforeReturn() {
+        viewModelScope.launch {
+            _sideEffect.emit(RenterRentalDetailSideEffect.NavigateToPhotoBeforeReturn)
+        }
+    }
+
+    fun navigateToRentalPhotoCheck() {
+        viewModelScope.launch {
+            _sideEffect.emit(RenterRentalDetailSideEffect.NavigateToRentalPhotoCheck)
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRentingContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRentingContent.kt
@@ -46,6 +46,8 @@ import kotlin.math.abs
 @Composable
 fun RenterRentingContent(
     rentingData: RenterRentalStatusUiModel.Renting,
+    onPhotoTaskClick: () -> Unit = {},
+    onTrackingNumTaskClick: () -> Unit = {},
 ) {
     val priceItems = listOf(
         PriceSummaryUiModel(
@@ -79,7 +81,9 @@ fun RenterRentingContent(
         trackingNumTaskLabel = stringResource(R.string.screen_rental_detail_renter_return_task_tracking_num),
         isTaskAvailable = rentingData.isReturnAvailable,
         isPhotoRegistered = rentingData.isReturnPhotoRegistered,
-        isTrackingNumRegistered = rentingData.isReturnTrackingNumRegistered
+        isTrackingNumRegistered = rentingData.isReturnTrackingNumRegistered,
+        onPhotoTaskClick = onPhotoTaskClick,
+        onTrackingNumTaskClick = onTrackingNumTaskClick,
     ) { if (rentingData.isOverdue) {
             ReturnOverdueWarning(
                 rentingData.daysFromReturnDate,

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRequestContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRequestContent.kt
@@ -35,6 +35,8 @@ import com.example.rentit.common.model.RentalSummaryUiModel
 @Composable
 fun RenterRequestContent(
     requestData: RenterRentalStatusUiModel.Request,
+    onPayClick: () -> Unit = {},
+    onCancelClick: () -> Unit = {},
 ) {
     val priceItems = listOf(
         PriceSummaryUiModel(
@@ -66,8 +68,9 @@ fun RenterRequestContent(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .offset(y = 8.dp),
-                text = stringResource(R.string.screen_rental_detail_renter_request_btn_pay)
-            ) { }
+                text = stringResource(R.string.screen_rental_detail_renter_request_btn_pay),
+                onClick = onPayClick
+            )
         }
     }
 
@@ -81,8 +84,9 @@ fun RenterRequestContent(
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
             ArrowedTextButton(
                 modifier = Modifier.padding(vertical = 10.dp),
-                text = stringResource(R.string.screen_rental_detail_request_btn_cancel_rent)
-            ) { }
+                text = stringResource(R.string.screen_rental_detail_request_btn_cancel_rent),
+                onClick = onCancelClick
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterReturnedContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterReturnedContent.kt
@@ -29,6 +29,7 @@ import com.example.rentit.common.model.RentalSummaryUiModel
 @Composable
 fun RenterReturnedContent(
     returnedData: RenterRentalStatusUiModel.Returned,
+    onCheckPhotoClick: () -> Unit = {},
 ) {
     val priceItems = listOf(
         PriceSummaryUiModel(
@@ -50,8 +51,9 @@ fun RenterReturnedContent(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .offset(y = 8.dp),
-            text = stringResource(R.string.screen_rental_detail_returned_check_photo_btn)
-        ) { }
+            text = stringResource(R.string.screen_rental_detail_returned_check_photo_btn),
+            onClick = onCheckPhotoClick
+        )
     }
 
     RentalPaymentSection(


### PR DESCRIPTION
# Pull Request

## Summary  
- Rental 도메인용 데이터 계층을 생성하고 대여 상세 조회 API를 연동
- 대여자용 대여 상세 화면의 UiState와 SideEffect를 생성해 Dialog와 로딩, 네비게이션의 상태를 처리

## Related Issue  
- Close: #100 

## Changes  
- Rental 관련 데이터 계층 파일 RentalApiService, RentalRemoteDataSource, RentalRepository 추가
- ApiModule 업데이트하여 RentalApiService 를 제공하는 모듈 추가
- 대여 상세 조회 API 연동 (getRentalDetail()) 및 성공/실패 여부에 따라 분기 처리
  - `EmptyBodyException` 추가
- RentalDetailResponseDto @SerializedName 추가하여 직렬화 가능하게 하고 관련 파일 수정
- Renter/Owner 각각 Route와 ViewModel 분리
- 사용자 대여 화면의 uiState와 sideEffect 구현
- Loading과 Dialog 및 Navigation 상태 처리 구현
- 공통 Loading 화면 추가 및 사용자용 대여 상세 화면에 적용

## Screenshots
- 추가된 로딩 화면
<div>
<img width="33%" src="https://github.com/user-attachments/assets/9ae78baa-88cd-49f3-9bdd-90c5546e3acf"/>
</div>

## Notes  
- 대여 상세 화면 관련 네비게이션은 아직 구현 전이므로 네비게이션 수행 확인은 print 출력 확인으로 대체
