### PR TITLE
Bugfix/137 error dialog not close

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/dialog/BaseDialog.kt
+++ b/app/src/main/java/com/example/rentit/common/component/dialog/BaseDialog.kt
@@ -42,12 +42,12 @@ fun BaseDialog(
     closeBtnText: String? = null,
     confirmBtnText: String,
     isBackgroundClickable: Boolean = true,
-    onCloseRequest: () -> Unit = {},
+    onDismissRequest: () -> Unit,
     onConfirmRequest: () -> Unit,
     customContent: @Composable ColumnScope.() -> Unit = {}
 ) {
     Dialog(
-        onDismissRequest = onCloseRequest
+        onDismissRequest = onDismissRequest
     ) {
         Box(
             modifier = Modifier
@@ -58,7 +58,7 @@ fun BaseDialog(
                     enabled = isBackgroundClickable,
                     // 터치 효과 제거
                     indication = null,
-                    interactionSource = remember { MutableInteractionSource() }) { onCloseRequest() },
+                    interactionSource = remember { MutableInteractionSource() }) { onDismissRequest() },
             contentAlignment = Alignment.Center
         ) {
             Column(
@@ -93,7 +93,7 @@ fun BaseDialog(
                 ) {
                     if (!closeBtnText.isNullOrEmpty())
                         TextButton(
-                            onClick = onCloseRequest,
+                            onClick = onDismissRequest,
                         ) {
                             Text(closeBtnText)
                         }
@@ -122,7 +122,7 @@ private fun Preview() {
             content = "Dialog 세부 내용",
             closeBtnText = null,
             confirmBtnText = "확인",
-            onCloseRequest = {},
+            onDismissRequest = {},
             onConfirmRequest = {},
         )
     }

--- a/app/src/main/java/com/example/rentit/common/component/dialog/NetworkErrorDialog.kt
+++ b/app/src/main/java/com/example/rentit/common/component/dialog/NetworkErrorDialog.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.res.stringResource
 import com.example.rentit.R
 
 @Composable
-fun NetworkErrorDialog(navigateBack: () -> Unit = {}, onRetry: () -> Unit = {}) {
+fun NetworkErrorDialog(navigateBack: () -> Unit, onRetry: () -> Unit) {
     BaseDialog(
         title = stringResource(R.string.dialog_network_error_title),
         content = stringResource(R.string.dialog_network_error_content),

--- a/app/src/main/java/com/example/rentit/common/component/dialog/NetworkErrorDialog.kt
+++ b/app/src/main/java/com/example/rentit/common/component/dialog/NetworkErrorDialog.kt
@@ -5,12 +5,13 @@ import androidx.compose.ui.res.stringResource
 import com.example.rentit.R
 
 @Composable
-fun NetworkErrorDialog(onRetry: () -> Unit = {}) {
+fun NetworkErrorDialog(navigateBack: () -> Unit = {}, onRetry: () -> Unit = {}) {
     BaseDialog(
         title = stringResource(R.string.dialog_network_error_title),
         content = stringResource(R.string.dialog_network_error_content),
         confirmBtnText = stringResource(R.string.dialog_network_error_retry_btn),
         isBackgroundClickable = false,
+        onDismissRequest = navigateBack,
         onConfirmRequest = onRetry,
     )
 }

--- a/app/src/main/java/com/example/rentit/common/component/dialog/RequestAcceptDialog.kt
+++ b/app/src/main/java/com/example/rentit/common/component/dialog/RequestAcceptDialog.kt
@@ -25,14 +25,14 @@ import com.example.rentit.common.util.formatRentalPeriod
 @Composable
 fun RequestAcceptDialog(
     uiModel: RequestAcceptDialogUiModel,
-    onClose: () -> Unit,
+    onDismiss: () -> Unit,
     onAccept: () -> Unit,
 ) {
     BaseDialog(
         title = stringResource(R.string.common_dialog_accept_request_title),
         confirmBtnText = stringResource(R.string.common_dialog_accept_request_btn_accept),
         closeBtnText = stringResource(R.string.common_dialog_btn_close),
-        onCloseRequest = onClose,
+        onDismissRequest = onDismiss,
         onConfirmRequest = onAccept
     ) {
         Text(
@@ -73,7 +73,7 @@ private fun Preview() {
             "2025-08-17",
             "2025-08-20",
             40000),
-            onClose = {},
+            onDismiss = {},
             onAccept = {})
     }
 }

--- a/app/src/main/java/com/example/rentit/common/component/dialog/ServerErrorDialog.kt
+++ b/app/src/main/java/com/example/rentit/common/component/dialog/ServerErrorDialog.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.res.stringResource
 import com.example.rentit.R
 
 @Composable
-fun ServerErrorDialog(navigateBack: () -> Unit = {}, onRetry: () -> Unit = {}) {
+fun ServerErrorDialog(navigateBack: () -> Unit, onRetry: () -> Unit) {
     BaseDialog(
         title = stringResource(R.string.dialog_server_error_title),
         content = stringResource(R.string.dialog_server_error_content),

--- a/app/src/main/java/com/example/rentit/common/component/dialog/ServerErrorDialog.kt
+++ b/app/src/main/java/com/example/rentit/common/component/dialog/ServerErrorDialog.kt
@@ -5,12 +5,13 @@ import androidx.compose.ui.res.stringResource
 import com.example.rentit.R
 
 @Composable
-fun ServerErrorDialog(onRetry: () -> Unit = {}) {
+fun ServerErrorDialog(navigateBack: () -> Unit = {}, onRetry: () -> Unit = {}) {
     BaseDialog(
         title = stringResource(R.string.dialog_server_error_title),
         content = stringResource(R.string.dialog_server_error_content),
         confirmBtnText = stringResource(R.string.dialog_server_error_retry_btn),
         isBackgroundClickable = false,
+        onDismissRequest = navigateBack,
         onConfirmRequest = onRetry,
     )
 }

--- a/app/src/main/java/com/example/rentit/presentation/chat/ChatListRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/ChatListRoute.kt
@@ -20,6 +20,7 @@ fun ChatListRoute(navHostController: NavHostController) {
         isLoading = uiState.isLoading,
         showNetworkErrorDialog = uiState.showNetworkErrorDialog,
         showServerErrorDialog = uiState.showServerErrorDialog,
+        navigateBack = navHostController::popBackStack,
         onRetry = chatListViewModel::retryFetchChatRoomSummaries,
         onItemClick = { navHostController.navigateToChatRoom(it) }
     )

--- a/app/src/main/java/com/example/rentit/presentation/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/ChatListScreen.kt
@@ -53,6 +53,7 @@ fun ChatListScreen(
     showNetworkErrorDialog: Boolean = false,
     showServerErrorDialog: Boolean = false,
     onItemClick: (String) -> Unit = {},
+    navigateBack: () -> Unit = {},
     onRetry: () -> Unit = {},
 ) {
     Column(Modifier
@@ -72,9 +73,9 @@ fun ChatListScreen(
 
     LoadingScreen(isLoading)
 
-    if(showNetworkErrorDialog) NetworkErrorDialog(onRetry)
+    if(showNetworkErrorDialog) NetworkErrorDialog(navigateBack, onRetry)
 
-    if(showServerErrorDialog) ServerErrorDialog(onRetry)
+    if(showServerErrorDialog) ServerErrorDialog(navigateBack, onRetry)
 }
 
 @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomRoute.kt
@@ -51,10 +51,10 @@ fun ChatroomRoute(navHostController: NavHostController, chatRoomId: String) {
         showNetworkErrorDialog = uiState.showNetworkErrorDialog,
         showServerErrorDialog = uiState.showServerErrorDialog,
         showForbiddenChatAccessDialog = uiState.showForbiddenChatAccessDialog,
-        onBackClick = navHostController::popBackStack,
         onRetry = { viewModel.retryFetchChatRoomData(chatRoomId) },
         onForbiddenDialogDismiss = navHostController::popBackStack,
         onMessageChange = { messageValue = it },
-        onMessageSend = { viewModel.sendMessage(chatRoomId, messageValue.text) }
+        onMessageSend = { viewModel.sendMessage(chatRoomId, messageValue.text) },
+        navigateBack = navHostController::popBackStack
     )
 }

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
@@ -132,6 +132,7 @@ fun ChatroomScreen(
             title = stringResource(R.string.dialog_forbidden_chat_access_title),
             confirmBtnText = stringResource(R.string.dialog_forbidden_chat_access_btn),
             isBackgroundClickable = false,
+            onDismissRequest = {},
             onConfirmRequest = onForbiddenDialogDismiss,
         )
     }

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomScreen.kt
@@ -76,15 +76,15 @@ fun ChatroomScreen(
     showNetworkErrorDialog: Boolean = false,
     showServerErrorDialog: Boolean = false,
     showForbiddenChatAccessDialog: Boolean = false,
-    onBackClick: () -> Unit,
     onForbiddenDialogDismiss: () -> Unit,
     onRetry: () -> Unit,
     onMessageChange: (TextFieldValue) -> Unit,
-    onMessageSend: () -> Unit
+    onMessageSend: () -> Unit,
+    navigateBack: () -> Unit
 ) {
 
     Scaffold(
-        topBar = { CommonTopAppBar(onBackClick = onBackClick) },
+        topBar = { CommonTopAppBar(onBackClick = navigateBack) },
         bottomBar = {
             BottomInputBar(
                 value = messageText,
@@ -123,16 +123,16 @@ fun ChatroomScreen(
 
     LoadingScreen(isLoading)
 
-    if(showNetworkErrorDialog) NetworkErrorDialog(onRetry)
+    if(showNetworkErrorDialog) NetworkErrorDialog(navigateBack, onRetry)
 
-    if(showServerErrorDialog) ServerErrorDialog(onRetry)
+    if(showServerErrorDialog) ServerErrorDialog(navigateBack, onRetry)
 
     if(showForbiddenChatAccessDialog){
         BaseDialog(
             title = stringResource(R.string.dialog_forbidden_chat_access_title),
             confirmBtnText = stringResource(R.string.dialog_forbidden_chat_access_btn),
             isBackgroundClickable = false,
-            onDismissRequest = {},
+            onDismissRequest = navigateBack,
             onConfirmRequest = onForbiddenDialogDismiss,
         )
     }
@@ -371,7 +371,7 @@ fun ChatRoomScreenPreview() {
             rentalSummary = sampleRental,
             inputScrollState = sampleScrollState,
             isLoading = false,
-            onBackClick = { },
+            navigateBack = { },
             onRetry = { },
             onMessageChange = { },
             onMessageSend = { },

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeScreen.kt
@@ -82,9 +82,9 @@ fun HomeScreen(
 
     LoadingScreen(isLoading)
 
-    if(showNetworkErrorDialog) NetworkErrorDialog(onRetry)
+    if(showNetworkErrorDialog) NetworkErrorDialog({}, onRetry)
 
-    if(showServerErrorDialog) ServerErrorDialog(onRetry)
+    if(showServerErrorDialog) ServerErrorDialog({}, onRetry)
 }
 
 @Composable

--- a/app/src/main/java/com/example/rentit/presentation/pay/PayScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/pay/PayScreen.kt
@@ -153,7 +153,7 @@ fun LoadErrorDialog(
         content = stringResource(R.string.dialog_data_load_error_content),
         confirmBtnText = stringResource(R.string.common_dialog_btn_close),
         isBackgroundClickable = false,
-        onCloseRequest = onDismiss,
+        onDismissRequest = onDismiss,
         onConfirmRequest = onDismiss,
     )
 }
@@ -167,7 +167,7 @@ fun PayResultDialog(
         title = stringResource(R.string.dialog_pay_result_success_title),
         confirmBtnText = stringResource(R.string.dialog_pay_result_btn_confirm),
         isBackgroundClickable = false,
-        onCloseRequest = onClose,
+        onDismissRequest = onClose,
         onConfirmRequest = onConfirm,
     )
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/PhotoLoadFailedDialog.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/PhotoLoadFailedDialog.kt
@@ -15,7 +15,7 @@ fun PhotoLoadFailedDialog(onDismiss: () -> Unit = {}) {
     BaseDialog(
         title = stringResource(R.string.dialog_fetch_photos_failed_title),
         confirmBtnText = stringResource(R.string.dialog_rental_detail_unknown_confirm_btn),
-        onCloseRequest = onDismiss,
+        onDismissRequest = onDismiss,
         onConfirmRequest = onDismiss
     ) {
         Text(

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/RentalCancelDialog.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/RentalCancelDialog.kt
@@ -6,13 +6,13 @@ import com.example.rentit.R
 import com.example.rentit.common.component.dialog.BaseDialog
 
 @Composable
-fun RentalCancelDialog(onClose: () -> Unit, onCancelAccept: () -> Unit) {
+fun RentalCancelDialog(onDismiss: () -> Unit, onCancelAccept: () -> Unit) {
     BaseDialog(
         title = stringResource(R.string.dialog_rental_detail_rental_cancel_title),
         content = stringResource(R.string.dialog_rental_detail_rental_cancel_content),
         confirmBtnText = stringResource(R.string.dialog_rental_detail_rental_cancel_btn_confirm),
         closeBtnText = stringResource(R.string.common_dialog_btn_close),
-        onCloseRequest = onClose,
+        onDismissRequest = onDismiss,
         onConfirmRequest = onCancelAccept
     )
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/TrackingRegistrationDialog.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/TrackingRegistrationDialog.kt
@@ -42,14 +42,14 @@ fun TrackingRegistrationDialog(
     showTrackingNumberEmptyError: Boolean = false,
     onSelectCourier: (String) -> Unit,
     onTrackingNumberChange: (String) -> Unit,
-    onClose: () -> Unit,
+    onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
     BaseDialog(
         title = stringResource(R.string.dialog_rental_detail_tracking_regs_title),
         confirmBtnText = stringResource(R.string.dialog_rental_detail_tracking_regs_btn_confirm),
         closeBtnText = stringResource(R.string.common_dialog_btn_close),
-        onCloseRequest = onClose,
+        onDismissRequest = onDismiss,
         onConfirmRequest = onConfirm
     ) {
         Text(
@@ -147,7 +147,7 @@ fun TrackingRegistrationDialogPreview() {
             onSelectCourier = { selectedCompany = it },
             trackingNumber = trackingNum,
             onTrackingNumberChange = { trackingNum = it },
-            onClose = { },
+            onDismiss = { },
             onConfirm = { },
         )
     }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/UnknownStatusDialog.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/dialog/UnknownStatusDialog.kt
@@ -10,7 +10,7 @@ fun UnknownStatusDialog(onDismiss: () -> Unit = {}) {
     BaseDialog(
         title = stringResource(R.string.dialog_rental_detail_unknown_title),
         confirmBtnText = stringResource(R.string.dialog_rental_detail_unknown_confirm_btn),
-        onCloseRequest = onDismiss,
+        onDismissRequest = onDismiss,
         onConfirmRequest = onDismiss
     )
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/owner/OwnerRentalDetailRoute.kt
@@ -95,14 +95,14 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
     uiState.requestAcceptDialog?.let {
         RequestAcceptDialog(
             uiModel = it,
-            onClose = viewModel::dismissRequestAcceptDialog,
+            onDismiss = viewModel::dismissRequestAcceptDialog,
             onAccept = { viewModel.acceptRequest(productId, reservationId) },
         )
     }
 
     if(uiState.showCancelDialog){
         RentalCancelDialog(
-            onClose = viewModel::dismissCancelDialog,
+            onDismiss = viewModel::dismissCancelDialog,
             onCancelAccept = { viewModel.confirmCancel(productId, reservationId) }
         )
     }
@@ -115,7 +115,7 @@ fun OwnerRentalDetailRoute(navHostController: NavHostController, productId: Int,
             showTrackingNumberEmptyError = uiState.showTrackingNumberEmptyError,
             onSelectCourier = viewModel::changeSelectedCourierName,
             onTrackingNumberChange = viewModel::changeTrackingNumber,
-            onClose = viewModel::dismissTrackingRegDialog,
+            onDismiss = viewModel::dismissTrackingRegDialog,
             onConfirm = { viewModel.confirmTrackingReg(productId, reservationId) }
         )
     }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/renter/RenterRentalDetailRoute.kt
@@ -90,7 +90,7 @@ fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int
 
     if(uiState.showCancelDialog){
         RentalCancelDialog(
-            onClose = viewModel::dismissCancelDialog,
+            onDismiss = viewModel::dismissCancelDialog,
             onCancelAccept = { viewModel.confirmCancel(productId, reservationId) }
         )
     }
@@ -103,7 +103,7 @@ fun RenterRentalDetailRoute(navHostController: NavHostController, productId: Int
             showTrackingNumberEmptyError = uiState.showTrackingNumberEmptyError,
             onSelectCourier = viewModel::changeSelectedCourierName,
             onTrackingNumberChange = viewModel::changeTrackingNumber,
-            onClose = viewModel::dismissTrackingRegDialog,
+            onDismiss = viewModel::dismissTrackingRegDialog,
             onConfirm = { viewModel.confirmTrackingReg(productId, reservationId) }
         )
     }

--- a/app/src/main/java/com/example/rentit/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/splash/SplashScreen.kt
@@ -18,7 +18,7 @@ fun SplashScreen(
             content = stringResource(R.string.dialog_server_connect_error_content),
             confirmBtnText = stringResource(R.string.dialog_server_connect_error_retry_btn),
             isBackgroundClickable = false,
-            onCloseRequest = onRetry,
+            onDismissRequest = onRetry,
             onConfirmRequest = onRetry,
         )
     }


### PR DESCRIPTION
# Pull Request

## Summary  
- `NetworkErrorDialog`, `ServerErrorDialog` 등 에러 Dialog에서 뒤로가기가 동작하도록 개선 (Root 화면인 Home 화면 제외)

## Related Issue  
- Close: #137

## Changes  
- `NetworkErrorDialog`, `ServerErrorDialog`와 ChatRoomScreen의 권한 없을 시 에러 Dialog의 onDismiss 액션으로 뒤로가기를 추가
- Dialog의 "닫힘" 동작을 dismiss라는 단어로 통일

## Notes  
- Home 화면은 Root 화면이므로 에러 시 뒤로가기 동작을 구현하지 않음
