### PR TITLE
Feat/104 tracking number register

### DIFF
--- a/app/src/main/java/com/example/rentit/common/enums/TrackingRegistrationRequestType.kt
+++ b/app/src/main/java/com/example/rentit/common/enums/TrackingRegistrationRequestType.kt
@@ -1,0 +1,5 @@
+package com.example.rentit.common.enums
+
+enum class TrackingRegistrationRequestType {
+    RENTAL, RETURN
+}

--- a/app/src/main/java/com/example/rentit/data/rental/dto/CourierNamesResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/dto/CourierNamesResponseDto.kt
@@ -1,0 +1,8 @@
+package com.example.rentit.data.rental.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class CourierNamesResponseDto(
+    @SerializedName("courierNames")
+    val courierNames: List<String>,
+)

--- a/app/src/main/java/com/example/rentit/data/rental/dto/TrackingRegistrationRequestDto.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/dto/TrackingRegistrationRequestDto.kt
@@ -1,0 +1,14 @@
+package com.example.rentit.data.rental.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class TrackingRegistrationRequestDto(
+    @SerializedName("type")
+    val type: String,
+
+    @SerializedName("courierName")
+    val courierName: String,
+
+    @SerializedName("trackingNumber")
+    val trackingNumber: String,
+)

--- a/app/src/main/java/com/example/rentit/data/rental/dto/TrackingRegistrationResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/dto/TrackingRegistrationResponseDto.kt
@@ -1,0 +1,25 @@
+package com.example.rentit.data.rental.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class TrackingRegistrationResponseDto(
+    @SerializedName("message")
+    val message: String,
+
+    @SerializedName("tracking")
+    val tracking: TrackingInfoDto
+)
+
+data class TrackingInfoDto(
+    @SerializedName("type")
+    val type: String,
+
+    @SerializedName("courierName")
+    val courierName: String,
+
+    @SerializedName("trackingNumber")
+    val trackingNumber: String,
+
+    @SerializedName("registeredAt")
+    val registeredAt: String,
+)

--- a/app/src/main/java/com/example/rentit/data/rental/remote/RentalApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/remote/RentalApiService.kt
@@ -1,9 +1,14 @@
 package com.example.rentit.data.rental.remote
 
+import com.example.rentit.data.rental.dto.CourierNamesResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
+import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
+import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Headers
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface RentalApiService {
@@ -13,4 +18,16 @@ interface RentalApiService {
         @Path("productId") productId: Int,
         @Path("reservationId") reservationId: Int,
     ): Response<RentalDetailResponseDto>
+
+    @POST("api/v1/products/{productId}/reservations/{reservationId}/tracking")
+    @Headers("Content-Type: application/json")
+    suspend fun postTrackingRegistration(
+        @Path("productId") productId: Int,
+        @Path("reservationId") reservationId: Int,
+        @Body trackingRegistrationRequestDto: TrackingRegistrationRequestDto
+    ): Response<TrackingRegistrationResponseDto>
+
+    @GET("api/v1/delivery/couriers")
+    @Headers("Content-Type: application/json")
+    suspend fun getCourierNames(): Response<CourierNamesResponseDto>
 }

--- a/app/src/main/java/com/example/rentit/data/rental/remote/RentalRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/remote/RentalRemoteDataSource.kt
@@ -1,6 +1,9 @@
 package com.example.rentit.data.rental.remote
 
+import com.example.rentit.data.rental.dto.CourierNamesResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
+import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
+import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
 import retrofit2.Response
 import javax.inject.Inject
 
@@ -9,5 +12,13 @@ class RentalRemoteDataSource @Inject constructor(
 ) {
     suspend fun getRentalDetail(productId: Int, reservationId: Int): Response<RentalDetailResponseDto> {
         return rentalApiService.getRentalDetail(productId, reservationId)
+    }
+
+    suspend fun postTrackingRegistration(productId: Int, reservationId: Int, body: TrackingRegistrationRequestDto): Response<TrackingRegistrationResponseDto> {
+        return rentalApiService.postTrackingRegistration(productId, reservationId, body)
+    }
+
+    suspend fun getCourierNames(): Response<CourierNamesResponseDto> {
+        return rentalApiService.getCourierNames()
     }
 }

--- a/app/src/main/java/com/example/rentit/data/rental/repository/RentalRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/repository/RentalRepository.kt
@@ -2,7 +2,10 @@ package com.example.rentit.data.rental.repository
 
 import com.example.rentit.common.exception.ServerException
 import com.example.rentit.common.exception.rental.EmptyBodyException
+import com.example.rentit.data.rental.dto.CourierNamesResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
+import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
+import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
 import com.example.rentit.data.rental.remote.RentalRemoteDataSource
 import javax.inject.Inject
 
@@ -12,6 +15,28 @@ class RentalRepository @Inject constructor(
     suspend fun getRentalDetail(productId: Int, reservationId: Int): Result<RentalDetailResponseDto> {
         return runCatching {
             val response = rentalRemoteDataSource.getRentalDetail(productId, reservationId)
+            if (response.isSuccessful) {
+                response.body() ?: throw EmptyBodyException()
+            } else {
+                throw ServerException()
+            }
+        }
+    }
+
+    suspend fun postTrackingRegistration(productId: Int, reservationId: Int, body: TrackingRegistrationRequestDto): Result<TrackingRegistrationResponseDto?> {
+        return runCatching {
+            val response = rentalRemoteDataSource.postTrackingRegistration(productId, reservationId, body)
+            if (response.isSuccessful) {
+                response.body()
+            } else {
+                throw ServerException()
+            }
+        }
+    }
+
+    suspend fun getCourierNames(): Result<CourierNamesResponseDto> {
+        return runCatching {
+            val response = rentalRemoteDataSource.getCourierNames()
             if (response.isSuccessful) {
                 response.body() ?: throw EmptyBodyException()
             } else {

--- a/app/src/main/java/com/example/rentit/data/rental/usecase/RegisterTrackingUseCase.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/usecase/RegisterTrackingUseCase.kt
@@ -1,0 +1,32 @@
+package com.example.rentit.data.rental.usecase
+
+import com.example.rentit.common.enums.TrackingRegistrationRequestType
+import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
+import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
+import com.example.rentit.data.rental.repository.RentalRepository
+import javax.inject.Inject
+
+class RegisterTrackingUseCase @Inject constructor(
+    private val rentalRepository: RentalRepository
+) {
+    suspend operator fun invoke(
+        productId: Int,
+        reservationId: Int,
+        type: TrackingRegistrationRequestType,
+        courierName: String,
+        trackingNumber: String
+    ): Result<TrackingRegistrationResponseDto?> {
+        if(trackingNumber.isBlank())
+            return Result.failure(IllegalArgumentException())
+
+        return rentalRepository.postTrackingRegistration(
+            productId = productId,
+            reservationId = reservationId,
+            body = TrackingRegistrationRequestDto(
+                type = type.name,
+                courierName = courierName,
+                trackingNumber = trackingNumber
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/TrackingRegistrationDialog.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/TrackingRegistrationDialog.kt
@@ -29,6 +29,7 @@ import com.example.rentit.R
 import com.example.rentit.common.component.CommonTextField
 import com.example.rentit.common.component.basicRoundedGrayBorder
 import com.example.rentit.common.component.dialog.BaseDialog
+import com.example.rentit.common.theme.AppRed
 import com.example.rentit.common.theme.Gray200
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
@@ -36,9 +37,10 @@ import com.example.rentit.common.theme.RentItTheme
 @Composable
 fun TrackingRegistrationDialog(
     courierNames: List<String>,
-    selectedCourierName: String?,
-    onSelectCourier: (String) -> Unit,
+    selectedCourierName: String,
     trackingNumber: String,
+    showTrackingNumberEmptyError: Boolean = false,
+    onSelectCourier: (String) -> Unit,
     onTrackingNumberChange: (String) -> Unit,
     onClose: () -> Unit,
     onConfirm: () -> Unit,
@@ -69,6 +71,14 @@ fun TrackingRegistrationDialog(
             placeholder = stringResource(R.string.dialog_rental_detail_tracking_regs_placeholder_tracking_num),
             keyboardType = KeyboardType.Number,
         )
+        if(showTrackingNumberEmptyError) {
+            Text(
+                modifier = Modifier.padding(bottom = 8.dp),
+                text = stringResource(R.string.dialog_rental_detail_tracking_regs_text_error_empty_number),
+                style = MaterialTheme.typography.labelMedium,
+                color = AppRed
+            )
+        }
     }
 }
 
@@ -76,13 +86,11 @@ fun TrackingRegistrationDialog(
 @Composable
 fun DeliveryCompanyDropDown(
     courierNames: List<String>,
-    selectedCourierName: String?,
+    selectedCourierName: String,
     onSelect: (String) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val borderColor = if (expanded) PrimaryBlue500 else Gray200
-    val selectedCompanyText = selectedCourierName
-        ?: stringResource(R.string.dialog_rental_detail_tracking_regs_dropdown_courier_unknown)
 
     ExposedDropdownMenuBox(
         modifier = Modifier
@@ -94,7 +102,7 @@ fun DeliveryCompanyDropDown(
     ) {
         BasicTextField(
             readOnly = true,
-            value = selectedCompanyText,
+            value = selectedCourierName,
             onValueChange = {},
             modifier = Modifier.menuAnchor().fillMaxWidth(),
             decorationBox = { innerTextField ->
@@ -129,7 +137,7 @@ fun DeliveryCompanyDropDown(
 @Preview(showBackground = true, backgroundColor = Color.DKGRAY.toLong())
 @Composable
 fun TrackingRegistrationDialogPreview() {
-    var selectedCompany by remember { mutableStateOf<String?>(null) }
+    var selectedCompany by remember { mutableStateOf("") }
     var trackingNum by remember { mutableStateOf("") }
     val companyList = listOf("대한통운", "한진택배", "우체국택배")
     RentItTheme {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/TrackingRegistrationDialog.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/TrackingRegistrationDialog.kt
@@ -35,11 +35,11 @@ import com.example.rentit.common.theme.RentItTheme
 
 @Composable
 fun TrackingRegistrationDialog(
-    companyList: List<String>,
-    selectedCompany: String?,
-    onSelectCompany: (String) -> Unit,
-    trackingNum: String,
-    onTrackingNumChange: (String) -> Unit,
+    courierNames: List<String>,
+    selectedCourierName: String?,
+    onSelectCourier: (String) -> Unit,
+    trackingNumber: String,
+    onTrackingNumberChange: (String) -> Unit,
     onClose: () -> Unit,
     onConfirm: () -> Unit,
 ) {
@@ -55,7 +55,7 @@ fun TrackingRegistrationDialog(
             text = stringResource(R.string.dialog_rental_detail_tracking_regs_label_delivery_company),
             style = MaterialTheme.typography.bodyLarge
         )
-        DeliveryCompanyDropDown(companyList, selectedCompany, onSelectCompany)
+        DeliveryCompanyDropDown(courierNames, selectedCourierName, onSelectCourier)
 
         Text(
             modifier = Modifier.padding(top = 20.dp, bottom = 14.dp),
@@ -64,8 +64,8 @@ fun TrackingRegistrationDialog(
         )
         CommonTextField(
             modifier = Modifier.fillMaxWidth().padding(bottom = 10.dp),
-            value = trackingNum,
-            onValueChange = onTrackingNumChange,
+            value = trackingNumber,
+            onValueChange = onTrackingNumberChange,
             placeholder = stringResource(R.string.dialog_rental_detail_tracking_regs_placeholder_tracking_num),
             keyboardType = KeyboardType.Number,
         )
@@ -75,14 +75,14 @@ fun TrackingRegistrationDialog(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DeliveryCompanyDropDown(
-    companyList: List<String>,
-    selectedCompany: String?,
+    courierNames: List<String>,
+    selectedCourierName: String?,
     onSelect: (String) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val borderColor = if (expanded) PrimaryBlue500 else Gray200
-    val selectedCompanyText = selectedCompany
-        ?: stringResource(R.string.dialog_rental_detail_tracking_regs_dropdown_company_default_text)
+    val selectedCompanyText = selectedCourierName
+        ?: stringResource(R.string.dialog_rental_detail_tracking_regs_dropdown_courier_unknown)
 
     ExposedDropdownMenuBox(
         modifier = Modifier
@@ -113,7 +113,7 @@ fun DeliveryCompanyDropDown(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
-            companyList.forEach {
+            courierNames.forEach {
                 DropdownMenuItem(
                     text = { Text(it) },
                     onClick = {
@@ -134,11 +134,11 @@ fun TrackingRegistrationDialogPreview() {
     val companyList = listOf("대한통운", "한진택배", "우체국택배")
     RentItTheme {
         TrackingRegistrationDialog(
-            companyList = companyList,
-            selectedCompany = selectedCompany,
-            onSelectCompany = { selectedCompany = it },
-            trackingNum = trackingNum,
-            onTrackingNumChange = { trackingNum = it },
+            courierNames = companyList,
+            selectedCourierName = selectedCompany,
+            onSelectCourier = { selectedCompany = it },
+            trackingNumber = trackingNum,
+            onTrackingNumberChange = { trackingNum = it },
             onClose = { },
             onConfirm = { },
         )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -1,17 +1,20 @@
 package com.example.rentit.presentation.rentaldetail.owner
 
 import android.os.Build
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
+import com.example.rentit.R
 import com.example.rentit.common.component.dialog.RequestAcceptDialog
 import com.example.rentit.presentation.rentaldetail.dialog.RentalCancelDialog
 import com.example.rentit.presentation.rentaldetail.dialog.TrackingRegistrationDialog
@@ -22,6 +25,7 @@ import com.example.rentit.presentation.rentaldetail.dialog.UnknownStatusDialog
 fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int, reservationId: Int) {
 
     val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
     val viewModel: OwnerRentalDetailViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val rentalDetailUiModel by viewModel.rentalDetailUiModel.collectAsStateWithLifecycle()
@@ -40,6 +44,9 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
                 when(it) {
                     is OwnerRentalDetailSideEffect.NavigateToPhotoBeforeRent -> { println("NavigateToPhotoBeforeRent") }
                     is OwnerRentalDetailSideEffect.NavigateToRentalPhotoCheck -> { println("NavigateToRentalPhotoCheck") }
+                    is OwnerRentalDetailSideEffect.ToastErrorGetCourierNames -> {
+                        Toast.makeText(context, context.getString(R.string.toast_error_get_courier_names), Toast.LENGTH_SHORT).show()
+                    }
                 }
             }
         }
@@ -54,7 +61,7 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
         onRequestResponseClick = viewModel::showRequestAcceptDialog,
         onCancelRentClick = viewModel::showCancelDialog,
         onPhotoTaskClick = viewModel::navigateToPhotoBeforeRent,
-        onTrackingNumTaskClick = viewModel::showTrackingRegDialog,
+        onTrackingNumTaskClick = viewModel::getCourierNames,
         onCheckPhotoClick = viewModel::navigateToRentalPhotoCheck
     )
 
@@ -73,13 +80,13 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
         )
     }
 
-    if(uiState.showTrackingRegDialog){
+    if(uiState.trackingRegDialog.isNotEmpty()){
         TrackingRegistrationDialog(
-            companyList = emptyList(),
-            selectedCompany = "",
-            onSelectCompany = { },
-            trackingNum = "",
-            onTrackingNumChange = { },
+            courierNames = uiState.trackingRegDialog,
+            selectedCourierName = uiState.selectedCourierName,
+            onSelectCourier = viewModel::changeSelectedCourierName,
+            trackingNumber = uiState.trackingNumber,
+            onTrackingNumberChange = viewModel::changeTrackingNumber,
             onClose = viewModel::dismissTrackingRegDialog,
             onConfirm = viewModel::confirmTrackingReg
         )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -47,6 +47,12 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
                     is OwnerRentalDetailSideEffect.ToastErrorGetCourierNames -> {
                         Toast.makeText(context, context.getString(R.string.toast_error_get_courier_names), Toast.LENGTH_SHORT).show()
                     }
+                    is OwnerRentalDetailSideEffect.ToastSuccessTrackingRegistration -> {
+                        Toast.makeText(context, context.getString(R.string.toast_success_post_tracking_registration), Toast.LENGTH_SHORT).show()
+                    }
+                    is OwnerRentalDetailSideEffect.ToastErrorTrackingRegistration -> {
+                        Toast.makeText(context, context.getString(R.string.toast_error_post_tracking_registration), Toast.LENGTH_SHORT).show()
+                    }
                 }
             }
         }
@@ -80,15 +86,16 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
         )
     }
 
-    if(uiState.trackingRegDialog.isNotEmpty()){
+    if(uiState.trackingCourierNames.isNotEmpty()){
         TrackingRegistrationDialog(
-            courierNames = uiState.trackingRegDialog,
+            courierNames = uiState.trackingCourierNames,
             selectedCourierName = uiState.selectedCourierName,
-            onSelectCourier = viewModel::changeSelectedCourierName,
             trackingNumber = uiState.trackingNumber,
+            showTrackingNumberEmptyError = uiState.showTrackingNumberEmptyError,
+            onSelectCourier = viewModel::changeSelectedCourierName,
             onTrackingNumberChange = viewModel::changeTrackingNumber,
             onClose = viewModel::dismissTrackingRegDialog,
-            onConfirm = viewModel::confirmTrackingReg
+            onConfirm = { viewModel.confirmTrackingReg(productId, reservationId) }
         )
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -67,7 +67,7 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
         onRequestResponseClick = viewModel::showRequestAcceptDialog,
         onCancelRentClick = viewModel::showCancelDialog,
         onPhotoTaskClick = viewModel::navigateToPhotoBeforeRent,
-        onTrackingNumTaskClick = viewModel::getCourierNames,
+        onTrackingNumTaskClick = viewModel::showTrackingRegDialog,
         onCheckPhotoClick = viewModel::navigateToRentalPhotoCheck
     )
 
@@ -86,7 +86,7 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
         )
     }
 
-    if(uiState.trackingCourierNames.isNotEmpty()){
+    if(uiState.showTrackingRegDialog && uiState.trackingCourierNames.isNotEmpty()){
         TrackingRegistrationDialog(
             courierNames = uiState.trackingCourierNames,
             selectedCourierName = uiState.selectedCourierName,

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
@@ -4,4 +4,6 @@ sealed class OwnerRentalDetailSideEffect {
     data object NavigateToPhotoBeforeRent: OwnerRentalDetailSideEffect()
     data object NavigateToRentalPhotoCheck: OwnerRentalDetailSideEffect()
     data object ToastErrorGetCourierNames: OwnerRentalDetailSideEffect()
+    data object ToastSuccessTrackingRegistration: OwnerRentalDetailSideEffect()
+    data object ToastErrorTrackingRegistration: OwnerRentalDetailSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
@@ -3,4 +3,5 @@ package com.example.rentit.presentation.rentaldetail.owner
 sealed class OwnerRentalDetailSideEffect {
     data object NavigateToPhotoBeforeRent: OwnerRentalDetailSideEffect()
     data object NavigateToRentalPhotoCheck: OwnerRentalDetailSideEffect()
+    data object ToastErrorGetCourierNames: OwnerRentalDetailSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailState.kt
@@ -6,9 +6,10 @@ data class OwnerRentalDetailState(
     val isLoading: Boolean = false,
     val selectedCourierName: String = "",
     val trackingNumber: String = "",
-    val requestAcceptDialog: RequestAcceptDialogUiModel? = null,
-    val showCancelDialog: Boolean = false,
     val trackingCourierNames: List<String> = emptyList(),
     val showTrackingNumberEmptyError: Boolean = false,
+    val showTrackingRegDialog: Boolean = false,
+    val requestAcceptDialog: RequestAcceptDialogUiModel? = null,
+    val showCancelDialog: Boolean = false,
     val showUnknownStatusDialog: Boolean = false,
 )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailState.kt
@@ -4,10 +4,11 @@ import com.example.rentit.common.model.RequestAcceptDialogUiModel
 
 data class OwnerRentalDetailState(
     val isLoading: Boolean = false,
-    val selectedCourierName: String? = null,
+    val selectedCourierName: String = "",
     val trackingNumber: String = "",
     val requestAcceptDialog: RequestAcceptDialogUiModel? = null,
     val showCancelDialog: Boolean = false,
-    val trackingRegDialog: List<String> = emptyList(),
+    val trackingCourierNames: List<String> = emptyList(),
+    val showTrackingNumberEmptyError: Boolean = false,
     val showUnknownStatusDialog: Boolean = false,
 )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailState.kt
@@ -4,8 +4,10 @@ import com.example.rentit.common.model.RequestAcceptDialogUiModel
 
 data class OwnerRentalDetailState(
     val isLoading: Boolean = false,
+    val selectedCourierName: String? = null,
+    val trackingNumber: String = "",
     val requestAcceptDialog: RequestAcceptDialogUiModel? = null,
     val showCancelDialog: Boolean = false,
-    val showTrackingRegDialog: Boolean = false,
+    val trackingRegDialog: List<String> = emptyList(),
     val showUnknownStatusDialog: Boolean = false,
 )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -4,8 +4,10 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.rentit.common.enums.TrackingRegistrationRequestType
 import com.example.rentit.common.model.RequestAcceptDialogUiModel
 import com.example.rentit.data.rental.repository.RentalRepository
+import com.example.rentit.data.rental.usecase.RegisterTrackingUseCase
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -18,6 +20,7 @@ import javax.inject.Inject
 @HiltViewModel
 class OwnerRentalDetailViewModel @Inject constructor(
     private val rentalRepository: RentalRepository,
+    private val registerTrackingUseCase: RegisterTrackingUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(OwnerRentalDetailState())
@@ -98,7 +101,10 @@ class OwnerRentalDetailViewModel @Inject constructor(
         viewModelScope.launch {
             rentalRepository.getCourierNames()
                 .onSuccess {
-                    _uiState.value = _uiState.value.copy(trackingRegDialog = it.courierNames, selectedCourierName = it.courierNames.firstOrNull())
+                    _uiState.value = _uiState.value.copy(
+                        trackingCourierNames = it.courierNames,
+                        selectedCourierName = it.courierNames.firstOrNull() ?: ""
+                    )
                 }.onFailure {
                     _sideEffect.emit(OwnerRentalDetailSideEffect.ToastErrorGetCourierNames)
                 }
@@ -106,12 +112,37 @@ class OwnerRentalDetailViewModel @Inject constructor(
     }
 
     fun dismissTrackingRegDialog() {
-        _uiState.value = _uiState.value.copy(trackingRegDialog = emptyList())
+        _uiState.value = _uiState.value.copy(trackingCourierNames = emptyList())
     }
 
-    fun confirmTrackingReg() {
-        /* 운송장 등록 로직 추가, 성공 시 닫기 */
-        _uiState.value = _uiState.value.copy(trackingRegDialog = emptyList())
+    fun confirmTrackingReg(productId: Int, reservationId: Int) {
+        viewModelScope.launch {
+            registerTrackingUseCase(
+                productId = productId,
+                reservationId = reservationId,
+                type = TrackingRegistrationRequestType.RENTAL,
+                courierName = _uiState.value.selectedCourierName,
+                trackingNumber = _uiState.value.trackingNumber
+            ).onSuccess {
+                dismissTrackingRegDialog()
+                toastTrackingRegistered()
+            }.onFailure { e -> handleTrackingError(e) }
+        }
+    }
+
+    private fun toastTrackingRegistered() {
+        viewModelScope.launch {
+            _sideEffect.emit(OwnerRentalDetailSideEffect.ToastSuccessTrackingRegistration)
+        }
+    }
+
+    private fun handleTrackingError(e: Throwable) {
+        viewModelScope.launch {
+            when (e) {
+                is IllegalArgumentException -> _uiState.value = _uiState.value.copy(showTrackingNumberEmptyError = true)
+                else -> _sideEffect.emit(OwnerRentalDetailSideEffect.ToastErrorTrackingRegistration)
+            }
+        }
     }
 
     fun changeSelectedCourierName(name: String) {
@@ -119,7 +150,8 @@ class OwnerRentalDetailViewModel @Inject constructor(
     }
 
     fun changeTrackingNumber(number: String) {
-        _uiState.value = _uiState.value.copy(trackingNumber = number)
+        val showError = if(number.isNotBlank()) false else _uiState.value.showTrackingNumberEmptyError
+        _uiState.value = _uiState.value.copy(trackingNumber = number, showTrackingNumberEmptyError = showError)
     }
 
     /** 네비게이션 */

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -56,6 +56,7 @@ class OwnerRentalDetailViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(showUnknownStatusDialog = true)
     }
 
+    /** 요청 수락 */
     @RequiresApi(Build.VERSION_CODES.O)
     fun showRequestAcceptDialog() {
         val requestData = _rentalDetailUiModel.value as? OwnerRentalStatusUiModel.Request ?: return
@@ -78,6 +79,7 @@ class OwnerRentalDetailViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(requestAcceptDialog = null)
     }
 
+    /** 대여 취소 */
     fun showCancelDialog() {
         _uiState.value = _uiState.value.copy(showCancelDialog = true)
     }
@@ -91,19 +93,36 @@ class OwnerRentalDetailViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(showCancelDialog = false)
     }
 
-    fun showTrackingRegDialog() {
-        _uiState.value = _uiState.value.copy(showTrackingRegDialog = true)
+    /** 운송장 등록 */
+    fun getCourierNames() {
+        viewModelScope.launch {
+            rentalRepository.getCourierNames()
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(trackingRegDialog = it.courierNames, selectedCourierName = it.courierNames.firstOrNull())
+                }.onFailure {
+                    _sideEffect.emit(OwnerRentalDetailSideEffect.ToastErrorGetCourierNames)
+                }
+        }
     }
 
     fun dismissTrackingRegDialog() {
-        _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
+        _uiState.value = _uiState.value.copy(trackingRegDialog = emptyList())
     }
 
     fun confirmTrackingReg() {
         /* 운송장 등록 로직 추가, 성공 시 닫기 */
-        _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
+        _uiState.value = _uiState.value.copy(trackingRegDialog = emptyList())
     }
 
+    fun changeSelectedCourierName(name: String) {
+        _uiState.value = _uiState.value.copy(selectedCourierName = name)
+    }
+
+    fun changeTrackingNumber(number: String) {
+        _uiState.value = _uiState.value.copy(trackingNumber = number)
+    }
+
+    /** 네비게이션 */
     fun navigateToPhotoBeforeRent() {
         viewModelScope.launch {
             _sideEffect.emit(OwnerRentalDetailSideEffect.NavigateToPhotoBeforeRent)

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -97,7 +97,7 @@ class OwnerRentalDetailViewModel @Inject constructor(
     }
 
     /** 운송장 등록 */
-    fun getCourierNames() {
+    private fun getCourierNames() {
         viewModelScope.launch {
             rentalRepository.getCourierNames()
                 .onSuccess {
@@ -111,8 +111,13 @@ class OwnerRentalDetailViewModel @Inject constructor(
         }
     }
 
+    fun showTrackingRegDialog() {
+        if(_uiState.value.trackingCourierNames.isEmpty()) getCourierNames()
+        _uiState.value = _uiState.value.copy(showTrackingRegDialog = true)
+    }
+
     fun dismissTrackingRegDialog() {
-        _uiState.value = _uiState.value.copy(trackingCourierNames = emptyList())
+        _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -115,6 +115,7 @@ class OwnerRentalDetailViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(trackingCourierNames = emptyList())
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     fun confirmTrackingReg(productId: Int, reservationId: Int) {
         viewModelScope.launch {
             registerTrackingUseCase(
@@ -126,6 +127,7 @@ class OwnerRentalDetailViewModel @Inject constructor(
             ).onSuccess {
                 dismissTrackingRegDialog()
                 toastTrackingRegistered()
+                getRentalDetail(productId, reservationId)
             }.onFailure { e -> handleTrackingError(e) }
         }
     }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
@@ -66,7 +66,7 @@ fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int
         onPayClick = viewModel::navigateToPay,
         onCancelRentClick = viewModel::showCancelDialog,
         onPhotoTaskClick = viewModel::navigateToPhotoBeforeReturn,
-        onTrackingNumTaskClick = viewModel::getCourierNames,
+        onTrackingNumTaskClick = viewModel::showTrackingRegDialog,
         onCheckPhotoClick = viewModel::navigateToRentalPhotoCheck
     )
 
@@ -77,7 +77,7 @@ fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int
         )
     }
 
-    if(uiState.trackingCourierNames.isNotEmpty()){
+    if(uiState.showTrackingRegDialog && uiState.trackingCourierNames.isNotEmpty()){
         TrackingRegistrationDialog(
             courierNames = uiState.trackingCourierNames,
             selectedCourierName = uiState.selectedCourierName,

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
@@ -66,11 +66,11 @@ fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int
 
     if(uiState.showTrackingRegDialog){
         TrackingRegistrationDialog(
-            companyList = emptyList(),
-            selectedCompany = "",
-            onSelectCompany = { },
-            trackingNum = "",
-            onTrackingNumChange = { },
+            courierNames = emptyList(),
+            selectedCourierName = "",
+            onSelectCourier = { },
+            trackingNumber = "",
+            onTrackingNumberChange = { },
             onClose = viewModel::dismissTrackingRegDialog,
             onConfirm = viewModel::confirmTrackingReg
         )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailSideEffect.kt
@@ -4,4 +4,7 @@ sealed class RenterRentalDetailSideEffect {
     data object NavigateToPay: RenterRentalDetailSideEffect()
     data object NavigateToPhotoBeforeReturn: RenterRentalDetailSideEffect()
     data object NavigateToRentalPhotoCheck: RenterRentalDetailSideEffect()
+    data object ToastErrorGetCourierNames: RenterRentalDetailSideEffect()
+    data object ToastSuccessTrackingRegistration: RenterRentalDetailSideEffect()
+    data object ToastErrorTrackingRegistration: RenterRentalDetailSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailState.kt
@@ -2,7 +2,10 @@ package com.example.rentit.presentation.rentaldetail.renter
 
 data class RenterRentalDetailState(
     val isLoading: Boolean = false,
+    val selectedCourierName: String = "",
+    val trackingNumber: String = "",
+    val trackingCourierNames: List<String> = emptyList(),
+    val showTrackingNumberEmptyError: Boolean = false,
     val showCancelDialog: Boolean = false,
-    val showTrackingRegDialog: Boolean = false,
     val showUnknownStatusDialog: Boolean = false,
 )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailState.kt
@@ -6,6 +6,7 @@ data class RenterRentalDetailState(
     val trackingNumber: String = "",
     val trackingCourierNames: List<String> = emptyList(),
     val showTrackingNumberEmptyError: Boolean = false,
+    val showTrackingRegDialog: Boolean = false,
     val showCancelDialog: Boolean = false,
     val showUnknownStatusDialog: Boolean = false,
 )

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
@@ -102,6 +102,7 @@ class RenterRentalDetailViewModel @Inject constructor(
             ).onSuccess {
                 dismissTrackingRegDialog()
                 toastTrackingRegistered()
+                getRentalDetail(productId, reservationId)
             }.onFailure { e -> handleTrackingError(e) }
         }
     }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
@@ -4,7 +4,9 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.rentit.common.enums.TrackingRegistrationRequestType
 import com.example.rentit.data.rental.repository.RentalRepository
+import com.example.rentit.data.rental.usecase.RegisterTrackingUseCase
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -17,6 +19,7 @@ import javax.inject.Inject
 @HiltViewModel
 class RenterRentalDetailViewModel @Inject constructor(
     private val rentalRepository: RentalRepository,
+    private val registerTrackingUseCase: RegisterTrackingUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(RenterRentalDetailState())
@@ -54,6 +57,7 @@ class RenterRentalDetailViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(showUnknownStatusDialog = true)
     }
 
+    /** 대여 취소 */
     fun showCancelDialog() {
         _uiState.value = _uiState.value.copy(showCancelDialog = true)
     }
@@ -67,19 +71,66 @@ class RenterRentalDetailViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(showCancelDialog = false)
     }
 
-    fun showTrackingRegDialog() {
-        _uiState.value = _uiState.value.copy(showTrackingRegDialog = true)
+    /** 운송장 등록 */
+    fun getCourierNames() {
+        viewModelScope.launch {
+            rentalRepository.getCourierNames()
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(
+                        trackingCourierNames = it.courierNames,
+                        selectedCourierName = it.courierNames.firstOrNull() ?: ""
+                    )
+                }.onFailure {
+                    _sideEffect.emit(RenterRentalDetailSideEffect.ToastErrorGetCourierNames)
+                }
+        }
     }
 
     fun dismissTrackingRegDialog() {
-        _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
+        _uiState.value = _uiState.value.copy(trackingCourierNames = emptyList())
     }
 
-    fun confirmTrackingReg() {
-        /* 운송장 등록 로직 추가, 성공 시 닫기 */
-        _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun confirmTrackingReg(productId: Int, reservationId: Int) {
+        viewModelScope.launch {
+            registerTrackingUseCase(
+                productId = productId,
+                reservationId = reservationId,
+                type = TrackingRegistrationRequestType.RETURN,
+                courierName = _uiState.value.selectedCourierName,
+                trackingNumber = _uiState.value.trackingNumber
+            ).onSuccess {
+                dismissTrackingRegDialog()
+                toastTrackingRegistered()
+            }.onFailure { e -> handleTrackingError(e) }
+        }
     }
 
+    private fun toastTrackingRegistered() {
+        viewModelScope.launch {
+            _sideEffect.emit(RenterRentalDetailSideEffect.ToastSuccessTrackingRegistration)
+        }
+    }
+
+    private fun handleTrackingError(e: Throwable) {
+        viewModelScope.launch {
+            when (e) {
+                is IllegalArgumentException -> _uiState.value = _uiState.value.copy(showTrackingNumberEmptyError = true)
+                else -> _sideEffect.emit(RenterRentalDetailSideEffect.ToastErrorTrackingRegistration)
+            }
+        }
+    }
+
+    fun changeSelectedCourierName(name: String) {
+        _uiState.value = _uiState.value.copy(selectedCourierName = name)
+    }
+
+    fun changeTrackingNumber(number: String) {
+        val showError = if(number.isNotBlank()) false else _uiState.value.showTrackingNumberEmptyError
+        _uiState.value = _uiState.value.copy(trackingNumber = number, showTrackingNumberEmptyError = showError)
+    }
+
+    /** 네비게이션 */
     fun navigateToPay() {
         viewModelScope.launch {
             _sideEffect.emit(RenterRentalDetailSideEffect.NavigateToPay)

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
@@ -72,7 +72,7 @@ class RenterRentalDetailViewModel @Inject constructor(
     }
 
     /** 운송장 등록 */
-    fun getCourierNames() {
+    private fun getCourierNames() {
         viewModelScope.launch {
             rentalRepository.getCourierNames()
                 .onSuccess {
@@ -86,8 +86,13 @@ class RenterRentalDetailViewModel @Inject constructor(
         }
     }
 
+    fun showTrackingRegDialog() {
+        if(_uiState.value.trackingCourierNames.isEmpty()) getCourierNames()
+        _uiState.value = _uiState.value.copy(showTrackingRegDialog = true)
+    }
+
     fun dismissTrackingRegDialog() {
-        _uiState.value = _uiState.value.copy(trackingCourierNames = emptyList())
+        _uiState.value = _uiState.value.copy(showTrackingRegDialog = false)
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,12 +257,14 @@
 
     <!-- 운송장 등록 Dialog -->
     <string name="dialog_rental_detail_tracking_regs_title">운송장 등록</string>
+    <string name="dialog_rental_detail_tracking_regs_text_error_empty_number">등록할 운송장 번호가 필요해요.</string>
     <string name="dialog_rental_detail_tracking_regs_label_delivery_company">택배사를 선택해주세요.</string>
     <string name="dialog_rental_detail_tracking_regs_label_tracking_num">송장 번호를 입력해주세요.</string>
     <string name="dialog_rental_detail_tracking_regs_placeholder_tracking_num">12345678</string>
     <string name="dialog_rental_detail_tracking_regs_btn_confirm">등록</string>
-    <string name="dialog_rental_detail_tracking_regs_dropdown_courier_unknown">알수 없음</string>
     <string name="toast_error_get_courier_names">운송사 정보를 불러올 수 없어요. 잠시 후 다시 시도해주세요.</string>
+    <string name="toast_success_post_tracking_registration">운송장이 등록되었어요.</string>
+    <string name="toast_error_post_tracking_registration">등록에 실패했어요. 잠시후 다시 시도해주세요.</string>
 
     <!-- 대여 전 사진 등록 -->
     <string name="screen_photo_before_rent_title">대여 전 사진 등록</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,20 +183,6 @@
     <string name="screen_rental_detail_returned_check_photo_btn">대여 전/후 사진 확인하기</string>
     <string name="screen_rental_detail_subtitle_day_before_rent">· 대여 %d일전</string>
 
-    <string name="dialog_rental_detail_unknown_title">대여 정보가 존재하지 않아요.</string>
-    <string name="dialog_rental_detail_unknown_confirm_btn">확인</string>
-
-    <string name="dialog_rental_detail_rental_cancel_title">대여를 취소할까요?</string>
-    <string name="dialog_rental_detail_rental_cancel_content">취소하면 이 거래가 없어져요.</string>
-    <string name="dialog_rental_detail_rental_cancel_btn_confirm">네, 취소할께요</string>
-
-    <string name="dialog_rental_detail_tracking_regs_title">운송장 등록</string>
-    <string name="dialog_rental_detail_tracking_regs_label_delivery_company">택배사를 선택해주세요.</string>
-    <string name="dialog_rental_detail_tracking_regs_label_tracking_num">송장 번호를 입력해주세요.</string>
-    <string name="dialog_rental_detail_tracking_regs_placeholder_tracking_num">12345678</string>
-    <string name="dialog_rental_detail_tracking_regs_btn_confirm">등록</string>
-    <string name="dialog_rental_detail_tracking_regs_dropdown_company_default_text">택배사 선택</string>
-
     <string name="screen_rental_detail_tracking_info_title">운송장 정보</string>
     <string name="screen_rental_detail_rental_tracking_num">대여 송장 번호</string>
     <string name="screen_rental_detail_returned_tracking_num">반납 송장 번호</string>
@@ -259,6 +245,24 @@
 
     <string name="screen_rental_detail_owner_renting_overdue_info_reward_leading_text">지연 보상금</string>
     <string name="screen_rental_detail_owner_renting_overdue_info_reward_tail_text">이 지급될 예정이에요.</string>
+
+    <!-- Unknown Dialog -->
+    <string name="dialog_rental_detail_unknown_title">대여 정보가 존재하지 않아요.</string>
+    <string name="dialog_rental_detail_unknown_confirm_btn">확인</string>
+
+    <!-- 대여 취소 Dialog -->
+    <string name="dialog_rental_detail_rental_cancel_title">대여를 취소할까요?</string>
+    <string name="dialog_rental_detail_rental_cancel_content">취소하면 이 거래가 없어져요.</string>
+    <string name="dialog_rental_detail_rental_cancel_btn_confirm">네, 취소할께요</string>
+
+    <!-- 운송장 등록 Dialog -->
+    <string name="dialog_rental_detail_tracking_regs_title">운송장 등록</string>
+    <string name="dialog_rental_detail_tracking_regs_label_delivery_company">택배사를 선택해주세요.</string>
+    <string name="dialog_rental_detail_tracking_regs_label_tracking_num">송장 번호를 입력해주세요.</string>
+    <string name="dialog_rental_detail_tracking_regs_placeholder_tracking_num">12345678</string>
+    <string name="dialog_rental_detail_tracking_regs_btn_confirm">등록</string>
+    <string name="dialog_rental_detail_tracking_regs_dropdown_courier_unknown">알수 없음</string>
+    <string name="toast_error_get_courier_names">운송사 정보를 불러올 수 없어요. 잠시 후 다시 시도해주세요.</string>
 
     <!-- 대여 전 사진 등록 -->
     <string name="screen_photo_before_rent_title">대여 전 사진 등록</string>


### PR DESCRIPTION
# Pull Request

## Summary  
대여자/사용자 대여 상세 화면의 운송장 등록 Dialog 기능 API 연동 (택배사 목록 조회 및 운송장 등록 API)

## Related Issue  
- Close: #104 

## Changes  
- 택배사 목록 조회 및 운송장 등록 API 연동 구현 (Service, DataSource, Repository)
- 택배사 리스트 -> Dialog 내부 Dropdown에 연결 
  - Dropdown 기본 값은 0번 인덱스 값으로 설정
- 송장 번호의 Blank를 경고하는 메세지 Text Composable 추가
- 운송장 등록 UseCase 구현 
  - 송장 번호의 Blank 여부를 확인하고 `IllegalArgumentException`을 리턴 
  - 운송장 등록 API 연동
- UseCase 결과에 따라 처리
  - 성공 시: Dialog를 닫고 Toast 메세지
  - 실패 시: 송장 번호 Blank -> 경고 메세지 Show / API 실패 -> 실패 Toast 메세지
- 운송장 등록 성공 시 대여 상세 데이터 Reload
