### PR TITLE
Feat/106 update rental status

### DIFF
--- a/app/src/main/java/com/example/rentit/common/exception/MissingTokenException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/MissingTokenException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.common.exception
+
+class MissingTokenException: Exception()

--- a/app/src/main/java/com/example/rentit/common/exception/product/ResvNotFoundException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/product/ResvNotFoundException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.common.exception.product
-
-class ResvNotFoundException: Exception()

--- a/app/src/main/java/com/example/rentit/common/exception/rental/RentalNotFoundException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/rental/RentalNotFoundException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.common.exception.rental
+
+class RentalNotFoundException: Exception()

--- a/app/src/main/java/com/example/rentit/data/product/dto/UpdateResvStatusRequestDto.kt
+++ b/app/src/main/java/com/example/rentit/data/product/dto/UpdateResvStatusRequestDto.kt
@@ -1,9 +1,0 @@
-package com.example.rentit.data.product.dto
-
-import com.example.rentit.common.enums.ResvStatus
-import com.google.gson.annotations.SerializedName
-
-data class UpdateResvStatusRequestDto(
-    @SerializedName("status")
-    val status: ResvStatus,
-)

--- a/app/src/main/java/com/example/rentit/data/product/remote/ProductApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/product/remote/ProductApiService.kt
@@ -8,7 +8,6 @@ import com.example.rentit.data.product.dto.ProductDetailResponseDto
 import com.example.rentit.data.product.dto.ProductReservedDatesResponseDto
 import com.example.rentit.data.product.dto.ProductListResponseDto
 import com.example.rentit.data.product.dto.RequestHistoryResponseDto
-import com.example.rentit.data.product.dto.UpdateResvStatusRequestDto
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Response
@@ -16,7 +15,6 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Multipart
-import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.Path
@@ -52,12 +50,4 @@ interface ProductApiService {
     @GET("api/v1/products/{productId}/reservations")
     @Headers("Content-Type: application/json")
     suspend fun getProductRequestList(@Path("productId") productId: Int): Response<RequestHistoryResponseDto>
-
-    @PATCH("api/v1/products/{productId}/reservations/{reservationId}")
-    @Headers("Content-Type: application/json")
-    suspend fun updateResvStatus(
-        @Path("productId") productId: Int,
-        @Path("reservationId") reservationId: Int,
-        @Body request: UpdateResvStatusRequestDto
-    ): Response<Unit>
 }

--- a/app/src/main/java/com/example/rentit/data/product/remote/ProductRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/product/remote/ProductRemoteDataSource.kt
@@ -8,7 +8,6 @@ import com.example.rentit.data.product.dto.ProductDetailResponseDto
 import com.example.rentit.data.product.dto.ProductReservedDatesResponseDto
 import com.example.rentit.data.product.dto.ProductListResponseDto
 import com.example.rentit.data.product.dto.RequestHistoryResponseDto
-import com.example.rentit.data.product.dto.UpdateResvStatusRequestDto
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Response
@@ -38,8 +37,4 @@ class ProductRemoteDataSource @Inject constructor(
     suspend fun getProductRequestList(productId: Int): Response<RequestHistoryResponseDto> {
         return productApiService.getProductRequestList(productId)
     }
-    suspend fun updateResvStatus(productId: Int, reservationId: Int, request: UpdateResvStatusRequestDto): Response<Unit> {
-        return productApiService.updateResvStatus(productId, reservationId, request)
-    }
-
 }

--- a/app/src/main/java/com/example/rentit/data/product/repository/ProductRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/product/repository/ProductRepository.kt
@@ -2,7 +2,7 @@ package com.example.rentit.data.product.repository
 
 import com.example.rentit.common.exception.ServerException
 import com.example.rentit.common.exception.product.NotProductOwnerException
-import com.example.rentit.common.exception.product.ResvNotFoundException
+import com.example.rentit.common.exception.rental.RentalNotFoundException
 import com.example.rentit.data.product.dto.ResvRequestDto
 import com.example.rentit.data.product.dto.ResvResponseDto
 import com.example.rentit.data.product.dto.CategoryListResponseDto
@@ -204,7 +204,7 @@ class ProductRepository @Inject constructor(
             when(response.code()) {
                 200 -> Result.success(Unit)
                 403 -> Result.failure(NotProductOwnerException())
-                404 -> Result.failure(ResvNotFoundException())
+                404 -> Result.failure(RentalNotFoundException())
                 500 -> Result.failure(ServerException())
                 else -> Result.failure(Exception("Unexpected error"))
             }

--- a/app/src/main/java/com/example/rentit/data/product/repository/ProductRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/product/repository/ProductRepository.kt
@@ -1,8 +1,5 @@
 package com.example.rentit.data.product.repository
 
-import com.example.rentit.common.exception.ServerException
-import com.example.rentit.common.exception.product.NotProductOwnerException
-import com.example.rentit.common.exception.rental.RentalNotFoundException
 import com.example.rentit.data.product.dto.ResvRequestDto
 import com.example.rentit.data.product.dto.ResvResponseDto
 import com.example.rentit.data.product.dto.CategoryListResponseDto
@@ -11,7 +8,6 @@ import com.example.rentit.data.product.dto.ProductDetailResponseDto
 import com.example.rentit.data.product.dto.ProductReservedDatesResponseDto
 import com.example.rentit.data.product.dto.ProductListResponseDto
 import com.example.rentit.data.product.dto.RequestHistoryResponseDto
-import com.example.rentit.data.product.dto.UpdateResvStatusRequestDto
 import com.example.rentit.data.product.remote.ProductRemoteDataSource
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -192,21 +188,6 @@ class ProductRepository @Inject constructor(
                 else -> {
                     Result.failure(Exception("Unexpected error"))
                 }
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
-    }
-
-    suspend fun updateResvStatus(productId: Int, reservationId: Int, request: UpdateResvStatusRequestDto): Result<Unit> {
-        return try {
-            val response = productRemoteDataSource.updateResvStatus(productId, reservationId, request)
-            when(response.code()) {
-                200 -> Result.success(Unit)
-                403 -> Result.failure(NotProductOwnerException())
-                404 -> Result.failure(RentalNotFoundException())
-                500 -> Result.failure(ServerException())
-                else -> Result.failure(Exception("Unexpected error"))
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/example/rentit/data/rental/dto/UpdateResvStatusRequestDto.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/dto/UpdateResvStatusRequestDto.kt
@@ -1,0 +1,9 @@
+package com.example.rentit.data.rental.dto
+
+import com.example.rentit.common.enums.RentalStatus
+import com.google.gson.annotations.SerializedName
+
+data class UpdateRentalStatusRequestDto(
+    @SerializedName("status")
+    val status: RentalStatus,
+)

--- a/app/src/main/java/com/example/rentit/data/rental/remote/RentalApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/remote/RentalApiService.kt
@@ -4,10 +4,12 @@ import com.example.rentit.data.rental.dto.CourierNamesResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
 import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
+import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Headers
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 
@@ -30,4 +32,12 @@ interface RentalApiService {
     @GET("api/v1/delivery/couriers")
     @Headers("Content-Type: application/json")
     suspend fun getCourierNames(): Response<CourierNamesResponseDto>
+
+    @PATCH("api/v1/products/{productId}/reservations/{reservationId}")
+    @Headers("Content-Type: application/json")
+    suspend fun updateRentalStatus(
+        @Path("productId") productId: Int,
+        @Path("reservationId") reservationId: Int,
+        @Body request: UpdateRentalStatusRequestDto
+    ): Response<Unit>
 }

--- a/app/src/main/java/com/example/rentit/data/rental/remote/RentalRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/remote/RentalRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.example.rentit.data.rental.dto.CourierNamesResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
 import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
+import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
 import retrofit2.Response
 import javax.inject.Inject
 
@@ -20,5 +21,8 @@ class RentalRemoteDataSource @Inject constructor(
 
     suspend fun getCourierNames(): Response<CourierNamesResponseDto> {
         return rentalApiService.getCourierNames()
+    }
+    suspend fun updateRentalStatus(productId: Int, reservationId: Int, request: UpdateRentalStatusRequestDto): Response<Unit> {
+        return rentalApiService.updateRentalStatus(productId, reservationId, request)
     }
 }

--- a/app/src/main/java/com/example/rentit/data/rental/repository/RentalRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/repository/RentalRepository.kt
@@ -2,7 +2,7 @@ package com.example.rentit.data.rental.repository
 
 import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.common.exception.ServerException
-import com.example.rentit.common.exception.product.ResvNotFoundException
+import com.example.rentit.common.exception.rental.RentalNotFoundException
 import com.example.rentit.common.exception.rental.EmptyBodyException
 import com.example.rentit.data.rental.dto.CourierNamesResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
@@ -54,7 +54,7 @@ class RentalRepository @Inject constructor(
             if (!response.isSuccessful) {
                 throw when (response.code()) {
                     401 -> MissingTokenException()
-                    404 -> ResvNotFoundException()
+                    404 -> RentalNotFoundException()
                     else -> ServerException()
                 }
             }

--- a/app/src/main/java/com/example/rentit/data/rental/repository/RentalRepository.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/repository/RentalRepository.kt
@@ -1,11 +1,14 @@
 package com.example.rentit.data.rental.repository
 
+import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.common.exception.ServerException
+import com.example.rentit.common.exception.product.ResvNotFoundException
 import com.example.rentit.common.exception.rental.EmptyBodyException
 import com.example.rentit.data.rental.dto.CourierNamesResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
 import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
+import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
 import com.example.rentit.data.rental.remote.RentalRemoteDataSource
 import javax.inject.Inject
 
@@ -42,6 +45,20 @@ class RentalRepository @Inject constructor(
             } else {
                 throw ServerException()
             }
+        }
+    }
+
+    suspend fun updateRentalStatus(productId: Int, reservationId: Int, request: UpdateRentalStatusRequestDto): Result<Unit> {
+        return runCatching {
+            val response = rentalRemoteDataSource.updateRentalStatus(productId, reservationId, request)
+            if (!response.isSuccessful) {
+                throw when (response.code()) {
+                    401 -> MissingTokenException()
+                    404 -> ResvNotFoundException()
+                    else -> ServerException()
+                }
+            }
+            Unit
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
@@ -58,7 +58,7 @@ import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.exception.chat.ForbiddenChatAccessException
 import com.example.rentit.common.exception.ServerException
 import com.example.rentit.common.exception.product.NotProductOwnerException
-import com.example.rentit.common.exception.product.ResvNotFoundException
+import com.example.rentit.common.exception.rental.RentalNotFoundException
 import com.example.rentit.common.theme.Gray100
 import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.Gray800
@@ -191,7 +191,7 @@ fun ChatroomScreen(navHostController: NavHostController, productId: Int?, reserv
                             var errorMsg = context.getString(R.string.error_cant_process_accept_request)
                             when(it){
                                 is NotProductOwnerException -> errorMsg = context.getString(R.string.error_only_seller)
-                                is ResvNotFoundException -> errorMsg = context.getString(R.string.error_reservation_not_found)
+                                is RentalNotFoundException -> errorMsg = context.getString(R.string.error_reservation_not_found)
                                 is ServerException -> errorMsg = context.getString(R.string.error_common_server)
                                 else -> Unit
                             }

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomViewModel.kt
@@ -5,13 +5,14 @@ import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.enums.AutoMsgType
-import com.example.rentit.common.enums.ResvStatus
+import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.websocket.WebSocketManager
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.repository.ChatRepository
 import com.example.rentit.data.product.dto.ProductDetailResponseDto
-import com.example.rentit.data.product.dto.UpdateResvStatusRequestDto
 import com.example.rentit.data.product.repository.ProductRepository
+import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
+import com.example.rentit.data.rental.repository.RentalRepository
 import com.example.rentit.data.user.repository.UserRepository
 import com.example.rentit.presentation.chat.chatroom.model.ChatMessageUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -24,7 +25,8 @@ import javax.inject.Inject
 class ChatRoomViewModel @Inject constructor(
     private val userRepository: UserRepository,
     private val chatRepository: ChatRepository,
-    private val productRepository: ProductRepository
+    private val productRepository: ProductRepository,
+    private val rentalRepository: RentalRepository
 ): ViewModel() {
 
     private val authUserId: Long = userRepository.getAuthUserIdFromPrefs()
@@ -104,18 +106,16 @@ class ChatRoomViewModel @Inject constructor(
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun updateResvStatus(chatroomId: String, productId: Int, reservationId: Int, onSuccess: () -> Unit = {}, onError: (Throwable) -> Unit = {}) {
+    fun acceptRentalRequest(chatroomId: String, productId: Int, reservationId: Int, onSuccess: () -> Unit = {}, onError: (Throwable) -> Unit = {}) {
         viewModelScope.launch {
-            productRepository.updateResvStatus(
+            rentalRepository.updateRentalStatus(
                 productId,
                 reservationId,
-                UpdateResvStatusRequestDto(ResvStatus.ACCEPTED)
-            )
-                .onSuccess {
-                    onSuccess()
-                    sendMessage(chatroomId, AutoMsgType.REQUEST_ACCEPT.code)
-                }
-                .onFailure(onError)
+                UpdateRentalStatusRequestDto(RentalStatus.ACCEPTED)
+            ).onSuccess {
+                onSuccess()
+                sendMessage(chatroomId, AutoMsgType.REQUEST_ACCEPT.code)
+            }.onFailure(onError)
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -59,6 +59,13 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
                     is OwnerRentalDetailSideEffect.ToastCancelRentalFailed -> {
                         Toast.makeText(context, context.getString(R.string.toast_cancel_rental_failed), Toast.LENGTH_SHORT).show()
                     }
+                    is OwnerRentalDetailSideEffect.ToastAcceptRentalSuccess -> {
+                        Toast.makeText(context, context.getString(R.string.toast_accept_rental_success), Toast.LENGTH_SHORT).show()
+                    }
+                    is OwnerRentalDetailSideEffect.ToastAcceptRentalFailed -> {
+                        Toast.makeText(context, context.getString(R.string.toast_accept_rental_failed), Toast.LENGTH_SHORT).show()
+                    }
+
                 }
             }
         }
@@ -81,7 +88,7 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
         RequestAcceptDialog(
             uiModel = it,
             onClose = viewModel::dismissRequestAcceptDialog,
-            onAccept = viewModel::acceptRequest,
+            onAccept = { viewModel.acceptRequest(productId, reservationId) },
         )
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -53,6 +53,9 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
                     is OwnerRentalDetailSideEffect.ToastErrorTrackingRegistration -> {
                         Toast.makeText(context, context.getString(R.string.toast_error_post_tracking_registration), Toast.LENGTH_SHORT).show()
                     }
+                    is OwnerRentalDetailSideEffect.ToastCancelRentalSuccess -> {
+                        Toast.makeText(context, context.getString(R.string.toast_cancel_rental_success), Toast.LENGTH_SHORT).show()
+                    }
                     is OwnerRentalDetailSideEffect.ToastCancelRentalFailed -> {
                         Toast.makeText(context, context.getString(R.string.toast_cancel_rental_failed), Toast.LENGTH_SHORT).show()
                     }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -53,6 +53,9 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
                     is OwnerRentalDetailSideEffect.ToastErrorTrackingRegistration -> {
                         Toast.makeText(context, context.getString(R.string.toast_error_post_tracking_registration), Toast.LENGTH_SHORT).show()
                     }
+                    is OwnerRentalDetailSideEffect.ToastCancelRentalFailed -> {
+                        Toast.makeText(context, context.getString(R.string.toast_cancel_rental_failed), Toast.LENGTH_SHORT).show()
+                    }
                 }
             }
         }
@@ -82,7 +85,7 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
     if(uiState.showCancelDialog){
         RentalCancelDialog(
             onClose = viewModel::dismissCancelDialog,
-            onCancelAccept = viewModel::confirmCancel
+            onCancelAccept = { viewModel.confirmCancel(productId, reservationId) }
         )
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
@@ -6,4 +6,5 @@ sealed class OwnerRentalDetailSideEffect {
     data object ToastErrorGetCourierNames: OwnerRentalDetailSideEffect()
     data object ToastSuccessTrackingRegistration: OwnerRentalDetailSideEffect()
     data object ToastErrorTrackingRegistration: OwnerRentalDetailSideEffect()
+    data object ToastCancelRentalFailed: OwnerRentalDetailSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
@@ -6,5 +6,6 @@ sealed class OwnerRentalDetailSideEffect {
     data object ToastErrorGetCourierNames: OwnerRentalDetailSideEffect()
     data object ToastSuccessTrackingRegistration: OwnerRentalDetailSideEffect()
     data object ToastErrorTrackingRegistration: OwnerRentalDetailSideEffect()
+    data object ToastCancelRentalSuccess: OwnerRentalDetailSideEffect()
     data object ToastCancelRentalFailed: OwnerRentalDetailSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailSideEffect.kt
@@ -8,4 +8,6 @@ sealed class OwnerRentalDetailSideEffect {
     data object ToastErrorTrackingRegistration: OwnerRentalDetailSideEffect()
     data object ToastCancelRentalSuccess: OwnerRentalDetailSideEffect()
     data object ToastCancelRentalFailed: OwnerRentalDetailSideEffect()
+    data object ToastAcceptRentalSuccess: OwnerRentalDetailSideEffect()
+    data object ToastAcceptRentalFailed: OwnerRentalDetailSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -95,7 +95,6 @@ class OwnerRentalDetailViewModel @Inject constructor(
                 handleAcceptError(e)
             }
         }
-        _uiState.value = _uiState.value.copy(requestAcceptDialog = null)
     }
 
     private fun toastAcceptSuccess() {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -4,8 +4,11 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.enums.TrackingRegistrationRequestType
+import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.common.model.RequestAcceptDialogUiModel
+import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
 import com.example.rentit.data.rental.repository.RentalRepository
 import com.example.rentit.data.rental.usecase.RegisterTrackingUseCase
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
@@ -20,7 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class OwnerRentalDetailViewModel @Inject constructor(
     private val rentalRepository: RentalRepository,
-    private val registerTrackingUseCase: RegisterTrackingUseCase
+    private val registerTrackingUseCase: RegisterTrackingUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(OwnerRentalDetailState())
@@ -91,9 +94,29 @@ class OwnerRentalDetailViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(showCancelDialog = false)
     }
 
-    fun confirmCancel() {
-        /* 대여 취소 로직 추가, 성공 시 닫기 */
-        _uiState.value = _uiState.value.copy(showCancelDialog = false)
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun confirmCancel(productId: Int, reservationId: Int) {
+        viewModelScope.launch {
+            rentalRepository.updateRentalStatus(
+                productId,
+                reservationId,
+                UpdateRentalStatusRequestDto(RentalStatus.CANCELED)
+            ).onSuccess {
+                dismissCancelDialog()
+                getRentalDetail(productId, reservationId)
+            }.onFailure { e ->
+                handleCancelError(e)
+            }
+        }
+    }
+
+    private fun handleCancelError(e: Throwable) {
+        viewModelScope.launch {
+            when(e) {
+                is MissingTokenException -> println("Logout") /* 로그아웃 수행 */
+                else -> _sideEffect.emit(OwnerRentalDetailSideEffect.ToastCancelRentalFailed)
+            }
+        }
     }
 
     /** 운송장 등록 */

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -102,11 +102,18 @@ class OwnerRentalDetailViewModel @Inject constructor(
                 reservationId,
                 UpdateRentalStatusRequestDto(RentalStatus.CANCELED)
             ).onSuccess {
+                toastCancelSuccess()
                 dismissCancelDialog()
                 getRentalDetail(productId, reservationId)
             }.onFailure { e ->
                 handleCancelError(e)
             }
+        }
+    }
+
+    private fun toastCancelSuccess() {
+        viewModelScope.launch {
+            _sideEffect.emit(OwnerRentalDetailSideEffect.ToastCancelRentalSuccess)
         }
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
@@ -53,6 +53,9 @@ fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int
                     is RenterRentalDetailSideEffect.ToastErrorTrackingRegistration -> {
                         Toast.makeText(context, context.getString(R.string.toast_error_post_tracking_registration), Toast.LENGTH_SHORT).show()
                     }
+                    is RenterRentalDetailSideEffect.ToastCancelRentalFailed -> {
+                        Toast.makeText(context, context.getString(R.string.toast_cancel_rental_failed), Toast.LENGTH_SHORT).show()
+                    }
                 }
             }
         }
@@ -73,7 +76,7 @@ fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int
     if(uiState.showCancelDialog){
         RentalCancelDialog(
             onClose = viewModel::dismissCancelDialog,
-            onCancelAccept = viewModel::confirmCancel
+            onCancelAccept = { viewModel.confirmCancel(productId, reservationId) }
         )
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
@@ -53,6 +53,9 @@ fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int
                     is RenterRentalDetailSideEffect.ToastErrorTrackingRegistration -> {
                         Toast.makeText(context, context.getString(R.string.toast_error_post_tracking_registration), Toast.LENGTH_SHORT).show()
                     }
+                    is RenterRentalDetailSideEffect.ToastCancelRentalSuccess -> {
+                        Toast.makeText(context, context.getString(R.string.toast_cancel_rental_success), Toast.LENGTH_SHORT).show()
+                    }
                     is RenterRentalDetailSideEffect.ToastCancelRentalFailed -> {
                         Toast.makeText(context, context.getString(R.string.toast_cancel_rental_failed), Toast.LENGTH_SHORT).show()
                     }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailSideEffect.kt
@@ -7,5 +7,6 @@ sealed class RenterRentalDetailSideEffect {
     data object ToastErrorGetCourierNames: RenterRentalDetailSideEffect()
     data object ToastSuccessTrackingRegistration: RenterRentalDetailSideEffect()
     data object ToastErrorTrackingRegistration: RenterRentalDetailSideEffect()
+    data object ToastCancelRentalSuccess: RenterRentalDetailSideEffect()
     data object ToastCancelRentalFailed: RenterRentalDetailSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailSideEffect.kt
@@ -7,4 +7,5 @@ sealed class RenterRentalDetailSideEffect {
     data object ToastErrorGetCourierNames: RenterRentalDetailSideEffect()
     data object ToastSuccessTrackingRegistration: RenterRentalDetailSideEffect()
     data object ToastErrorTrackingRegistration: RenterRentalDetailSideEffect()
+    data object ToastCancelRentalFailed: RenterRentalDetailSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
@@ -7,11 +7,9 @@ import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.enums.TrackingRegistrationRequestType
 import com.example.rentit.common.exception.MissingTokenException
-import com.example.rentit.common.exception.product.NotProductOwnerException
 import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
 import com.example.rentit.data.rental.repository.RentalRepository
 import com.example.rentit.data.rental.usecase.RegisterTrackingUseCase
-import com.example.rentit.presentation.rentaldetail.owner.OwnerRentalDetailSideEffect
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -79,11 +77,18 @@ class RenterRentalDetailViewModel @Inject constructor(
                 reservationId,
                 UpdateRentalStatusRequestDto(RentalStatus.CANCELED)
             ).onSuccess {
+                toastCancelSuccess()
                 dismissCancelDialog()
                 getRentalDetail(productId, reservationId)
             }.onFailure { e ->
                 handleCancelError(e)
             }
+        }
+    }
+
+    private fun toastCancelSuccess() {
+        viewModelScope.launch {
+            _sideEffect.emit(RenterRentalDetailSideEffect.ToastCancelRentalSuccess)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -254,6 +254,7 @@
     <string name="dialog_rental_detail_rental_cancel_title">대여를 취소할까요?</string>
     <string name="dialog_rental_detail_rental_cancel_content">취소하면 이 거래가 없어져요.</string>
     <string name="dialog_rental_detail_rental_cancel_btn_confirm">네, 취소할께요</string>
+    <string name="toast_cancel_rental_failed">대여 취소에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
 
     <!-- 운송장 등록 Dialog -->
     <string name="dialog_rental_detail_tracking_regs_title">운송장 등록</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,10 +27,13 @@
 
     <string name="common_dialog_btn_close">닫기</string>
 
+    <!-- 요청 승인 Dialog -->
     <string name="common_dialog_accept_request_title">요청을 수락할까요?</string>
     <string name="common_dialog_accept_request_label_rental_period">대여 기간</string>
     <string name="common_dialog_accept_request_label_total_price">예상 수익</string>
     <string name="common_dialog_accept_request_btn_accept">수락하기</string>
+    <string name="toast_accept_rental_success">대여 요청이 정상적으로 승인되었어요.</string>
+    <string name="toast_accept_rental_failed">요청 수락에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
 
     <string name="common_calendar_left_chevron_description">다음달로 이동</string>
     <string name="common_calendar_right_chevron_description">이전달로 이동</string>
@@ -131,10 +134,6 @@
     <string name="error_chat_list_load">채팅 목록을 불러올 수 없어요.</string>
     <string name="error_chat_access">채팅방 접근 권한이 없어요.</string>
     <string name="error_chat_unknown">채팅방에 접속할 수 없어요.</string>
-
-    <string name="error_only_seller">해당 작업은 판매자만 수행할 수 있어요.</string>
-    <string name="error_cant_process_accept_request">요청을 수락할 수 없어요.</string>
-    <string name="error_reservation_not_found">예약 정보를 찾을 수 없어요.</string>
 
     <string name="toast_chatroom_entered">채팅방에 입장했어요.</string>
 
@@ -256,8 +255,6 @@
     <string name="dialog_rental_detail_rental_cancel_btn_confirm">네, 취소할께요</string>
     <string name="toast_cancel_rental_success">거래가 취소되었어요.</string>
     <string name="toast_cancel_rental_failed">대여 취소에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
-    <string name="toast_accept_rental_success">대여가 정상적으로 승인되었어요.</string>
-    <string name="toast_accept_rental_failed">대여 승인에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
 
 
     <!-- 운송장 등록 Dialog -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,6 +256,9 @@
     <string name="dialog_rental_detail_rental_cancel_btn_confirm">네, 취소할께요</string>
     <string name="toast_cancel_rental_success">거래가 취소되었어요.</string>
     <string name="toast_cancel_rental_failed">대여 취소에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
+    <string name="toast_accept_rental_success">대여가 정상적으로 승인되었어요.</string>
+    <string name="toast_accept_rental_failed">대여 승인에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
+
 
     <!-- 운송장 등록 Dialog -->
     <string name="dialog_rental_detail_tracking_regs_title">운송장 등록</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -254,6 +254,7 @@
     <string name="dialog_rental_detail_rental_cancel_title">대여를 취소할까요?</string>
     <string name="dialog_rental_detail_rental_cancel_content">취소하면 이 거래가 없어져요.</string>
     <string name="dialog_rental_detail_rental_cancel_btn_confirm">네, 취소할께요</string>
+    <string name="toast_cancel_rental_success">거래가 취소되었어요.</string>
     <string name="toast_cancel_rental_failed">대여 취소에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
 
     <!-- 운송장 등록 Dialog -->


### PR DESCRIPTION
# Pull Request

## Summary  
- 예약 요청 상태 변경 API -> 대여 상태 변경 API로 확장됨에 따라 기존에 Product 도메인 아래 구현된 API 연동을 Rental 도메인으로 옮기고 관련 파일 (ChatViewModel)을 수정
- 해당 API 대여 상세 화면의 대여 취소, 요청 수락 Dialog의 기능을 구현

## Related Issue  
- Close: #106 

## Changes  
- product 도메인 아래 `UpdateResvStatus` 관련 코드 제거
- rental 도메인 아래 `UpdateRentalStatus` 구현
- 기존에 UpdateResvStatus를 사용했던 ChatRoomViewModel을 UpdateRentalStatus를 사용하도록 수정
- 대여 상세 화면의 대여 취소 Dialog, 요청 수락 Dialog 각각 기능 구현 (CANCELED, ACCEPTED로 상태 변화 API 요청)
- 상태 변화 성공/실패 시 Toast 메세지 출력 및 관련 문자열 리소스 추가

## Notes  
- 현재 `대여 상태 변경 API`의 동작에는 문제가 없으나 성공 시에도 `500` 코드를 반환하는 에러를 확인하여 **백엔드에게 전달 완료**한 상태임
