### PR TITLE
Bugfix/153 null date parse

### DIFF
--- a/app/src/main/java/com/example/rentit/domain/chat/usecase/GetChatRoomSummariesUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/usecase/GetChatRoomSummariesUseCase.kt
@@ -16,7 +16,7 @@ class GetChatRoomSummariesUseCase @Inject constructor(
             val chatList = chatRepository.getChatList().getOrThrow().chatRooms
 
             chatList.map {
-                val localDateTime = OffsetDateTime.parse(it.lastMessageTime)
+                val localDateTime = it.lastMessageTime?.let { time -> OffsetDateTime.parse(time) }
                 ChatRoomSummaryModel(
                     chatRoomId = it.chatRoomId,
                     productTitle = it.productTitle,

--- a/app/src/main/java/com/example/rentit/domain/chat/usecase/GetChatRoomSummariesUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/usecase/GetChatRoomSummariesUseCase.kt
@@ -16,14 +16,14 @@ class GetChatRoomSummariesUseCase @Inject constructor(
             val chatList = chatRepository.getChatList().getOrThrow().chatRooms
 
             chatList.map {
-                val localDateTime = it.lastMessageTime?.let { time -> OffsetDateTime.parse(time) }
+                val parsedLastMessageTime = it.lastMessageTime?.let { time -> OffsetDateTime.parse(time) }
                 ChatRoomSummaryModel(
                     chatRoomId = it.chatRoomId,
                     productTitle = it.productTitle,
                     thumbnailImgUrl = it.thumbnailImgUrl,
                     partnerNickname = it.partnerNickname,
                     lastMessage = it.lastMessage,
-                    lastMessageTime = localDateTime
+                    lastMessageTime = parsedLastMessageTime
                 )
             }
         }

--- a/app/src/main/java/com/example/rentit/presentation/chat/ChatListViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/ChatListViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.rentit.presentation.chat
 
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -11,6 +12,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.io.IOException
 import javax.inject.Inject
+
+private const val TAG = "ChatList"
 
 @RequiresApi(Build.VERSION_CODES.O)
 @HiltViewModel
@@ -31,14 +34,17 @@ class ChatListViewModel @Inject constructor(
             getChatRoomSummariesUseCase.invoke()
                 .onSuccess {
                     _uiState.value = _uiState.value.copy(chatRoomSummaries = it)
+                    Log.i(TAG, "채팅 리스트 가져오기 성공: 채팅방 ${it.size}개")
                 }
                 .onFailure { e ->
                     when (e) {
                         is IOException -> {
                             showNetworkErrorDialog()
+                            Log.e(TAG, "네트워크 에러: 채팅 리스트 가져오기 실패", e)
                         }
                         else -> {
                             showServerErrorDialog()
+                            Log.e(TAG, "채팅 리스트 가져오기 실패", e)
                         }
                         // TODO: 토큰 에러 처리 필요 (리프레시 토큰으로 재발급 또는 로그인 화면 이동)
                     }


### PR DESCRIPTION
# Pull Request

## Summary
- 채팅방 리스트에서 `lastMessageTime`을 OffsetDateTime으로 파싱할 때 null 가능성을 처리하도록 수정
- `ChatListViewModel`에서 데이터 fetch 결과에 따른 로그 출력 개선

## Related Issue
- Close: #135

## Changes
- `GetChatRoomSummariesUseCase`에서 `lastMessageTime`이 null이 아닐 때만 OffsetDateTime으로 파싱
- 파싱한 날짜 변수명을 `parsedLastMessageTime`으로 변경
- `ChatListViewModel`에서 채팅방 리스트 fetch 성공/실패 시 로그 추가
