### PR TITLE
Refactor/124 splash separate error

### DIFF
--- a/app/src/main/java/com/example/rentit/data/user/usecase/CheckUserSessionUseCase.kt
+++ b/app/src/main/java/com/example/rentit/data/user/usecase/CheckUserSessionUseCase.kt
@@ -1,0 +1,27 @@
+package com.example.rentit.data.user.usecase
+
+import com.example.rentit.common.exception.MissingTokenException
+import com.example.rentit.data.user.repository.UserRepository
+import javax.inject.Inject
+
+class CheckUserSessionUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(): Result<Long> {
+        return runCatching {
+            val token = userRepository.getTokenFromPrefs()
+            if(token.isNullOrEmpty()) throw MissingTokenException()
+
+            val localUserId = userRepository.getAuthUserIdFromPrefs()
+            if(localUserId == -1L){
+                val userId = userRepository.getMyInfo().getOrThrow().data.userId
+                userRepository.saveAuthUserIdToPrefs(userId)
+                userId // 로그 출력용
+            } else {
+                localUserId // 로그 출력용
+            }
+        }.onFailure { e ->
+            if(e is MissingTokenException) userRepository.clearPrefs()
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/splash/SplashRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/splash/SplashRoute.kt
@@ -3,20 +3,35 @@ package com.example.rentit.presentation.splash
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
 import com.example.rentit.navigation.auth.navigateToLogin
 import com.example.rentit.navigation.bottomtab.navigateToHome
 
 @Composable
 fun SplashRoute(navHostController: NavHostController) {
-    val splashViewModel: SplashViewModel = hiltViewModel()
+    val viewModel: SplashViewModel = hiltViewModel()
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-        splashViewModel.splashSideEffect.collect {
-            when (it) {
-                SplashSideEffect.NavigateToMain -> navHostController.navigateToHome()
-                SplashSideEffect.NavigateToLogin -> navHostController.navigateToLogin()
+        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.splashSideEffect.collect {
+                when (it) {
+                    SplashSideEffect.NavigateToMain -> navHostController.navigateToHome()
+                    SplashSideEffect.NavigateToLogin -> navHostController.navigateToLogin()
+                }
             }
         }
     }
+
+    SplashScreen(
+        isLoading = uiState.value.isLoading,
+        showErrorDialog = uiState.value.showErrorDialog,
+        onRetry = viewModel::retryCheckUserSession
+    )
 }

--- a/app/src/main/java/com/example/rentit/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/splash/SplashScreen.kt
@@ -1,0 +1,27 @@
+package com.example.rentit.presentation.splash
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.example.rentit.R
+import com.example.rentit.common.component.dialog.BaseDialog
+import com.example.rentit.common.component.layout.LoadingScreen
+
+@Composable
+fun SplashScreen(
+    isLoading: Boolean,
+    showErrorDialog: Boolean,
+    onRetry: () -> Unit,
+) {
+    if(showErrorDialog) {
+        BaseDialog(
+            title = stringResource(R.string.dialog_server_connect_error_title),
+            content = stringResource(R.string.dialog_server_connect_error_content),
+            confirmBtnText = stringResource(R.string.dialog_server_connect_error_retry_btn),
+            isBackgroundClickable = false,
+            onCloseRequest = onRetry,
+            onConfirmRequest = onRetry,
+        )
+    }
+
+    LoadingScreen(isLoading)
+}

--- a/app/src/main/java/com/example/rentit/presentation/splash/SplashState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/splash/SplashState.kt
@@ -1,0 +1,6 @@
+package com.example.rentit.presentation.splash
+
+data class SplashState(
+    val isLoading: Boolean = false,
+    val showErrorDialog: Boolean = false
+)

--- a/app/src/main/java/com/example/rentit/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/splash/SplashViewModel.kt
@@ -1,50 +1,81 @@
 package com.example.rentit.presentation.splash
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.data.user.repository.UserRepository
+import com.example.rentit.common.exception.MissingTokenException
+import com.example.rentit.data.user.usecase.CheckUserSessionUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val TAG = "Splash"
+
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val userRepository: UserRepository
+    private val checkUserSessionUseCase: CheckUserSessionUseCase
 ) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SplashState())
+    val uiState: StateFlow<SplashState> = _uiState
 
     private val _splashSideEffect = Channel<SplashSideEffect>()
     val splashSideEffect = _splashSideEffect.receiveAsFlow()
 
     init {
-        initialize()
+        checkUserSession()
     }
 
-    private fun initialize() {
+    private fun checkUserSession() {
         viewModelScope.launch {
-            val token = userRepository.getTokenFromPrefs()
-            if(token.isNullOrEmpty()){
-                navigateToLogin()
-                return@launch
-            }
-
-            val localUserId = userRepository.getAuthUserIdFromPrefs()
-            if(localUserId == -1L){
-                userRepository.getMyInfo().onSuccess {
-                    userRepository.saveAuthUserIdToPrefs(it.data.userId)
-                }.onFailure {
-                    // 서버가 토큰 에러를 구분하지 않음 -> 500 포함 모든 에러 재로그인 유도
-                    navigateToLogin()
-                    return@launch
+            startLoading()
+            checkUserSessionUseCase.invoke()
+                .onSuccess { userId ->
+                    navigateToMain()
+                    Log.i(TAG, "사용자 정보 조회 성공: User ID $userId")
                 }
-            }
-            _splashSideEffect.send(SplashSideEffect.NavigateToMain)
+                .onFailure { e ->
+                    when(e) {
+                        is MissingTokenException -> {
+                            navigateToLogin()
+                            Log.w(TAG, "토큰 누락으로 사용자 정보 조회 실패", e)
+                        }
+                        else -> {
+                            showErrorDialog()
+                            Log.e(TAG, "사용자 정보 조회 실패 (서버/네트워크)", e)
+                        }
+                    }
+                }
+            stopLoading()
         }
     }
 
+    private fun startLoading() {
+        _uiState.value = _uiState.value.copy(isLoading = true)
+    }
+
+    private fun stopLoading() {
+        _uiState.value = _uiState.value.copy(isLoading = false)
+    }
+
+    private fun showErrorDialog() {
+        _uiState.value = _uiState.value.copy(showErrorDialog = true)
+    }
+
+    fun retryCheckUserSession() {
+        _uiState.value = _uiState.value.copy(showErrorDialog = false)
+        checkUserSession()
+    }
+
+    private suspend fun navigateToMain() {
+        _splashSideEffect.send(SplashSideEffect.NavigateToMain)
+    }
+
     private suspend fun navigateToLogin() {
-        userRepository.clearPrefs()
         _splashSideEffect.send(SplashSideEffect.NavigateToLogin)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,11 @@
     <string name="util_formatted_period">%s (%s) ~ %s (%s) · %d일</string>
     <string name="util_error_rental_period_unavailable">기간 정보 없음</string>
 
+    <!-- 서버/네트워크 에러 Dialog -->
+    <string name="dialog_server_connect_error_title">서버와 연결할 수 없어요</string>
+    <string name="dialog_server_connect_error_content">서버와 연결에 실패했어요. 다시 시도해주세요.</string>
+    <string name="dialog_server_connect_error_retry_btn">재시도</string>
+
     <!-- 로그인 -->
     <string name="screen_login_app_logo_description">랜팃 로고</string>
     <string name="screen_login_google_logo_description">구글 로고</string>


### PR DESCRIPTION
# Pull Request

## Summary  
- 앱 진입 시 token 과 userId 검사 로직은 비즈니스 로직이므로 UseCase로 분리
- userId가 비어있을 경우 조회 로직에서 토큰 없음 / 네트워크, 서버 에러를 구분
- 네트워크 또는 서버 에러가 발생한 경우 사용자에게 알림 dialog 표시

## Related Issue  
- Close: #124

## Changes  
- ViewModel의 로컬 저장소에서 token과 userId 확인하는 로직을 UseCase로 분리
- SplashScreen 추가: 로딩 상태 및 네트워크/서버 에러 Dialog 구현
- SplashState를 사용해 Loading 상태과 Dialog Visibility 관리
- 각 API 결과에 따른 Log 출력 추가
- Splash의 SideEffect 수집을 lifecycle-safe하게 변경 (UI가 STARTED 상태일 때만 네비게이션 이벤트 처리)
