### PR TITLE
Feat/102 owner rental detail state

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/dialog/RequestAcceptDialog.kt
+++ b/app/src/main/java/com/example/rentit/common/component/dialog/RequestAcceptDialog.kt
@@ -1,5 +1,7 @@
 package com.example.rentit.common.component.dialog
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,18 +10,21 @@ import androidx.compose.material.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.rentit.R
+import com.example.rentit.common.model.RequestAcceptDialogUiModel
 import com.example.rentit.common.theme.Gray800
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.util.formatPrice
+import com.example.rentit.common.util.formatRentalPeriod
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun RequestAcceptDialog(
-    rentalPeriodText: String,
-    expectedRevenue: Int,
+    uiModel: RequestAcceptDialogUiModel,
     onClose: () -> Unit,
     onAccept: () -> Unit,
 ) {
@@ -36,7 +41,7 @@ fun RequestAcceptDialog(
             style = MaterialTheme.typography.bodyLarge
         )
         Text(
-            text = rentalPeriodText,
+            text = formatRentalPeriod(LocalContext.current, uiModel.startDate,uiModel.endDate),
             style = MaterialTheme.typography.bodyMedium,
             color = Gray800
         )
@@ -51,20 +56,23 @@ fun RequestAcceptDialog(
                 style = MaterialTheme.typography.bodyLarge
             )
             Text(
-                text = "${formatPrice(expectedRevenue)} ${stringResource(R.string.common_price_unit)}",
+                text = "${formatPrice(uiModel.expectedRevenue)} ${stringResource(R.string.common_price_unit)}",
                 style = MaterialTheme.typography.bodyMedium
             )
         }
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
 private fun Preview() {
     RentItTheme {
         RequestAcceptDialog(
-            "25.08.17 (목) ~ 25.08.20 (일) · 4일",
-            40000,
+            RequestAcceptDialogUiModel(
+            "2025-08-17",
+            "2025-08-20",
+            40000),
             onClose = {},
             onAccept = {})
     }

--- a/app/src/main/java/com/example/rentit/common/model/RequestAcceptDialogUiModel.kt
+++ b/app/src/main/java/com/example/rentit/common/model/RequestAcceptDialogUiModel.kt
@@ -1,0 +1,7 @@
+package com.example.rentit.common.model
+
+data class RequestAcceptDialogUiModel(
+    val startDate: String,
+    val endDate: String,
+    val expectedRevenue: Int
+)

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
@@ -68,6 +68,7 @@ import com.example.rentit.data.chat.dto.StatusHistoryDto
 import com.example.rentit.data.product.dto.ProductDto
 import com.example.rentit.navigation.chatroom.navigateToRequestAcceptConfirm
 import com.example.rentit.common.component.dialog.RequestAcceptDialog
+import com.example.rentit.common.model.RequestAcceptDialogUiModel
 import com.example.rentit.presentation.chat.chatroom.components.ReceivedMsgBubble
 import com.example.rentit.presentation.chat.chatroom.components.SentMsgBubble
 import com.example.rentit.presentation.chat.chatroom.model.ChatMessageUiModel
@@ -173,8 +174,11 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reserv
     }
     if (showAcceptDialog) {
         RequestAcceptDialog(
-            rentalPeriodText = "25.08.17 (목) ~ 25.08.20 (일) · 4일",      // 백엔드 데이터 누락,
-            expectedRevenue = productDetail?.product?.price ?: 0,
+            uiModel = RequestAcceptDialogUiModel(
+                "2025-08-17",
+                "2025-08-20",    // 백엔드 데이터 누락,
+                expectedRevenue = productDetail?.product?.price ?: 0
+            ),
             onClose = { showAcceptDialog = false },
             onAccept = {
                 if(productId != null && chatRoomId != null && reservationId != null){

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalTaskSection.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/components/section/RentalTaskSection.kt
@@ -25,7 +25,7 @@ fun RentalTaskSection(
     isTrackingNumRegistered: Boolean,
     onPhotoTaskClick: () -> Unit = {},
     onTrackingNumTaskClick: () -> Unit = {},
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit = {}
 ) {
     val returnRegCountText = listOf(isPhotoRegistered, isTrackingNumRegistered)
         .count { it }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
+import com.example.rentit.common.component.dialog.RequestAcceptDialog
 import com.example.rentit.presentation.rentaldetail.dialog.RentalCancelDialog
 import com.example.rentit.presentation.rentaldetail.dialog.TrackingRegistrationDialog
 import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
@@ -48,14 +49,22 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
     OwnerRentalDetailScreen(
         uiModel = rentalDetailUiModel,
         scrollState = scrollState,
-        isLoading = true,
+        isLoading = uiState.isLoading,
         onBackClick = { navHostController.popBackStack() },
-        onRequestResponseClick = {},
+        onRequestResponseClick = viewModel::showRequestAcceptDialog,
         onCancelRentClick = viewModel::showCancelDialog,
         onPhotoTaskClick = viewModel::navigateToPhotoBeforeRent,
         onTrackingNumTaskClick = viewModel::showTrackingRegDialog,
         onCheckPhotoClick = viewModel::navigateToRentalPhotoCheck
     )
+
+    uiState.requestAcceptDialog?.let {
+        RequestAcceptDialog(
+            uiModel = it,
+            onClose = viewModel::dismissRequestAcceptDialog,
+            onAccept = viewModel::acceptRequest,
+        )
+    }
 
     if(uiState.showCancelDialog){
         RentalCancelDialog(

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -18,5 +18,15 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController) {
 
     val scrollState = rememberScrollState()
 
-    OwnerRentalDetailScreen(uiModel, scrollState) { navHostController.popBackStack() }
+    OwnerRentalDetailScreen(
+        uiModel = uiModel,
+        scrollState = scrollState,
+        isLoading = true,
+        onBackClick = { navHostController.popBackStack() },
+        onRequestResponseClick = { },
+        onCancelRentClick = { },
+        onPhotoTaskClick = { },
+        onTrackingNumTaskClick = { },
+        onCheckPhotoClick = { }
+    )
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -4,29 +4,79 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
+import com.example.rentit.presentation.rentaldetail.dialog.RentalCancelDialog
+import com.example.rentit.presentation.rentaldetail.dialog.TrackingRegistrationDialog
+import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun OwnerRentalDetailRoute(navHostController: NavHostController) {
+fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int, reservationId: Int) {
 
+    val lifecycleOwner = LocalLifecycleOwner.current
     val viewModel: OwnerRentalDetailViewModel = hiltViewModel()
-    val uiModel by viewModel.uiModel.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val rentalDetailUiModel by viewModel.rentalDetailUiModel.collectAsStateWithLifecycle()
 
     val scrollState = rememberScrollState()
 
+    LaunchedEffect(Unit) {
+        viewModel.setLoading(true)
+        viewModel.getRentalDetail(productId, reservationId)
+        viewModel.setLoading(false)
+    }
+
+    LaunchedEffect(Unit) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.sideEffect.collect {
+                when(it) {
+                    is OwnerRentalDetailSideEffect.NavigateToPhotoBeforeRent -> { println("NavigateToPhotoBeforeRent") }
+                    is OwnerRentalDetailSideEffect.NavigateToRentalPhotoCheck -> { println("NavigateToRentalPhotoCheck") }
+                }
+            }
+        }
+    }
+
+
     OwnerRentalDetailScreen(
-        uiModel = uiModel,
+        uiModel = rentalDetailUiModel,
         scrollState = scrollState,
         isLoading = true,
         onBackClick = { navHostController.popBackStack() },
-        onRequestResponseClick = { },
-        onCancelRentClick = { },
-        onPhotoTaskClick = { },
-        onTrackingNumTaskClick = { },
-        onCheckPhotoClick = { }
+        onRequestResponseClick = {},
+        onCancelRentClick = viewModel::showCancelDialog,
+        onPhotoTaskClick = viewModel::navigateToPhotoBeforeRent,
+        onTrackingNumTaskClick = viewModel::showTrackingRegDialog,
+        onCheckPhotoClick = viewModel::navigateToRentalPhotoCheck
     )
+
+    if(uiState.showCancelDialog){
+        RentalCancelDialog(
+            onClose = viewModel::dismissCancelDialog,
+            onCancelAccept = viewModel::confirmCancel
+        )
+    }
+
+    if(uiState.showTrackingRegDialog){
+        TrackingRegistrationDialog(
+            companyList = emptyList(),
+            selectedCompany = "",
+            onSelectCompany = { },
+            trackingNum = "",
+            onTrackingNumChange = { },
+            onClose = viewModel::dismissTrackingRegDialog,
+            onConfirm = viewModel::confirmTrackingReg
+        )
+    }
+
+    if(uiState.showUnknownStatusDialog){
+        UnknownStatusDialog { navHostController.popBackStack() }
+    }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.component.layout.LoadingScreen
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.data.rental.dto.DeliveryStatusDto
 import com.example.rentit.data.rental.dto.ProductDto
@@ -21,7 +22,6 @@ import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.RentalDto
 import com.example.rentit.data.rental.dto.RenterDto
 import com.example.rentit.data.rental.dto.ReturnStatusDto
-import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerPaidContent
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentingContent
@@ -30,24 +30,48 @@ import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerReturnedC
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun OwnerRentalDetailScreen(uiModel: OwnerRentalStatusUiModel, scrollState: ScrollState, onBackClick: () -> Unit) {
+fun OwnerRentalDetailScreen(
+    uiModel: OwnerRentalStatusUiModel,
+    scrollState: ScrollState,
+    isLoading: Boolean = true,
+    onBackClick: () -> Unit,
+    onRequestResponseClick: () -> Unit,
+    onCancelRentClick: () -> Unit,
+    onPhotoTaskClick: () -> Unit,
+    onTrackingNumTaskClick: () -> Unit,
+    onCheckPhotoClick: () -> Unit,
+) {
     Scaffold(
         topBar = { CommonTopAppBar(title = stringResource(R.string.screen_rental_detail_title)) { onBackClick() } }
     ) {
-        Column(modifier = Modifier.padding(it).verticalScroll(scrollState)) {
+        Column(modifier = Modifier
+            .padding(it)
+            .verticalScroll(scrollState)) {
             when(uiModel) {
                 is OwnerRentalStatusUiModel.Request ->
-                    OwnerRequestContent(uiModel)
+                    OwnerRequestContent(
+                        requestData = uiModel,
+                        onRequestResponseClick = onRequestResponseClick,
+                        onCancelRentClick = onCancelRentClick
+                    )
                 is OwnerRentalStatusUiModel.Paid ->
-                    OwnerPaidContent(uiModel)
+                    OwnerPaidContent(
+                        paidData = uiModel,
+                        onPhotoTaskClick = onPhotoTaskClick,
+                        onTrackingNumTaskClick = onTrackingNumTaskClick,
+                        onCancelRentClick = onCancelRentClick
+                    )
                 is OwnerRentalStatusUiModel.Renting ->
                     OwnerRentingContent(uiModel)
                 is OwnerRentalStatusUiModel.Returned ->
-                    OwnerReturnedContent(uiModel)
-                is OwnerRentalStatusUiModel.Unknown ->
-                    UnknownStatusDialog { onBackClick() }
+                    OwnerReturnedContent(
+                        returnedData = uiModel,
+                        onCheckPhotoClick = onCheckPhotoClick
+                    )
+                is OwnerRentalStatusUiModel.Unknown -> Unit
             }
         }
+        LoadingScreen(isLoading)
     }
 }
 
@@ -87,7 +111,13 @@ private fun Preview() {
     RentItTheme {
         OwnerRentalDetailScreen(
             sample2.toOwnerUiModel(),
-            rememberScrollState()
+            rememberScrollState(),
+            isLoading = true,
+            onBackClick = {},
+            onRequestResponseClick = {},
+            onCancelRentClick = {},
+            onPhotoTaskClick = {},
+            onTrackingNumTaskClick = {},
         ) {}
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
@@ -1,0 +1,6 @@
+package com.example.rentit.presentation.rentaldetail.owner
+
+sealed class OwnerRentalDetailSideEffect {
+    data object NavigateToPhotoBeforeRent: OwnerRentalDetailSideEffect()
+    data object NavigateToRentalPhotoCheck: OwnerRentalDetailSideEffect()
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailState.kt
@@ -1,8 +1,10 @@
 package com.example.rentit.presentation.rentaldetail.owner
 
+import com.example.rentit.common.model.RequestAcceptDialogUiModel
+
 data class OwnerRentalDetailState(
     val isLoading: Boolean = false,
-    val requestAcceptDialog: Boolean = false,
+    val requestAcceptDialog: RequestAcceptDialogUiModel? = null,
     val showCancelDialog: Boolean = false,
     val showTrackingRegDialog: Boolean = false,
     val showUnknownStatusDialog: Boolean = false,

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailState.kt
@@ -1,0 +1,9 @@
+package com.example.rentit.presentation.rentaldetail.owner
+
+data class OwnerRentalDetailState(
+    val isLoading: Boolean = false,
+    val requestAcceptDialog: Boolean = false,
+    val showCancelDialog: Boolean = false,
+    val showTrackingRegDialog: Boolean = false,
+    val showUnknownStatusDialog: Boolean = false,
+)

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.rentit.common.model.RequestAcceptDialogUiModel
 import com.example.rentit.data.rental.repository.RentalRepository
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -53,6 +54,28 @@ class OwnerRentalDetailViewModel @Inject constructor(
 
     private fun showUnknownStatusDialog() {
         _uiState.value = _uiState.value.copy(showUnknownStatusDialog = true)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun showRequestAcceptDialog() {
+        val requestData = _rentalDetailUiModel.value as? OwnerRentalStatusUiModel.Request ?: return
+
+        _uiState.value = _uiState.value.copy(
+            requestAcceptDialog = RequestAcceptDialogUiModel(
+                startDate = requestData.rentalSummary.startDate,
+                endDate = requestData.rentalSummary.endDate,
+                expectedRevenue = requestData.basicRentalFee
+            ),
+        )
+    }
+
+    fun dismissRequestAcceptDialog() {
+        _uiState.value = _uiState.value.copy(requestAcceptDialog = null)
+    }
+
+    fun acceptRequest() {
+        /* 요청 수락 로직 추가, 성공 시 닫기 */
+        _uiState.value = _uiState.value.copy(requestAcceptDialog = null)
     }
 
     fun showCancelDialog() {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -4,18 +4,12 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.data.rental.dto.ChangedByDto
-import com.example.rentit.data.rental.dto.DeliveryStatusDto
-import com.example.rentit.data.rental.dto.ProductDto
-import com.example.rentit.data.rental.dto.RentalDetailResponseDto
-import com.example.rentit.data.rental.dto.RentalDto
-import com.example.rentit.data.rental.dto.RenterDto
-import com.example.rentit.data.rental.dto.ReturnStatusDto
-import com.example.rentit.data.rental.dto.StatusHistoryDto
 import com.example.rentit.data.rental.repository.RentalRepository
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -24,60 +18,78 @@ import javax.inject.Inject
 class OwnerRentalDetailViewModel @Inject constructor(
     private val rentalRepository: RentalRepository,
 ) : ViewModel() {
-    private val sampleRentalDetail = RentalDetailResponseDto(
-        rental = RentalDto(
-            reservationId = 1001,
-            renter = RenterDto(
-                userId = 101,
-                nickname = "김철수"
-            ),
-            status = "RENTING",
-            product = ProductDto(
-                title = "캐논 EOS R6 카메라",
-                thumbnailImgUrl = "https://example.com/image/123.jpg"
-            ),
-            startDate = "2025-04-15",
-            endDate = "2025-04-17",
-            totalAmount = 90000,
-            depositAmount = 45000,
-            rentalTrackingNumber = "1234567890",
-            returnTrackingNumber = null,
-            deliveryStatus = DeliveryStatusDto(
-                isPhotoRegistered = true,
-                isTrackingNumberRegistered = true
-            ),
-            returnStatus = ReturnStatusDto(
-                isPhotoRegistered = false,
-                isTrackingNumberRegistered = false
-            )
-        ),
-        statusHistory = listOf(
-            StatusHistoryDto(
-                status = "PENDING",
-                changedAt = "2025-03-25T09:00:00Z",
-                changedBy = ChangedByDto(
-                    userId = 1,
-                    nickname = "김숙명"
-                )
-            )
-        )
-    )
+
+    private val _uiState = MutableStateFlow(OwnerRentalDetailState())
+    val uiState: StateFlow<OwnerRentalDetailState> = _uiState
+
+    private val _sideEffect = MutableSharedFlow<OwnerRentalDetailSideEffect>()
+    val sideEffect: SharedFlow<OwnerRentalDetailSideEffect> = _sideEffect
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private val _uiModel = MutableStateFlow(sampleRentalDetail.toOwnerUiModel())
-
+    private val _rentalDetailUiModel = MutableStateFlow<OwnerRentalStatusUiModel>(
+        OwnerRentalStatusUiModel.Unknown)
     @RequiresApi(Build.VERSION_CODES.O)
-    val uiModel: StateFlow<OwnerRentalStatusUiModel> = _uiModel
+    val rentalDetailUiModel: StateFlow<OwnerRentalStatusUiModel> = _rentalDetailUiModel
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun getRentalDetail(productId: Int, reservationId: Int) {
         viewModelScope.launch {
             rentalRepository.getRentalDetail(productId, reservationId)
                 .onSuccess {
-                    _uiModel.value = it.toOwnerUiModel()
+                    if(it.toOwnerUiModel() != OwnerRentalStatusUiModel.Unknown){
+                        _rentalDetailUiModel.value = it.toOwnerUiModel()
+                    } else {
+                        showUnknownStatusDialog()
+                    }
                 }.onFailure {
-
+                    showUnknownStatusDialog()
                 }
+        }
+    }
+
+    fun setLoading(isLoading: Boolean) {
+        _uiState.value = _uiState.value.copy(isLoading = isLoading)
+    }
+
+    private fun showUnknownStatusDialog() {
+        _uiState.value = _uiState.value.copy(showUnknownStatusDialog = true)
+    }
+
+    fun showCancelDialog() {
+        _uiState.value = _uiState.value.copy(showCancelDialog = true)
+    }
+
+    fun dismissCancelDialog() {
+        _uiState.value = _uiState.value.copy(showCancelDialog = false)
+    }
+
+    fun confirmCancel() {
+        /* 대여 취소 로직 추가, 성공 시 닫기 */
+        _uiState.value = _uiState.value.copy(showCancelDialog = false)
+    }
+
+    fun showTrackingRegDialog() {
+        _uiState.value = _uiState.value.copy(showTrackingRegDialog = true)
+    }
+
+    fun dismissTrackingRegDialog() {
+        _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
+    }
+
+    fun confirmTrackingReg() {
+        /* 대여 취소 로직 추가, 성공 시 닫기 */
+        _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
+    }
+
+    fun navigateToPhotoBeforeRent() {
+        viewModelScope.launch {
+            _sideEffect.emit(OwnerRentalDetailSideEffect.NavigateToPhotoBeforeRent)
+        }
+    }
+
+    fun navigateToRentalPhotoCheck() {
+        viewModelScope.launch {
+            _sideEffect.emit(OwnerRentalDetailSideEffect.NavigateToRentalPhotoCheck)
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -100,7 +100,7 @@ class OwnerRentalDetailViewModel @Inject constructor(
     }
 
     fun confirmTrackingReg() {
-        /* 대여 취소 로직 추가, 성공 시 닫기 */
+        /* 운송장 등록 로직 추가, 성공 시 닫기 */
         _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerPaidContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerPaidContent.kt
@@ -35,6 +35,9 @@ import com.example.rentit.presentation.rentaldetail.components.section.RentalTas
 @Composable
 fun OwnerPaidContent(
     paidData: OwnerRentalStatusUiModel.Paid,
+    onPhotoTaskClick: () -> Unit = {},
+    onTrackingNumTaskClick: () -> Unit = {},
+    onCancelRentClick: () -> Unit = {},
 ) {
     val priceItem = listOf(
         PriceSummaryUiModel(
@@ -63,8 +66,10 @@ fun OwnerPaidContent(
         trackingNumTaskLabel = stringResource(R.string.screen_rental_detail_owner_paid_sending_task_tracking_num),
         isTaskAvailable = true,
         isPhotoRegistered = paidData.isSendingPhotoRegistered,
-        isTrackingNumRegistered = paidData.isSendingTrackingNumRegistered
-    ) { }
+        isTrackingNumRegistered = paidData.isSendingTrackingNumRegistered,
+        onPhotoTaskClick = onPhotoTaskClick,
+        onTrackingNumTaskClick = onTrackingNumTaskClick
+    )
 
     RentalPaymentSection(
         title = stringResource(R.string.screen_rental_detail_owner_expected_price_title),
@@ -79,8 +84,9 @@ fun OwnerPaidContent(
     Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
         ArrowedTextButton(
             modifier = Modifier.padding(vertical = 10.dp),
-            text = stringResource(R.string.screen_rental_detail_request_btn_cancel_rent)
-        ) { }
+            text = stringResource(R.string.screen_rental_detail_request_btn_cancel_rent),
+            onClick = onCancelRentClick
+        )
     }
 }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRequestContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerRequestContent.kt
@@ -35,6 +35,8 @@ import com.example.rentit.common.model.RentalSummaryUiModel
 @Composable
 fun OwnerRequestContent(
     requestData: OwnerRentalStatusUiModel.Request,
+    onRequestResponseClick: () -> Unit = {},
+    onCancelRentClick: () -> Unit = {},
 ) {
     val priceItem = listOf(
         PriceSummaryUiModel(
@@ -65,8 +67,9 @@ fun OwnerRequestContent(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .offset(y = 8.dp),
-                text = stringResource(R.string.screen_rental_detail_owner_request_btn_request_response)
-            ) { }
+                text = stringResource(R.string.screen_rental_detail_owner_request_btn_request_response),
+                onClick = onRequestResponseClick
+            )
         }
     }
 
@@ -80,8 +83,9 @@ fun OwnerRequestContent(
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
             ArrowedTextButton(
                 modifier = Modifier.padding(vertical = 10.dp),
-                text = stringResource(R.string.screen_rental_detail_request_btn_cancel_rent)
-            ) { }
+                text = stringResource(R.string.screen_rental_detail_request_btn_cancel_rent),
+                onClick = onCancelRentClick
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerReturnedContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/stateui/OwnerReturnedContent.kt
@@ -29,6 +29,7 @@ import com.example.rentit.common.model.RentalSummaryUiModel
 @Composable
 fun OwnerReturnedContent(
     returnedData: OwnerRentalStatusUiModel.Returned,
+    onCheckPhotoClick: () -> Unit = {},
 ) {
     val priceItems = listOf(
         PriceSummaryUiModel(
@@ -50,8 +51,9 @@ fun OwnerReturnedContent(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .offset(y = 8.dp),
-            text = stringResource(R.string.screen_rental_detail_returned_check_photo_btn)
-        ) { }
+            text = stringResource(R.string.screen_rental_detail_returned_check_photo_btn),
+            onClick = onCheckPhotoClick
+        )
     }
 
     RentalPaymentSection(

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
@@ -51,7 +51,7 @@ fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int
         isLoading = uiState.isLoading,
         onBackPressed = { navHostController.popBackStack() },
         onPayClick = viewModel::navigateToPay,
-        onCancelClick = viewModel::showCancelDialog,
+        onCancelRentClick = viewModel::showCancelDialog,
         onTrackingNumTaskClick = viewModel::showTrackingRegDialog,
         onPhotoTaskClick = viewModel::navigateToPhotoBeforeReturn,
         onCheckPhotoClick = viewModel::navigateToRentalPhotoCheck

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailScreen.kt
@@ -36,7 +36,7 @@ fun RentalDetailRenterScreen(
     isLoading: Boolean,
     onBackPressed: () -> Unit,
     onPayClick: () -> Unit,
-    onCancelClick: () -> Unit,
+    onCancelRentClick: () -> Unit,
     onTrackingNumTaskClick: () -> Unit,
     onPhotoTaskClick: () -> Unit,
     onCheckPhotoClick: () -> Unit,
@@ -47,7 +47,7 @@ fun RentalDetailRenterScreen(
         Column(modifier = Modifier.padding(it).verticalScroll(scrollState)) {
             when(uiModel) {
                 is RenterRentalStatusUiModel.Request ->
-                    RenterRequestContent(uiModel, onPayClick, onCancelClick)
+                    RenterRequestContent(uiModel, onPayClick, onCancelRentClick)
                 is RenterRentalStatusUiModel.Paid ->
                     RenterPaidContent(uiModel)
                 is RenterRentalStatusUiModel.Renting ->
@@ -101,7 +101,7 @@ private fun Preview() {
             isLoading = true,
             onBackPressed =  { },
             onPayClick = { },
-            onCancelClick = { },
+            onCancelRentClick = { },
             onTrackingNumTaskClick = { },
             onPhotoTaskClick = { },
             onCheckPhotoClick = { }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
@@ -76,7 +76,7 @@ class RenterRentalDetailViewModel @Inject constructor(
     }
 
     fun confirmTrackingReg() {
-        /* 대여 취소 로직 추가, 성공 시 닫기 */
+        /* 운송장 등록 로직 추가, 성공 시 닫기 */
         _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRequestContent.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/stateui/RenterRequestContent.kt
@@ -36,7 +36,7 @@ import com.example.rentit.common.model.RentalSummaryUiModel
 fun RenterRequestContent(
     requestData: RenterRentalStatusUiModel.Request,
     onPayClick: () -> Unit = {},
-    onCancelClick: () -> Unit = {},
+    onCancelRentClick: () -> Unit = {},
 ) {
     val priceItems = listOf(
         PriceSummaryUiModel(
@@ -85,7 +85,7 @@ fun RenterRequestContent(
             ArrowedTextButton(
                 modifier = Modifier.padding(vertical = 10.dp),
                 text = stringResource(R.string.screen_rental_detail_request_btn_cancel_rent),
-                onClick = onCancelClick
+                onClick = onCancelRentClick
             )
         }
     }


### PR DESCRIPTION
# Pull Request

## Summary  
- Owner Rental Detail 화면에서 필요한 네비게이션 트리거, 상태 관리, 다이얼로그 및 Loading 구현

## Related Issue  
- Close: #102 

## Changes  
- Rental Status 별 Content 내부의 버튼 클릭 이벤트 함수 추가
- Dialog, Loading 상태를 관리하는 State, Navigation 상태를 관리할 SideEffect 구현
- ViewModel에서 State와 SideEffect 관리 구현
- 필요한 다이얼로그 연동

## Notes  
- `RequestAcceptDialog`는 표시 시 전달해야 할 데이터(RequestAcceptDialogUiModel)가 필요하므로, Boolean 대신 UiModel? 타입으로 State를 관리함
- 버튼 클릭 시에는 UiModel을 생성하여 State에 할당하고, 다이얼로그를 닫을 때는 null을 할당
- 따라서, UiModel이 null이 아닐 경우에만 다이얼로그가 화면에 표시되도록 구현
- 네비게이션은 구현 전이므로 println() 출력으로 임시 확인함
