### PR TITLE
Refactor/129 separate domain

### DIFF
--- a/app/src/main/java/com/example/rentit/common/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/rentit/common/di/RepositoryModule.kt
@@ -1,0 +1,35 @@
+package com.example.rentit.common.di
+
+import com.example.rentit.data.chat.repositoryImpl.ChatRepositoryImpl
+import com.example.rentit.data.product.repositoryImpl.ProductRepositoryImpl
+import com.example.rentit.data.rental.repositoryImpl.RentalRepositoryImpl
+import com.example.rentit.data.user.repositoryImpl.UserRepositoryImpl
+import com.example.rentit.domain.chat.repository.ChatRepository
+import com.example.rentit.domain.product.repository.ProductRepository
+import com.example.rentit.domain.rental.repository.RentalRepository
+import com.example.rentit.domain.user.repository.UserRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RepositoryModule {
+    @Provides
+    @Singleton
+    fun provideChatRepository(chatRepositoryImpl: ChatRepositoryImpl): ChatRepository = chatRepositoryImpl
+
+    @Provides
+    @Singleton
+    fun provideUserRepository(userRepositoryImpl: UserRepositoryImpl): UserRepository = userRepositoryImpl
+
+    @Provides
+    @Singleton
+    fun provideProductRepository(productRepositoryImpl: ProductRepositoryImpl): ProductRepository = productRepositoryImpl
+
+    @Provides
+    @Singleton
+    fun provideRentalRepository(rentalRepositoryImpl: RentalRepositoryImpl): RentalRepository = rentalRepositoryImpl
+}

--- a/app/src/main/java/com/example/rentit/common/exception/product/NotProductOwnerException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/product/NotProductOwnerException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.common.exception.product
-
-class NotProductOwnerException: Exception()

--- a/app/src/main/java/com/example/rentit/common/exception/product/ResvByOwnerException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/product/ResvByOwnerException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.common.exception.product
-
-class ResvByOwnerException(): Exception()

--- a/app/src/main/java/com/example/rentit/common/exception/rental/RentalNotFoundException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/rental/RentalNotFoundException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.common.exception.rental
-
-class RentalNotFoundException: Exception()

--- a/app/src/main/java/com/example/rentit/common/exception/rental/TooManyRequestException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/rental/TooManyRequestException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.common.exception.rental
-
-class TooManyRequestException: Exception()

--- a/app/src/main/java/com/example/rentit/data/chat/repositoryImpl/ChatRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/repositoryImpl/ChatRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.data.chat.repository
+package com.example.rentit.data.chat.repositoryImpl
 
 import android.util.Log
 import com.example.rentit.common.exception.chat.ForbiddenChatAccessException
@@ -9,13 +9,15 @@ import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
 import com.example.rentit.data.chat.dto.NewChatResponseDto
 import com.example.rentit.data.chat.remote.ChatRemoteDataSource
+import com.example.rentit.domain.chat.repository.ChatRepository
 import javax.inject.Inject
 
 private const val TAG = "ChatRepository"
 
-class ChatRepository @Inject constructor(
+class ChatRepositoryImpl @Inject constructor(
     private val chatRemoteDataSource: ChatRemoteDataSource,
-) {
+): ChatRepository {
+    override
     suspend fun getChatList(): Result<ChatListResponseDto> {
         return runCatching {
             val response = chatRemoteDataSource.getChatList()
@@ -33,6 +35,7 @@ class ChatRepository @Inject constructor(
         }
     }
 
+    override
     suspend fun getChatDetail(chatRoomMessageId: String, skip: Int, size: Int): Result<ChatDetailResponseDto> {
         return runCatching {
             val response = chatRemoteDataSource.getChatDetail(chatRoomMessageId, skip, size)
@@ -54,6 +57,7 @@ class ChatRepository @Inject constructor(
         }
     }
 
+    override
     suspend fun postNewChat(productId: Int): Result<NewChatResponseDto> {
         return runCatching {
             val response = chatRemoteDataSource.postNewChat(productId)

--- a/app/src/main/java/com/example/rentit/data/chat/repositoryImpl/ChatRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/repositoryImpl/ChatRepositoryImpl.kt
@@ -1,10 +1,10 @@
 package com.example.rentit.data.chat.repositoryImpl
 
 import android.util.Log
-import com.example.rentit.common.exception.chat.ForbiddenChatAccessException
+import com.example.rentit.domain.chat.exception.ForbiddenChatAccessException
 import com.example.rentit.common.exception.ServerException
-import com.example.rentit.common.exception.chat.ChatRoomAlreadyExistsException
-import com.example.rentit.common.exception.product.ResvByOwnerException
+import com.example.rentit.domain.chat.exception.ChatRoomAlreadyExistsException
+import com.example.rentit.domain.product.exception.ResvByOwnerException
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
 import com.example.rentit.data.chat.dto.NewChatResponseDto

--- a/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.example.rentit.data.product.repositoryImpl
 
 import com.example.rentit.common.exception.ExpiredTokenException
 import com.example.rentit.common.exception.ServerException
-import com.example.rentit.common.exception.rental.EmptyBodyException
+import com.example.rentit.domain.rental.exception.EmptyBodyException
 import com.example.rentit.data.product.dto.ResvRequestDto
 import com.example.rentit.data.product.dto.ResvResponseDto
 import com.example.rentit.data.product.dto.CategoryListResponseDto

--- a/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.data.product.repository
+package com.example.rentit.data.product.repositoryImpl
 
 import com.example.rentit.common.exception.ExpiredTokenException
 import com.example.rentit.common.exception.ServerException
@@ -12,14 +12,15 @@ import com.example.rentit.data.product.dto.ProductReservedDatesResponseDto
 import com.example.rentit.data.product.dto.ProductListResponseDto
 import com.example.rentit.data.product.dto.RequestHistoryResponseDto
 import com.example.rentit.data.product.remote.ProductRemoteDataSource
+import com.example.rentit.domain.product.repository.ProductRepository
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import javax.inject.Inject
 
-class ProductRepository @Inject constructor(
+class ProductRepositoryImpl @Inject constructor(
     private val productRemoteDataSource: ProductRemoteDataSource
-) {
-    suspend fun getProductList(): Result<ProductListResponseDto> {
+): ProductRepository {
+    override suspend fun getProductList(): Result<ProductListResponseDto> {
         return runCatching {
             val response = productRemoteDataSource.getProductList()
             if(response.isSuccessful) {
@@ -35,7 +36,7 @@ class ProductRepository @Inject constructor(
         }
     }
 
-    suspend fun getProductDetail(productId: Int): Result<ProductDetailResponseDto> {
+    override suspend fun getProductDetail(productId: Int): Result<ProductDetailResponseDto> {
         return try {
             val response = productRemoteDataSource.getProductDetail(productId)
             when(response.code()) {
@@ -59,7 +60,7 @@ class ProductRepository @Inject constructor(
         }
     }
 
-    suspend fun getReservedDates(productId: Int): Result<ProductReservedDatesResponseDto> {
+    override suspend fun getReservedDates(productId: Int): Result<ProductReservedDatesResponseDto> {
         return try {
             val response = productRemoteDataSource.getReservedDates(productId)
             when(response.code()) {
@@ -83,7 +84,7 @@ class ProductRepository @Inject constructor(
         }
     }
 
-    suspend fun postResv(productId: Int, request: ResvRequestDto): Result<ResvResponseDto> {
+    override suspend fun postResv(productId: Int, request: ResvRequestDto): Result<ResvResponseDto> {
         return try {
             val response = productRemoteDataSource.postResv(productId, request)
             when(response.code()) {
@@ -115,7 +116,7 @@ class ProductRepository @Inject constructor(
         }
     }
 
-    suspend fun getCategories(): Result<CategoryListResponseDto> {
+    override suspend fun getCategories(): Result<CategoryListResponseDto> {
         return runCatching {
             val response = productRemoteDataSource.getCategories()
             if(response.isSuccessful) {
@@ -127,7 +128,7 @@ class ProductRepository @Inject constructor(
         }
     }
 
-    suspend fun createPost(payLoad: RequestBody, thumbnailImg: MultipartBody.Part?): Result<CreatePostResponseDto> {
+    override suspend fun createPost(payLoad: RequestBody, thumbnailImg: MultipartBody.Part?): Result<CreatePostResponseDto> {
         return try {
             val response = productRemoteDataSource.createPost(payLoad, thumbnailImg)
             when(response.code()) {
@@ -151,7 +152,7 @@ class ProductRepository @Inject constructor(
         }
     }
 
-    suspend fun getProductRequestList(productId: Int): Result<RequestHistoryResponseDto> {
+    override suspend fun getProductRequestList(productId: Int): Result<RequestHistoryResponseDto> {
         return try {
             val response = productRemoteDataSource.getProductRequestList(productId)
             when(response.code()) {

--- a/app/src/main/java/com/example/rentit/data/rental/repositoryImpl/RentalRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/repositoryImpl/RentalRepositoryImpl.kt
@@ -3,8 +3,8 @@ package com.example.rentit.data.rental.repositoryImpl
 import com.example.rentit.common.enums.PhotoRegistrationType
 import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.common.exception.ServerException
-import com.example.rentit.common.exception.rental.RentalNotFoundException
-import com.example.rentit.common.exception.rental.EmptyBodyException
+import com.example.rentit.domain.rental.exception.RentalNotFoundException
+import com.example.rentit.domain.rental.exception.EmptyBodyException
 import com.example.rentit.data.rental.dto.CourierNamesResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.RentalPhotoResponseDto

--- a/app/src/main/java/com/example/rentit/data/rental/repositoryImpl/RentalRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/repositoryImpl/RentalRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.data.rental.repository
+package com.example.rentit.data.rental.repositoryImpl
 
 import com.example.rentit.common.enums.PhotoRegistrationType
 import com.example.rentit.common.exception.MissingTokenException
@@ -12,13 +12,14 @@ import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
 import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
 import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
 import com.example.rentit.data.rental.remote.RentalRemoteDataSource
+import com.example.rentit.domain.rental.repository.RentalRepository
 import okhttp3.MultipartBody
 import javax.inject.Inject
 
-class RentalRepository @Inject constructor(
+class RentalRepositoryImpl @Inject constructor(
     private val rentalRemoteDataSource: RentalRemoteDataSource
-){
-    suspend fun getRentalDetail(productId: Int, reservationId: Int): Result<RentalDetailResponseDto> {
+): RentalRepository {
+    override suspend fun getRentalDetail(productId: Int, reservationId: Int): Result<RentalDetailResponseDto> {
         return runCatching {
             val response = rentalRemoteDataSource.getRentalDetail(productId, reservationId)
             if (response.isSuccessful) {
@@ -29,7 +30,7 @@ class RentalRepository @Inject constructor(
         }
     }
 
-    suspend fun postTrackingRegistration(productId: Int, reservationId: Int, body: TrackingRegistrationRequestDto): Result<TrackingRegistrationResponseDto?> {
+    override suspend fun postTrackingRegistration(productId: Int, reservationId: Int, body: TrackingRegistrationRequestDto): Result<TrackingRegistrationResponseDto?> {
         return runCatching {
             val response = rentalRemoteDataSource.postTrackingRegistration(productId, reservationId, body)
             if (response.isSuccessful) {
@@ -40,7 +41,7 @@ class RentalRepository @Inject constructor(
         }
     }
 
-    suspend fun getCourierNames(): Result<CourierNamesResponseDto> {
+    override suspend fun getCourierNames(): Result<CourierNamesResponseDto> {
         return runCatching {
             val response = rentalRemoteDataSource.getCourierNames()
             if (response.isSuccessful) {
@@ -51,7 +52,7 @@ class RentalRepository @Inject constructor(
         }
     }
 
-    suspend fun updateRentalStatus(productId: Int, reservationId: Int, request: UpdateRentalStatusRequestDto): Result<Unit> {
+    override suspend fun updateRentalStatus(productId: Int, reservationId: Int, request: UpdateRentalStatusRequestDto): Result<Unit> {
         return runCatching {
             val response = rentalRemoteDataSource.updateRentalStatus(productId, reservationId, request)
             if (!response.isSuccessful) {
@@ -65,7 +66,7 @@ class RentalRepository @Inject constructor(
         }
     }
 
-    suspend fun postPhotoRegistration(productId: Int, reservationId: Int, type: PhotoRegistrationType, images: List<MultipartBody.Part>): Result<Unit> {
+    override suspend fun postPhotoRegistration(productId: Int, reservationId: Int, type: PhotoRegistrationType, images: List<MultipartBody.Part>): Result<Unit> {
         return runCatching {
             val response = rentalRemoteDataSource.postPhotoRegistration(productId, reservationId, type, images)
             if (!response.isSuccessful) {
@@ -75,7 +76,7 @@ class RentalRepository @Inject constructor(
         }
     }
 
-    suspend fun getRentalPhotos(productId: Int, reservationId: Int): Result<RentalPhotoResponseDto> {
+    override suspend fun getRentalPhotos(productId: Int, reservationId: Int): Result<RentalPhotoResponseDto> {
         return runCatching {
             val response = rentalRemoteDataSource.getRentalPhotos(productId, reservationId)
             if (response.isSuccessful) {

--- a/app/src/main/java/com/example/rentit/data/rental/usecase/RegisterTrackingUseCase.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/usecase/RegisterTrackingUseCase.kt
@@ -3,7 +3,7 @@ package com.example.rentit.data.rental.usecase
 import com.example.rentit.common.enums.TrackingRegistrationRequestType
 import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
 import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
-import com.example.rentit.data.rental.repository.RentalRepository
+import com.example.rentit.domain.rental.repository.RentalRepository
 import javax.inject.Inject
 
 class RegisterTrackingUseCase @Inject constructor(

--- a/app/src/main/java/com/example/rentit/data/user/repositoryImpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/user/repositoryImpl/UserRepositoryImpl.kt
@@ -2,11 +2,11 @@ package com.example.rentit.data.user.repositoryImpl
 
 import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.common.exception.ServerException
-import com.example.rentit.common.exception.rental.EmptyBodyException
-import com.example.rentit.common.exception.rental.TooManyRequestException
-import com.example.rentit.common.exception.rental.VerificationFailedException
-import com.example.rentit.common.exception.rental.VerificationRequestNotFoundException
-import com.example.rentit.common.exception.user.GoogleSsoFailedException
+import com.example.rentit.domain.rental.exception.EmptyBodyException
+import com.example.rentit.domain.rental.exception.TooManyRequestException
+import com.example.rentit.domain.rental.exception.VerificationFailedException
+import com.example.rentit.domain.rental.exception.VerificationRequestNotFoundException
+import com.example.rentit.domain.user.exception.GoogleSsoFailedException
 import com.example.rentit.data.user.dto.GoogleLoginResponseDto
 import com.example.rentit.data.user.dto.MyInfoResponseDto
 import com.example.rentit.data.user.dto.MyProductListResponseDto

--- a/app/src/main/java/com/example/rentit/data/user/repositoryImpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/user/repositoryImpl/UserRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.data.user.repository
+package com.example.rentit.data.user.repositoryImpl
 
 import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.common.exception.ServerException
@@ -14,13 +14,14 @@ import com.example.rentit.data.user.dto.MyRentalListResponseDto
 import com.example.rentit.data.user.dto.SendPhoneCodeResponseDto
 import com.example.rentit.data.user.local.UserPrefsDataSource
 import com.example.rentit.data.user.remote.UserRemoteDataSource
+import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
 
-class UserRepository @Inject constructor(
+class UserRepositoryImpl @Inject constructor(
     private val prefsDataSource: UserPrefsDataSource,
     private val remoteDataSource: UserRemoteDataSource
-) {
-    suspend fun googleLogin(code: String, redirectUri: String): Result<GoogleLoginResponseDto> {
+): UserRepository {
+    override suspend fun googleLogin(code: String, redirectUri: String): Result<GoogleLoginResponseDto> {
         return runCatching {
             val response = remoteDataSource.googleLogin(code, redirectUri)
             if (response.isSuccessful) {
@@ -32,7 +33,7 @@ class UserRepository @Inject constructor(
         }
     }
 
-    suspend fun sendPhoneCode(phoneNumber: String): Result<SendPhoneCodeResponseDto> {
+    override suspend fun sendPhoneCode(phoneNumber: String): Result<SendPhoneCodeResponseDto> {
         return runCatching {
             val response = remoteDataSource.sendPhoneCode(phoneNumber)
             if(response.isSuccessful) {
@@ -43,7 +44,7 @@ class UserRepository @Inject constructor(
         }
     }
 
-    suspend fun verifyPhoneCode(phoneNumber: String, code: String): Result<Unit> {
+    override suspend fun verifyPhoneCode(phoneNumber: String, code: String): Result<Unit> {
         return runCatching {
             val response = remoteDataSource.verifyPhoneCode(phoneNumber, code)
             if (response.isSuccessful) {
@@ -56,7 +57,7 @@ class UserRepository @Inject constructor(
         }
     }
 
-    suspend fun signUp(name: String, email: String, nickname: String, profileImageUrl: String): Result<Unit> {
+    override suspend fun signUp(name: String, email: String, nickname: String, profileImageUrl: String): Result<Unit> {
         return try {
             val response = remoteDataSource.signUp(name, email, nickname, profileImageUrl)
             when(response.code()) {
@@ -84,7 +85,7 @@ class UserRepository @Inject constructor(
         }
     }
 
-    suspend fun getMyInfo(): Result<MyInfoResponseDto> {
+    override suspend fun getMyInfo(): Result<MyInfoResponseDto> {
         return runCatching {
             val response = remoteDataSource.getMyInfo()
             if(response.isSuccessful) {
@@ -96,7 +97,7 @@ class UserRepository @Inject constructor(
         }
     }
 
-    suspend fun getMyProductList(): Result<MyProductListResponseDto> {
+    override suspend fun getMyProductList(): Result<MyProductListResponseDto> {
         return try {
             val response = remoteDataSource.getMyProductList()
             when(response.code()) {
@@ -120,7 +121,7 @@ class UserRepository @Inject constructor(
         }
     }
 
-    suspend fun getMyRentalList(): Result<MyRentalListResponseDto> {
+    override suspend fun getMyRentalList(): Result<MyRentalListResponseDto> {
         return try {
             val response = remoteDataSource.getMyRentalList()
             when(response.code()) {
@@ -144,13 +145,13 @@ class UserRepository @Inject constructor(
         }
     }
 
-    fun getAuthUserIdFromPrefs(): Long = prefsDataSource.getAuthUserIdFromPrefs()
+    override fun getAuthUserIdFromPrefs(): Long = prefsDataSource.getAuthUserIdFromPrefs()
 
-    fun saveAuthUserIdToPrefs(authUserId: Long) = prefsDataSource.saveAuthUserIdToPrefs(authUserId)
+    override fun saveAuthUserIdToPrefs(authUserId: Long) = prefsDataSource.saveAuthUserIdToPrefs(authUserId)
 
-    fun getTokenFromPrefs(): String? = prefsDataSource.getTokenFromPrefs()
+    override fun getTokenFromPrefs(): String? = prefsDataSource.getTokenFromPrefs()
 
-    fun saveTokenToPrefs(token: String) = prefsDataSource.saveTokenToPrefs(token)
+    override fun saveTokenToPrefs(token: String) = prefsDataSource.saveTokenToPrefs(token)
 
-    fun clearPrefs() = prefsDataSource.clearPrefs()
+    override fun clearPrefs() = prefsDataSource.clearPrefs()
 }

--- a/app/src/main/java/com/example/rentit/di/EncryptedSharedPrefsModule.kt
+++ b/app/src/main/java/com/example/rentit/di/EncryptedSharedPrefsModule.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.common.di
+package com.example.rentit.di
 
 import android.content.Context
 import android.content.SharedPreferences

--- a/app/src/main/java/com/example/rentit/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/rentit/di/NetworkModule.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.common.di
+package com.example.rentit.di
 
 import com.example.rentit.data.user.local.UserPrefsDataSource
 import dagger.Module

--- a/app/src/main/java/com/example/rentit/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/rentit/di/RepositoryModule.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.common.di
+package com.example.rentit.di
 
 import com.example.rentit.data.chat.repositoryImpl.ChatRepositoryImpl
 import com.example.rentit.data.product.repositoryImpl.ProductRepositoryImpl

--- a/app/src/main/java/com/example/rentit/di/ServiceModule.kt
+++ b/app/src/main/java/com/example/rentit/di/ServiceModule.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.common.di
+package com.example.rentit.di
 
 import com.example.rentit.data.chat.remote.ChatApiService
 import com.example.rentit.data.product.remote.ProductApiService
@@ -13,7 +13,7 @@ import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
-object ApiModule {
+object ServiceModule {
     @Provides
     fun provideChatApiService(retrofit: Retrofit): ChatApiService {
         return retrofit.create(ChatApiService::class.java)

--- a/app/src/main/java/com/example/rentit/domain/chat/exception/ChatRoomAlreadyExistsException.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/exception/ChatRoomAlreadyExistsException.kt
@@ -1,3 +1,3 @@
-package com.example.rentit.common.exception.chat
+package com.example.rentit.domain.chat.exception
 
 class ChatRoomAlreadyExistsException: Exception()

--- a/app/src/main/java/com/example/rentit/domain/chat/exception/ForbiddenChatAccessException.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/exception/ForbiddenChatAccessException.kt
@@ -1,3 +1,3 @@
-package com.example.rentit.common.exception.chat
+package com.example.rentit.domain.chat.exception
 
 class ForbiddenChatAccessException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/chat/repository/ChatRepository.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/repository/ChatRepository.kt
@@ -1,0 +1,13 @@
+package com.example.rentit.domain.chat.repository
+
+import com.example.rentit.data.chat.dto.ChatDetailResponseDto
+import com.example.rentit.data.chat.dto.ChatListResponseDto
+import com.example.rentit.data.chat.dto.NewChatResponseDto
+
+interface ChatRepository {
+    suspend fun getChatList(): Result<ChatListResponseDto>
+
+    suspend fun getChatDetail(chatRoomMessageId: String, skip: Int, size: Int): Result<ChatDetailResponseDto>
+
+    suspend fun postNewChat(productId: Int): Result<NewChatResponseDto>
+}

--- a/app/src/main/java/com/example/rentit/domain/product/exception/NotProductOwnerException.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/exception/NotProductOwnerException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.product.exception
-
-class NotProductOwnerException: Exception()

--- a/app/src/main/java/com/example/rentit/domain/product/exception/NotProductOwnerException.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/exception/NotProductOwnerException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.domain.product.exception
+
+class NotProductOwnerException: Exception()

--- a/app/src/main/java/com/example/rentit/domain/product/exception/ResvByOwnerException.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/exception/ResvByOwnerException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.domain.product.exception
+
+class ResvByOwnerException(): Exception()

--- a/app/src/main/java/com/example/rentit/domain/product/model/Category.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/model/Category.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.data.product.model
+package com.example.rentit.domain.product.model
 
 data class Category (
     val name: String,

--- a/app/src/main/java/com/example/rentit/domain/product/model/ProductWithCategory.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/model/ProductWithCategory.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.data.product.model
+package com.example.rentit.domain.product.model
 
 import com.example.rentit.common.enums.ProductStatus
 

--- a/app/src/main/java/com/example/rentit/domain/product/repository/ProductRepository.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/repository/ProductRepository.kt
@@ -1,0 +1,28 @@
+package com.example.rentit.domain.product.repository
+
+import com.example.rentit.data.product.dto.ResvRequestDto
+import com.example.rentit.data.product.dto.ResvResponseDto
+import com.example.rentit.data.product.dto.CategoryListResponseDto
+import com.example.rentit.data.product.dto.CreatePostResponseDto
+import com.example.rentit.data.product.dto.ProductDetailResponseDto
+import com.example.rentit.data.product.dto.ProductReservedDatesResponseDto
+import com.example.rentit.data.product.dto.ProductListResponseDto
+import com.example.rentit.data.product.dto.RequestHistoryResponseDto
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+
+interface ProductRepository {
+    suspend fun getProductList(): Result<ProductListResponseDto>
+
+    suspend fun getProductDetail(productId: Int): Result<ProductDetailResponseDto>
+
+    suspend fun getReservedDates(productId: Int): Result<ProductReservedDatesResponseDto>
+
+    suspend fun postResv(productId: Int, request: ResvRequestDto): Result<ResvResponseDto>
+
+    suspend fun getCategories(): Result<CategoryListResponseDto>
+
+    suspend fun createPost(payLoad: RequestBody, thumbnailImg: MultipartBody.Part?): Result<CreatePostResponseDto>
+
+    suspend fun getProductRequestList(productId: Int): Result<RequestHistoryResponseDto>
+}

--- a/app/src/main/java/com/example/rentit/domain/product/usecase/GetCategoryMapUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/usecase/GetCategoryMapUseCase.kt
@@ -1,7 +1,7 @@
-package com.example.rentit.data.product.usecase
+package com.example.rentit.domain.product.usecase
 
-import com.example.rentit.data.product.model.Category
-import com.example.rentit.data.product.repository.ProductRepository
+import com.example.rentit.domain.product.model.Category
+import com.example.rentit.domain.product.repository.ProductRepository
 import javax.inject.Inject
 
 class GetCategoryMapUseCase @Inject constructor(

--- a/app/src/main/java/com/example/rentit/domain/product/usecase/GetProductListWithCategoryUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/usecase/GetProductListWithCategoryUseCase.kt
@@ -1,8 +1,8 @@
-package com.example.rentit.data.product.usecase
+package com.example.rentit.domain.product.usecase
 
-import com.example.rentit.data.product.model.Category
-import com.example.rentit.data.product.model.ProductWithCategory
-import com.example.rentit.data.product.repository.ProductRepository
+import com.example.rentit.domain.product.model.Category
+import com.example.rentit.domain.product.model.ProductWithCategory
+import com.example.rentit.domain.product.repository.ProductRepository
 import javax.inject.Inject
 
 class GetProductListWithCategoryUseCase @Inject constructor(

--- a/app/src/main/java/com/example/rentit/domain/rental/exception/EmptyBodyException.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/exception/EmptyBodyException.kt
@@ -1,3 +1,3 @@
-package com.example.rentit.common.exception.rental
+package com.example.rentit.domain.rental.exception
 
 class EmptyBodyException(message: String = "Empty response body"): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/rental/exception/RentalNotFoundException.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/exception/RentalNotFoundException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.domain.rental.exception
+
+class RentalNotFoundException: Exception()

--- a/app/src/main/java/com/example/rentit/domain/rental/exception/TooManyRequestException.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/exception/TooManyRequestException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.domain.rental.exception
+
+class TooManyRequestException: Exception()

--- a/app/src/main/java/com/example/rentit/domain/rental/exception/VerificationFailedException.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/exception/VerificationFailedException.kt
@@ -1,3 +1,3 @@
-package com.example.rentit.common.exception.rental
+package com.example.rentit.domain.rental.exception
 
 class VerificationFailedException(message: String) : Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/rental/exception/VerificationRequestNotFoundException.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/exception/VerificationRequestNotFoundException.kt
@@ -1,3 +1,3 @@
-package com.example.rentit.common.exception.rental
+package com.example.rentit.domain.rental.exception
 
 class VerificationRequestNotFoundException : Exception()

--- a/app/src/main/java/com/example/rentit/domain/rental/repository/RentalRepository.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/repository/RentalRepository.kt
@@ -1,0 +1,24 @@
+package com.example.rentit.domain.rental.repository
+
+import com.example.rentit.common.enums.PhotoRegistrationType
+import com.example.rentit.data.rental.dto.CourierNamesResponseDto
+import com.example.rentit.data.rental.dto.RentalDetailResponseDto
+import com.example.rentit.data.rental.dto.RentalPhotoResponseDto
+import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
+import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
+import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
+import okhttp3.MultipartBody
+
+interface RentalRepository {
+    suspend fun getRentalDetail(productId: Int, reservationId: Int): Result<RentalDetailResponseDto>
+
+    suspend fun postTrackingRegistration(productId: Int, reservationId: Int, body: TrackingRegistrationRequestDto): Result<TrackingRegistrationResponseDto?>
+
+    suspend fun getCourierNames(): Result<CourierNamesResponseDto>
+
+    suspend fun updateRentalStatus(productId: Int, reservationId: Int, request: UpdateRentalStatusRequestDto): Result<Unit>
+
+    suspend fun postPhotoRegistration(productId: Int, reservationId: Int, type: PhotoRegistrationType, images: List<MultipartBody.Part>): Result<Unit>
+
+    suspend fun getRentalPhotos(productId: Int, reservationId: Int): Result<RentalPhotoResponseDto>
+}

--- a/app/src/main/java/com/example/rentit/domain/rental/usecase/RegisterTrackingUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/usecase/RegisterTrackingUseCase.kt
@@ -1,4 +1,4 @@
-package com.example.rentit.data.rental.usecase
+package com.example.rentit.domain.rental.usecase
 
 import com.example.rentit.common.enums.TrackingRegistrationRequestType
 import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto

--- a/app/src/main/java/com/example/rentit/domain/user/exception/GoogleSsoFailedException.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/exception/GoogleSsoFailedException.kt
@@ -1,3 +1,3 @@
-package com.example.rentit.common.exception.user
+package com.example.rentit.domain.user.exception
 
 class GoogleSsoFailedException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/user/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/repository/UserRepository.kt
@@ -1,0 +1,33 @@
+package com.example.rentit.domain.user.repository
+
+import com.example.rentit.data.user.dto.GoogleLoginResponseDto
+import com.example.rentit.data.user.dto.MyInfoResponseDto
+import com.example.rentit.data.user.dto.MyProductListResponseDto
+import com.example.rentit.data.user.dto.MyRentalListResponseDto
+import com.example.rentit.data.user.dto.SendPhoneCodeResponseDto
+
+interface UserRepository {
+    suspend fun googleLogin(code: String, redirectUri: String): Result<GoogleLoginResponseDto>
+
+    suspend fun sendPhoneCode(phoneNumber: String): Result<SendPhoneCodeResponseDto>
+
+    suspend fun verifyPhoneCode(phoneNumber: String, code: String): Result<Unit>
+
+    suspend fun signUp(name: String, email: String, nickname: String, profileImageUrl: String): Result<Unit>
+
+    suspend fun getMyInfo(): Result<MyInfoResponseDto>
+
+    suspend fun getMyProductList(): Result<MyProductListResponseDto>
+
+    suspend fun getMyRentalList(): Result<MyRentalListResponseDto>
+
+    fun getAuthUserIdFromPrefs(): Long
+
+    fun saveAuthUserIdToPrefs(authUserId: Long)
+
+    fun getTokenFromPrefs(): String?
+
+    fun saveTokenToPrefs(token: String)
+
+    fun clearPrefs()
+}

--- a/app/src/main/java/com/example/rentit/domain/user/usecase/CheckUserSessionUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/usecase/CheckUserSessionUseCase.kt
@@ -1,7 +1,7 @@
-package com.example.rentit.data.user.usecase
+package com.example.rentit.domain.user.usecase
 
 import com.example.rentit.common.exception.MissingTokenException
-import com.example.rentit.data.user.repository.UserRepository
+import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
 
 class CheckUserSessionUseCase @Inject constructor(

--- a/app/src/main/java/com/example/rentit/domain/user/usecase/InitializeAuthUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/usecase/InitializeAuthUseCase.kt
@@ -1,6 +1,6 @@
-package com.example.rentit.data.user.usecase
+package com.example.rentit.domain.user.usecase
 
-import com.example.rentit.data.user.repository.UserRepository
+import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
 
 class InitializeAuthUseCase @Inject constructor(

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/nickname/JoinNicknameViewModel.kt
@@ -2,7 +2,7 @@ package com.example.rentit.presentation.auth.join.nickname
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.data.user.repository.UserRepository
+import com.example.rentit.domain.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/phoneverification/JoinPhoneVerificationViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/phoneverification/JoinPhoneVerificationViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.exception.rental.TooManyRequestException
 import com.example.rentit.common.exception.rental.VerificationFailedException
 import com.example.rentit.common.exception.rental.VerificationRequestNotFoundException
-import com.example.rentit.data.user.repository.UserRepository
+import com.example.rentit.domain.user.repository.UserRepository
 import com.example.rentit.presentation.auth.join.phoneverification.model.VerificationError
 import com.example.rentit.presentation.auth.join.phoneverification.model.toUiMessage
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/phoneverification/JoinPhoneVerificationViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/phoneverification/JoinPhoneVerificationViewModel.kt
@@ -2,9 +2,9 @@ package com.example.rentit.presentation.auth.join.phoneverification
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.common.exception.rental.TooManyRequestException
-import com.example.rentit.common.exception.rental.VerificationFailedException
-import com.example.rentit.common.exception.rental.VerificationRequestNotFoundException
+import com.example.rentit.domain.rental.exception.TooManyRequestException
+import com.example.rentit.domain.rental.exception.VerificationFailedException
+import com.example.rentit.domain.rental.exception.VerificationRequestNotFoundException
 import com.example.rentit.domain.user.repository.UserRepository
 import com.example.rentit.presentation.auth.join.phoneverification.model.VerificationError
 import com.example.rentit.presentation.auth.join.phoneverification.model.toUiMessage

--- a/app/src/main/java/com/example/rentit/presentation/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/login/LoginViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.example.rentit.BuildConfig
 import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.common.exception.user.GoogleSsoFailedException
-import com.example.rentit.data.user.repository.UserRepository
-import com.example.rentit.data.user.usecase.InitializeAuthUseCase
+import com.example.rentit.domain.user.repository.UserRepository
+import com.example.rentit.domain.user.usecase.InitializeAuthUseCase
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.common.api.ApiException
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/example/rentit/presentation/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/login/LoginViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.BuildConfig
 import com.example.rentit.common.exception.MissingTokenException
-import com.example.rentit.common.exception.user.GoogleSsoFailedException
+import com.example.rentit.domain.user.exception.GoogleSsoFailedException
 import com.example.rentit.domain.user.repository.UserRepository
 import com.example.rentit.domain.user.usecase.InitializeAuthUseCase
 import com.google.android.gms.auth.api.signin.GoogleSignIn

--- a/app/src/main/java/com/example/rentit/presentation/chat/ChatListViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/ChatListViewModel.kt
@@ -3,7 +3,7 @@ package com.example.rentit.presentation.chat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.data.chat.dto.ChatRoomSummaryDto
-import com.example.rentit.data.chat.repository.ChatRepository
+import com.example.rentit.domain.chat.repository.ChatRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
@@ -55,7 +55,7 @@ import com.example.rentit.common.component.CommonBorders
 import com.example.rentit.common.component.CommonTopAppBar
 import com.example.rentit.common.component.LoadableUrlImage
 import com.example.rentit.common.component.screenHorizontalPadding
-import com.example.rentit.common.exception.chat.ForbiddenChatAccessException
+import com.example.rentit.domain.chat.exception.ForbiddenChatAccessException
 import com.example.rentit.common.exception.ServerException
 import com.example.rentit.common.theme.Gray100
 import com.example.rentit.common.theme.Gray400

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomViewModel.kt
@@ -8,12 +8,12 @@ import com.example.rentit.common.enums.AutoMsgType
 import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.websocket.WebSocketManager
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
-import com.example.rentit.data.chat.repository.ChatRepository
 import com.example.rentit.data.product.dto.ProductDetailResponseDto
-import com.example.rentit.data.product.repository.ProductRepository
 import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
-import com.example.rentit.data.rental.repository.RentalRepository
-import com.example.rentit.data.user.repository.UserRepository
+import com.example.rentit.domain.chat.repository.ChatRepository
+import com.example.rentit.domain.product.repository.ProductRepository
+import com.example.rentit.domain.rental.repository.RentalRepository
+import com.example.rentit.domain.user.repository.UserRepository
 import com.example.rentit.presentation.chat.chatroom.model.ChatMessageUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeScreen.kt
@@ -46,7 +46,7 @@ import com.example.rentit.common.component.dialog.BaseDialog
 import com.example.rentit.common.component.layout.LoadingScreen
 import com.example.rentit.common.theme.Gray200
 import com.example.rentit.common.theme.PrimaryBlue500
-import com.example.rentit.data.product.model.ProductWithCategory
+import com.example.rentit.domain.product.model.ProductWithCategory
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeState.kt
@@ -1,8 +1,8 @@
 package com.example.rentit.presentation.home
 
 import com.example.rentit.common.enums.ProductStatus
-import com.example.rentit.data.product.model.Category
-import com.example.rentit.data.product.model.ProductWithCategory
+import com.example.rentit.domain.product.model.Category
+import com.example.rentit.domain.product.model.ProductWithCategory
 
 data class HomeState(
     val productList: List<ProductWithCategory> = emptyList(),

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeViewModel.kt
@@ -3,8 +3,8 @@ package com.example.rentit.presentation.home
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.data.product.usecase.GetCategoryMapUseCase
-import com.example.rentit.data.product.usecase.GetProductListWithCategoryUseCase
+import com.example.rentit.domain.product.usecase.GetCategoryMapUseCase
+import com.example.rentit.domain.product.usecase.GetProductListWithCategoryUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/example/rentit/presentation/main/createpost/CreatePostViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/main/createpost/CreatePostViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.rentit.data.product.dto.CategoryDto
 import com.example.rentit.data.product.dto.CreatePostRequestDto
 import com.example.rentit.data.product.dto.CreatePostResponseDto
-import com.example.rentit.data.product.repository.ProductRepository
+import com.example.rentit.domain.product.repository.ProductRepository
 import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.data.product.dto.ProductDto
 import com.example.rentit.data.user.dto.ReservationDto
-import com.example.rentit.data.user.repository.UserRepository
+import com.example.rentit.domain.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/example/rentit/presentation/pay/PayViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/pay/PayViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.uimodel.RentalSummaryUiModel
 import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
-import com.example.rentit.data.rental.repository.RentalRepository
+import com.example.rentit.domain.rental.repository.RentalRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/ProductDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/ProductDetailViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.enums.ResvStatus
 import com.example.rentit.data.product.dto.ProductDetailResponseDto
 import com.example.rentit.data.product.dto.RequestInfoDto
-import com.example.rentit.data.product.repository.ProductRepository
-import com.example.rentit.data.user.repository.UserRepository
+import com.example.rentit.domain.product.repository.ProductRepository
+import com.example.rentit.domain.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/rentalhistory/RentalHistoryViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/rentalhistory/RentalHistoryViewModel.kt
@@ -2,7 +2,7 @@ package com.example.rentit.presentation.productdetail.rentalhistory
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.data.product.repository.ProductRepository
+import com.example.rentit.domain.product.repository.ProductRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.util.inclusiveDaysBetween
 import com.example.rentit.data.product.dto.ResvRequestDto
 import com.example.rentit.data.product.dto.ResvResponseDto
-import com.example.rentit.data.product.repository.ProductRepository
+import com.example.rentit.domain.product.repository.ProductRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/requesthistory/RequestHistoryViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/requesthistory/RequestHistoryViewModel.kt
@@ -3,9 +3,9 @@ package com.example.rentit.presentation.productdetail.reservation.requesthistory
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.enums.ResvStatus
-import com.example.rentit.data.chat.repository.ChatRepository
 import com.example.rentit.data.product.dto.RequestInfoDto
-import com.example.rentit.data.product.repository.ProductRepository
+import com.example.rentit.domain.chat.repository.ChatRepository
+import com.example.rentit.domain.product.repository.ProductRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -9,8 +9,8 @@ import com.example.rentit.common.enums.TrackingRegistrationRequestType
 import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.common.uimodel.RequestAcceptDialogUiModel
 import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
-import com.example.rentit.data.rental.repository.RentalRepository
 import com.example.rentit.data.rental.usecase.RegisterTrackingUseCase
+import com.example.rentit.domain.rental.repository.RentalRepository
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailViewModel.kt
@@ -9,7 +9,7 @@ import com.example.rentit.common.enums.TrackingRegistrationRequestType
 import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.common.uimodel.RequestAcceptDialogUiModel
 import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
-import com.example.rentit.data.rental.usecase.RegisterTrackingUseCase
+import com.example.rentit.domain.rental.usecase.RegisterTrackingUseCase
 import com.example.rentit.domain.rental.repository.RentalRepository
 import com.example.rentit.presentation.rentaldetail.owner.stateui.OwnerRentalStatusUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/photobeforerent/PhotoBeforeRentViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/photobeforerent/PhotoBeforeRentViewModel.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.enums.PhotoRegistrationType
-import com.example.rentit.data.rental.repository.RentalRepository
+import com.example.rentit.domain.rental.repository.RentalRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/rentalphotocheck/RentalPhotoCheckViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/rentalphotocheck/RentalPhotoCheckViewModel.kt
@@ -2,7 +2,7 @@ package com.example.rentit.presentation.rentaldetail.rentalphotocheck
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.data.rental.repository.RentalRepository
+import com.example.rentit.domain.rental.repository.RentalRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
@@ -8,7 +8,7 @@ import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.enums.TrackingRegistrationRequestType
 import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
-import com.example.rentit.data.rental.usecase.RegisterTrackingUseCase
+import com.example.rentit.domain.rental.usecase.RegisterTrackingUseCase
 import com.example.rentit.domain.rental.repository.RentalRepository
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailViewModel.kt
@@ -8,8 +8,8 @@ import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.enums.TrackingRegistrationRequestType
 import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
-import com.example.rentit.data.rental.repository.RentalRepository
 import com.example.rentit.data.rental.usecase.RegisterTrackingUseCase
+import com.example.rentit.domain.rental.repository.RentalRepository
 import com.example.rentit.presentation.rentaldetail.renter.stateui.RenterRentalStatusUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/photobeforereturn/PhotoBeforeReturnViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/photobeforereturn/PhotoBeforeReturnViewModel.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.enums.PhotoRegistrationType
-import com.example.rentit.data.rental.repository.RentalRepository
+import com.example.rentit.domain.rental.repository.RentalRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/example/rentit/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/splash/SplashViewModel.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.exception.MissingTokenException
-import com.example.rentit.data.user.usecase.CheckUserSessionUseCase
+import com.example.rentit.domain.user.usecase.CheckUserSessionUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow


### PR DESCRIPTION
# Pull Request

## Summary  
- `data` 패키지에서 비즈니스 로직을 `domain`으로 분리

## Related Issue  
- Close: #129 

## Changes  
- `domain` 패키지를 생성하고, 도메인 별로 usecase과 model을 구분하여 배치
- Repository 인터페이스 및 DI 모듈 추가
- `di` 패키지를 `common`에서 최상위 패키지로 이동
- `common`에 있던 exception을 도메인별로 `domain` 패키지 아래로 이동
- 사용하지 않는 `NotProductOwnerException` 제거

```  
├── data     // 구현체, 데이터 소스
│   ├── dto      // Retrofit Dto
│   ├── remote    // API
│   ├── repositoryImpl  // Repository 구현체
│   └── local    // SharedPref
├── di     // 의존성 주입 관련 모듈
└── domain   // 비즈니스 로직, 규칙
    ├── exception     // 도메인별 예외 클래스
    ├── model     // Domain Model
    ├── repository // Repository 인터페이스
    └── usecase   // UseCase
```
