### PR TITLE
Refactor/146 reservation request

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/Paddings.kt
+++ b/app/src/main/java/com/example/rentit/common/component/Paddings.kt
@@ -4,12 +4,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
-// 화면 기본 수평 여백을 적용하는 Modifier
+/**
+ * 화면 기본 수평 여백 적용
+  */
 fun Modifier.screenHorizontalPadding(): Modifier {
     return this.then(Modifier.padding(horizontal = 30.dp))
 }
 
-// 화면 하단에 Button이 고정으로 사용될 경우 필요한 하단 여백을 적용하는 Modifier
+/**
+ * 화면 하단에 단일 버튼 고정 사용 시 필요한 하단 여백 적용
+ */
 fun Modifier.paddingForBottomBarButton(): Modifier {
     return this.then(Modifier.padding(bottom = 30.dp))
 }

--- a/app/src/main/java/com/example/rentit/common/component/calendar/CalendarDate.kt
+++ b/app/src/main/java/com/example/rentit/common/component/calendar/CalendarDate.kt
@@ -86,8 +86,6 @@ fun CalendarDate(
     }
 
     Column(
-        modifier = Modifier
-            .padding(bottom = 28.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         repeat(weeksInMonth) {

--- a/app/src/main/java/com/example/rentit/data/chat/repositoryImpl/ChatRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/repositoryImpl/ChatRepositoryImpl.kt
@@ -5,12 +5,12 @@ import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.domain.chat.exception.ForbiddenChatAccessException
 import com.example.rentit.common.exception.ServerException
 import com.example.rentit.domain.chat.exception.ChatRoomAlreadyExistsException
-import com.example.rentit.domain.product.exception.ResvByOwnerException
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
 import com.example.rentit.data.chat.dto.NewChatResponseDto
 import com.example.rentit.data.chat.remote.ChatRemoteDataSource
 import com.example.rentit.domain.chat.repository.ChatRepository
+import com.example.rentit.domain.product.exception.AccessNotAllowedException
 import com.example.rentit.domain.rental.exception.EmptyBodyException
 import javax.inject.Inject
 
@@ -52,7 +52,7 @@ class ChatRepositoryImpl @Inject constructor(
                 200 -> response.body() ?: throw Exception("Empty response body")
                 403 -> {
                     Log.e(TAG, "Server error 403: ${response.errorBody()?.string()}")
-                    throw ResvByOwnerException()
+                    throw AccessNotAllowedException()
                 }
                 409 -> {
                     Log.e(TAG, "Server error 409: ${response.errorBody()?.string()}")

--- a/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
@@ -15,7 +15,6 @@ import com.example.rentit.data.product.dto.RequestHistoryResponseDto
 import com.example.rentit.data.product.remote.ProductRemoteDataSource
 import com.example.rentit.domain.product.exception.AccessNotAllowedException
 import com.example.rentit.domain.product.exception.ResvAlreadyExistException
-import com.example.rentit.domain.product.exception.ResvByOwnerException
 import com.example.rentit.domain.product.repository.ProductRepository
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -76,7 +75,8 @@ class ProductRepositoryImpl @Inject constructor(
             } else {
                 val errorMsg = response.errorBody()?.string() ?: "Client Error"
                 throw when(response.code()) {
-                    403 -> ResvByOwnerException(errorMsg)   // 판매자가 요청한 경우
+                    401 -> MissingTokenException(errorMsg)
+                    403 -> AccessNotAllowedException(errorMsg)   // 판매자가 요청한 경우
                     409 -> ResvAlreadyExistException(errorMsg)  // 이미 동일 기간의 예약이 1건 이상 존재하는 경우
                     500 -> ServerException(errorMsg)
                     else -> Exception(errorMsg)

--- a/app/src/main/java/com/example/rentit/domain/product/exception/ResvAlreadyExistException.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/exception/ResvAlreadyExistException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.domain.product.exception
+
+class ResvAlreadyExistException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/product/exception/ResvByOwnerException.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/exception/ResvByOwnerException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.product.exception
-
-class ResvByOwnerException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/product/exception/ResvByOwnerException.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/exception/ResvByOwnerException.kt
@@ -1,3 +1,3 @@
 package com.example.rentit.domain.product.exception
 
-class ResvByOwnerException(): Exception()
+class ResvByOwnerException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/product/usecase/PostResvRequestUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/usecase/PostResvRequestUseCase.kt
@@ -1,6 +1,7 @@
 package com.example.rentit.domain.product.usecase
 
 import com.example.rentit.data.product.dto.ResvRequestDto
+import com.example.rentit.data.product.dto.ResvResponseDto
 import com.example.rentit.domain.product.repository.ProductRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -21,7 +22,7 @@ class PostResvRequestUseCase @Inject constructor(
         selectedPeriod: Int,
         startDate: String,
         endDate: String,
-    ): Result<Unit> {
+    ): Result<ResvResponseDto> {
         return runCatching {
             val periodRange = (minPeriod ?: 0)..(maxPeriod ?: Int.MAX_VALUE)
             if(selectedPeriod !in periodRange) throw IllegalArgumentException("Invalid period")

--- a/app/src/main/java/com/example/rentit/domain/product/usecase/PostResvRequestUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/usecase/PostResvRequestUseCase.kt
@@ -1,0 +1,33 @@
+package com.example.rentit.domain.product.usecase
+
+import com.example.rentit.data.product.dto.ResvRequestDto
+import com.example.rentit.domain.product.repository.ProductRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ *  선택한 기간이 유효한지 확인하고 예약 요청을 보내는 UseCase
+ */
+
+@Singleton
+class PostResvRequestUseCase @Inject constructor(
+    private val productRepository: ProductRepository,
+) {
+
+    suspend operator fun invoke(
+        productId: Int,
+        minPeriod: Int?,
+        maxPeriod: Int?,
+        selectedPeriod: Int,
+        startDate: String,
+        endDate: String,
+    ): Result<Unit> {
+        return runCatching {
+            val periodRange = (minPeriod ?: 0)..(maxPeriod ?: Int.MAX_VALUE)
+            if(selectedPeriod !in periodRange) throw IllegalArgumentException("Invalid period")
+
+            val request = ResvRequestDto(startDate, endDate)
+            productRepository.postResv(productId, request).getOrThrow()
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/navigation/productdetail/ProductDetailNavigation.kt
+++ b/app/src/main/java/com/example/rentit/navigation/productdetail/ProductDetailNavigation.kt
@@ -7,7 +7,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.example.rentit.presentation.productdetail.ProductDetailRoute
-import com.example.rentit.presentation.productdetail.reservation.request.ResvRequestScreen
+import com.example.rentit.presentation.productdetail.reservation.request.ResvRequestRoute
 import com.example.rentit.presentation.productdetail.reservation.request.complete.ResvRequestCompleteScreen
 import com.example.rentit.presentation.productdetail.reservation.requesthistory.RequestHistoryScreen
 
@@ -17,7 +17,7 @@ fun NavHostController.navigateToProductDetail(productId: Int) {
     )
 }
 
-fun NavHostController.navigateToResvRequest(productId: Int?) {
+fun NavHostController.navigateToResvRequest(productId: Int) {
     navigate(
         route = ProductDetailRoute.ResvRequest(productId)
     )
@@ -51,7 +51,7 @@ fun NavGraphBuilder.productDetailGraph(navHostController: NavHostController) {
     }
     composable<ProductDetailRoute.ResvRequest> { backStackEntry ->
         val items: ProductDetailRoute.ResvRequest = backStackEntry.toRoute()
-        ResvRequestScreen(navHostController, items.productId)
+        ResvRequestRoute(navHostController, items.productId)
     }
     composable<ProductDetailRoute.ResvRequestComplete> { backStackEntry ->
         val items: ProductDetailRoute.ResvRequestComplete = backStackEntry.toRoute()

--- a/app/src/main/java/com/example/rentit/navigation/productdetail/ProductDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/navigation/productdetail/ProductDetailRoute.kt
@@ -7,7 +7,7 @@ sealed class ProductDetailRoute {
     data class ProductDetail(val productId: Int) : ProductDetailRoute()
 
     @Serializable
-    data class ResvRequest(val productId: Int?) : ProductDetailRoute()
+    data class ResvRequest(val productId: Int) : ProductDetailRoute()
 
     @Serializable
     data class ResvRequestComplete(

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
+import com.example.rentit.common.util.formatPrice
 import com.example.rentit.navigation.productdetail.navigateToResvRequestComplete
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -30,15 +31,19 @@ fun ResvRequestRoute(navHostController: NavHostController, productId: Int) {
 
     LaunchedEffect(Unit) {
         lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-            viewModel.sideEffect.collect { sideEffect -> }
+            viewModel.sideEffect.collect { sideEffect ->
+                when (sideEffect) {
+                    is ResvRequestSideEffect.NavigateToResvRequestComplete -> {
+                        navHostController.navigateToResvRequestComplete(
+                            rentalStartDate = sideEffect.rentalStartDate,
+                            rentalEndDate = sideEffect.rentalEndDate,
+                            formattedTotalPrice = formatPrice(sideEffect.totalPrice)
+                        )
+                    }
+                }
+            }
         }
     }
-
-    navHostController.navigateToResvRequestComplete(
-        rentalStartDate = uiState.rentalStartDate.toString(),
-        rentalEndDate = uiState.rentalEndDate.toString(),
-        formattedTotalPrice = ""
-    )
 
     ResvRequestScreen(
         rentalStartDate = uiState.rentalStartDate,

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
@@ -50,6 +50,8 @@ fun ResvRequestRoute(navHostController: NavHostController, productId: Int) {
         rentalEndDate = uiState.rentalEndDate,
         rentalPeriod = uiState.rentalPeriod,
         reservedDateList = uiState.reservedDateList,
+        minPeriod = uiState.minPeriod,
+        maxPeriod = uiState.maxPeriod,
         rentalPrice = uiState.rentalPrice,
         totalPrice = uiState.totalPrice,
         deposit = uiState.deposit,

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
@@ -3,15 +3,21 @@ package com.example.rentit.presentation.productdetail.reservation.request
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
+import com.example.rentit.R
+import com.example.rentit.common.component.dialog.BaseDialog
+import com.example.rentit.common.component.dialog.NetworkErrorDialog
+import com.example.rentit.common.component.dialog.ServerErrorDialog
+import com.example.rentit.common.component.layout.LoadingScreen
 import com.example.rentit.common.util.formatPrice
 import com.example.rentit.navigation.productdetail.navigateToResvRequestComplete
 
@@ -19,14 +25,12 @@ import com.example.rentit.navigation.productdetail.navigateToResvRequestComplete
 @Composable
 fun ResvRequestRoute(navHostController: NavHostController, productId: Int) {
     val viewModel: ResvRequestViewModel = hiltViewModel()
-    val context = LocalContext.current
     val lifecycle = LocalLifecycleOwner.current.lifecycle
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-        viewModel.getProductDetail(productId)
-        viewModel.getReservedDates(productId)
+        viewModel.loadInitialData(productId)
     }
 
     LaunchedEffect(Unit) {
@@ -45,6 +49,10 @@ fun ResvRequestRoute(navHostController: NavHostController, productId: Int) {
         }
     }
 
+    DisposableEffect(Unit) {
+        onDispose { viewModel.dismissAllDialogs() }
+    }
+
     ResvRequestScreen(
         rentalStartDate = uiState.rentalStartDate,
         rentalEndDate = uiState.rentalEndDate,
@@ -59,5 +67,41 @@ fun ResvRequestRoute(navHostController: NavHostController, productId: Int) {
         onResvRequestClick = { viewModel.postResv(productId) },
         onSetRentalStartDate = viewModel::setRentalStartDate,
         onSetRentalEndDate = viewModel::setRentalEndDate
-    ) 
+    )
+
+    LoadingScreen(uiState.isLoading)
+
+    if(uiState.showNetworkErrorDialog){
+        NetworkErrorDialog(
+            navigateBack = navHostController::popBackStack,
+            onRetry = { viewModel.onRetryLoadData(productId) }
+        )
+    }
+
+    if(uiState.showServerErrorDialog){
+        ServerErrorDialog(
+            navigateBack = navHostController::popBackStack,
+            onRetry = { viewModel.onRetryLoadData(productId) }
+        )
+    }
+
+    if(uiState.showAccessNotAllowedDialog) {
+        BaseDialog(
+            title = stringResource(R.string.dialog_owner_access_not_allowed_title),
+            content = stringResource(R.string.dialog_owner_access_not_allowed_content),
+            confirmBtnText = stringResource(R.string.common_dialog_btn_close),
+            onDismissRequest = viewModel::dismissAccessNotAllowedDialog,
+            onConfirmRequest = viewModel::dismissAccessNotAllowedDialog
+        )
+    }
+
+    if(uiState.showResvAlreadyExistDialog) {
+        BaseDialog(
+            title = stringResource(R.string.dialog_resv_already_exist_title),
+            content = stringResource(R.string.dialog_resv_already_exist_content),
+            confirmBtnText = stringResource(R.string.common_dialog_btn_close),
+            onDismissRequest = viewModel::dismissResvAlreadyExistDialog,
+            onConfirmRequest = viewModel::dismissResvAlreadyExistDialog
+        )
+    }
 }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
@@ -66,7 +66,7 @@ fun ResvRequestRoute(navHostController: NavHostController, productId: Int) {
         reservedDateList = uiState.reservedDateList,
         minPeriod = uiState.minPeriod,
         maxPeriod = uiState.maxPeriod,
-        rentalPrice = uiState.rentalPrice,
+        rentalPrice = uiState.totalRentalPrice,
         totalPrice = uiState.totalPrice,
         deposit = uiState.deposit,
         onBackClick = navHostController::popBackStack,

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
@@ -1,11 +1,13 @@
 package com.example.rentit.presentation.productdetail.reservation.request
 
 import android.os.Build
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -26,6 +28,7 @@ import com.example.rentit.navigation.productdetail.navigateToResvRequestComplete
 fun ResvRequestRoute(navHostController: NavHostController, productId: Int) {
     val viewModel: ResvRequestViewModel = hiltViewModel()
     val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val context = LocalContext.current
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -44,6 +47,9 @@ fun ResvRequestRoute(navHostController: NavHostController, productId: Int) {
                             formattedTotalPrice = formatPrice(sideEffect.totalPrice)
                         )
                     }
+                    ResvRequestSideEffect.ToastInvalidPeriod -> {
+                        Toast.makeText(context, R.string.toast_invalid_period, Toast.LENGTH_SHORT).show()
+                    }
                 }
             }
         }
@@ -56,7 +62,7 @@ fun ResvRequestRoute(navHostController: NavHostController, productId: Int) {
     ResvRequestScreen(
         rentalStartDate = uiState.rentalStartDate,
         rentalEndDate = uiState.rentalEndDate,
-        rentalPeriod = uiState.rentalPeriod,
+        selectedPeriod = uiState.selectedPeriod,
         reservedDateList = uiState.reservedDateList,
         minPeriod = uiState.minPeriod,
         maxPeriod = uiState.maxPeriod,

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestRoute.kt
@@ -1,0 +1,65 @@
+package com.example.rentit.presentation.productdetail.reservation.request
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import com.example.rentit.common.util.formatPrice
+import com.example.rentit.navigation.productdetail.navigateToResvRequestComplete
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun ResvRequestRoute(navHostController: NavHostController, productId: Int) {
+    val resvRequestViewModel: ResvRequestViewModel = hiltViewModel()
+    val context = LocalContext.current
+
+    val rentalStartDate by resvRequestViewModel.rentalStartDate.collectAsStateWithLifecycle()
+    val rentalEndDate by resvRequestViewModel.rentalEndDate.collectAsStateWithLifecycle()
+    val rentalPeriod by resvRequestViewModel.rentalPeriod.collectAsStateWithLifecycle()
+    val productPrice by resvRequestViewModel.productPrice.collectAsStateWithLifecycle()
+    val reservedDateList by resvRequestViewModel.reservedDateList.collectAsStateWithLifecycle()
+
+    var formattedRentalPrice by remember { mutableStateOf("") }
+    val formattedTotalPrice = resvRequestViewModel.formattedTotalPrice.collectAsStateWithLifecycle()
+
+    val sampleDeposit = 5000
+
+    LaunchedEffect(productId) {
+        resvRequestViewModel.getProductDetail(productId)
+        resvRequestViewModel.getReservedDates(productId)
+    }
+
+    LaunchedEffect(rentalPeriod) {
+        val totalPrice = rentalPeriod * productPrice
+        formattedRentalPrice = formatPrice(totalPrice)
+        resvRequestViewModel.setFormattedTotalPrice(formatPrice(totalPrice + sampleDeposit))
+    }
+
+    navHostController.navigateToResvRequestComplete(
+        rentalStartDate = rentalStartDate.toString(),
+        rentalEndDate = rentalEndDate.toString(),
+        formattedTotalPrice = formattedTotalPrice.value
+    )
+
+    ResvRequestScreen(
+        rentalStartDate = TODO(),
+        rentalEndDate = TODO(),
+        rentalPeriod = TODO(),
+        reservedDateList = TODO(),
+        rentalPrice = TODO(),
+        totalPrice = TODO(),
+        deposit = TODO(),
+        onBackClick = TODO(),
+        onResvRequestClick = TODO(),
+        onSetRentalStartDate = TODO(),
+        onSetRentalEndDate = TODO()
+    ) 
+}

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestScreen.kt
@@ -40,7 +40,7 @@ import java.time.LocalDate
 fun ResvRequestScreen(
     rentalStartDate: LocalDate? = null,
     rentalEndDate: LocalDate? = null,
-    rentalPeriod: Int = 0,
+    selectedPeriod: Int = 0,
     reservedDateList: List<String> = emptyList(),
     minPeriod: Int? = null,
     maxPeriod: Int? = null,
@@ -79,7 +79,7 @@ fun ResvRequestScreen(
                 modifier = Modifier.padding(top = 10.dp, bottom = 8.dp),
                 rentalStartDate = rentalStartDate,
                 rentalEndDate = rentalEndDate,
-                rentalPeriod = rentalPeriod,
+                selectedPeriod = selectedPeriod,
                 disabledDates = reservedDateList,
                 setRentalStartDate = onSetRentalStartDate,
                 setRentalEndDate = onSetRentalEndDate
@@ -173,7 +173,7 @@ fun ResvRequestScreenPreview() {
         ResvRequestScreen(
             rentalStartDate = LocalDate.now(),
             rentalEndDate = LocalDate.now(),
-            rentalPeriod = 5, // 대여일수
+            selectedPeriod = 5, // 대여일수
             reservedDateList = listOf("2025-09-12", "2025-09-13"), // 이미 예약된 날짜
             rentalPrice = 90_000,
             totalPrice = 120_000,

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestScreen.kt
@@ -5,8 +5,12 @@ import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -72,7 +76,9 @@ fun ResvRequestScreen(
         }
     ) {
         Column(
-            modifier = Modifier.padding(it),
+            modifier = Modifier
+                .padding(it)
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             DateRangePicker(
@@ -90,6 +96,7 @@ fun ResvRequestScreen(
                 deposit = deposit,
                 totalPrice = totalPrice
             )
+            Spacer(modifier = Modifier.height(60.dp))
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestScreen.kt
@@ -23,9 +23,11 @@ import com.example.rentit.R
 import com.example.rentit.common.component.CommonButton
 import com.example.rentit.common.component.CommonDivider
 import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.component.formatPeriodTextWithLabel
 import com.example.rentit.common.component.paddingForBottomBarButton
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.Gray300
+import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.Gray800
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
@@ -40,6 +42,8 @@ fun ResvRequestScreen(
     rentalEndDate: LocalDate? = null,
     rentalPeriod: Int = 0,
     reservedDateList: List<String> = emptyList(),
+    minPeriod: Int? = null,
+    maxPeriod: Int? = null,
     rentalPrice: Int = 0,
     totalPrice: Int = 0,
     deposit: Int = 0,
@@ -72,7 +76,7 @@ fun ResvRequestScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             DateRangePicker(
-                modifier = Modifier.padding(top = 10.dp, bottom = 26.dp),
+                modifier = Modifier.padding(top = 10.dp, bottom = 8.dp),
                 rentalStartDate = rentalStartDate,
                 rentalEndDate = rentalEndDate,
                 rentalPeriod = rentalPeriod,
@@ -80,6 +84,7 @@ fun ResvRequestScreen(
                 setRentalStartDate = onSetRentalStartDate,
                 setRentalEndDate = onSetRentalEndDate
             )
+            PeriodGuideText(minPeriod, maxPeriod)
             PriceSection(
                 rentalPrice = rentalPrice,
                 deposit = deposit,
@@ -90,9 +95,19 @@ fun ResvRequestScreen(
 }
 
 @Composable
+fun PeriodGuideText(minPeriod: Int?, maxPeriod: Int?) {
+    val periodText = formatPeriodTextWithLabel(minPeriod, maxPeriod)
+    Text(
+        text = stringResource(id = R.string.screen_resv_request_period_guide, periodText),
+        style = MaterialTheme.typography.labelMedium,
+        color = Gray400
+    )
+}
+
+@Composable
 fun PriceSection(rentalPrice: Int, deposit: Int, totalPrice: Int){
     Column(Modifier.screenHorizontalPadding()) {
-        LabelValueRow(Modifier.padding(bottom = 10.dp)) {
+        LabelValueRow(Modifier.padding(top = 30.dp, bottom = 10.dp)) {
             Text(
                 text = stringResource(
                     id = R.string.screen_resv_request_label_total_rental_fee
@@ -162,6 +177,8 @@ fun ResvRequestScreenPreview() {
             reservedDateList = listOf("2025-09-12", "2025-09-13"), // 이미 예약된 날짜
             rentalPrice = 90_000,
             totalPrice = 120_000,
+            minPeriod = 1,
+            maxPeriod = 5,
             deposit = 30_000,
             onBackClick = { /* 뒤로가기 처리 */ },
             onResvRequestClick = { /* 예약 요청 처리 */ },

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestScreen.kt
@@ -1,12 +1,10 @@
 package com.example.rentit.presentation.productdetail.reservation.request
 
 import android.os.Build
-import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
@@ -14,160 +12,161 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonButton
 import com.example.rentit.common.component.CommonDivider
 import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.component.paddingForBottomBarButton
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.Gray300
 import com.example.rentit.common.theme.Gray800
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.util.formatPrice
-import com.example.rentit.navigation.productdetail.navigateToResvRequestComplete
 import com.example.rentit.presentation.productdetail.reservation.request.components.DateRangePicker
+import java.time.LocalDate
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun ResvRequestScreen(navHostController: NavHostController, productId: Int?) {
-    val resvRequestViewModel: ResvRequestViewModel = hiltViewModel()
-    val context = LocalContext.current
-
-    val rentalStartDate by resvRequestViewModel.rentalStartDate.collectAsStateWithLifecycle()
-    val rentalEndDate by resvRequestViewModel.rentalEndDate.collectAsStateWithLifecycle()
-    val rentalPeriod by resvRequestViewModel.rentalPeriod.collectAsStateWithLifecycle()
-    val productPrice by resvRequestViewModel.productPrice.collectAsStateWithLifecycle()
-    val reservedDateList by resvRequestViewModel.reservedDateList.collectAsStateWithLifecycle()
-
-    var formattedRentalPrice by remember { mutableStateOf("") }
-    val formattedTotalPrice = resvRequestViewModel.formattedTotalPrice.collectAsStateWithLifecycle()
-
-    val sampleDeposit = 5000
-
-    LaunchedEffect(productId) {
-        if(productId == null) {
-            Toast.makeText(context, context.getString(R.string.error_common_cant_find_product), Toast.LENGTH_SHORT).show()
-            navHostController.popBackStack()
-        } else {
-            resvRequestViewModel.getProductDetail(productId)
-            resvRequestViewModel.getReservedDates(productId)
-        }
-    }
-
-    LaunchedEffect(rentalPeriod) {
-        val totalPrice = rentalPeriod * productPrice
-        formattedRentalPrice = formatPrice(totalPrice)
-        resvRequestViewModel.setFormattedTotalPrice(formatPrice(totalPrice + sampleDeposit))
-    }
-
+fun ResvRequestScreen(
+    rentalStartDate: LocalDate? = null,
+    rentalEndDate: LocalDate? = null,
+    rentalPeriod: Int = 0,
+    reservedDateList: List<String> = emptyList(),
+    rentalPrice: Int = 0,
+    totalPrice: Int = 0,
+    deposit: Int = 0,
+    onBackClick: () -> Unit,
+    onResvRequestClick: () -> Unit,
+    onSetRentalStartDate: (LocalDate?) -> Unit,
+    onSetRentalEndDate: (LocalDate?) -> Unit,
+) {
     Scaffold(
         topBar = {
             CommonTopAppBar(
-                title = stringResource(id = R.string.screen_resv_request_app_bar_title)
-            ) { navHostController.popBackStack() }
+                title = stringResource(id = R.string.screen_resv_request_app_bar_title),
+                onBackClick = onBackClick
+            )
+        },
+        bottomBar = {
+            CommonButton(
+                modifier = Modifier
+                    .screenHorizontalPadding()
+                    .paddingForBottomBarButton(),
+                text = stringResource(id = R.string.screen_resv_request_btn_resv_request),
+                containerColor = PrimaryBlue500,
+                contentColor = Color.White,
+                onClick = onResvRequestClick
+            )
         }
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(it)
-                .padding(bottom = 48.dp),
+            modifier = Modifier.padding(it),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             DateRangePicker(
-                modifier = Modifier
-                    .weight(1F)
-                    .padding(top = 24.dp),
+                modifier = Modifier.padding(top = 10.dp, bottom = 26.dp),
                 rentalStartDate = rentalStartDate,
                 rentalEndDate = rentalEndDate,
                 rentalPeriod = rentalPeriod,
                 disabledDates = reservedDateList,
-                setRentalStartDate = { date -> resvRequestViewModel.setRentalStartDate(date) },
-                setRentalEndDate = { date -> resvRequestViewModel.setRentalEndDate(date) }
+                setRentalStartDate = onSetRentalStartDate,
+                setRentalEndDate = onSetRentalEndDate
             )
-            Column(Modifier.screenHorizontalPadding()) {
-                LabelValueRow(Modifier.padding(bottom = 10.dp)) {
-                    Text(text = stringResource(
-                        id = R.string.screen_resv_request_label_total_rental_fee), style = MaterialTheme.typography.bodyMedium)
-                    Text(text = "$formattedRentalPrice 원", style = MaterialTheme.typography.bodyMedium, color = Gray800)
-                }
-                LabelValueRow(Modifier.padding(bottom = 14.dp)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(text = stringResource(
-                            id = R.string.screen_resv_request_label_deposit), style = MaterialTheme.typography.bodyMedium)
-                        Icon(modifier = Modifier.padding(start = 5.dp), painter = painterResource(id = R.drawable.ic_info), contentDescription = "", tint = Gray300 )
-                    }
-                    Text(text = "${formatPrice(sampleDeposit)} 원",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = PrimaryBlue500
-                    )
-                }
-                CommonDivider()
-                LabelValueRow(Modifier.padding(top = 14.dp)) {
-                    Text(text = stringResource(
-                        id = R.string.screen_resv_request_label_total_fee), style = MaterialTheme.typography.bodyLarge)
-                    Text(text = "${formattedTotalPrice.value} 원", style = MaterialTheme.typography.bodyLarge, color = PrimaryBlue500)
-                }
-                CommonButton(text = stringResource(id = R.string.screen_resv_request_btn_resv_request),
-                    containerColor = PrimaryBlue500, contentColor = Color.White, modifier = Modifier.padding(top = 21.dp)) {
-                    if (rentalStartDate != null && rentalEndDate != null) {
-                        resvRequestViewModel.postResv(productId ?: -1)
-                    }
-                }
-            }
+            PriceSection(
+                rentalPrice = rentalPrice,
+                deposit = deposit,
+                totalPrice = totalPrice
+            )
         }
     }
-    ResvResultHandler(resvRequestViewModel){
-        navHostController.navigateToResvRequestComplete(
-            rentalStartDate = rentalStartDate.toString(),
-            rentalEndDate = rentalEndDate.toString(),
-            formattedTotalPrice = formattedTotalPrice.value
-        )
+}
+
+@Composable
+fun PriceSection(rentalPrice: Int, deposit: Int, totalPrice: Int){
+    Column(Modifier.screenHorizontalPadding()) {
+        LabelValueRow(Modifier.padding(bottom = 10.dp)) {
+            Text(
+                text = stringResource(
+                    id = R.string.screen_resv_request_label_total_rental_fee
+                ), style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = "${formatPrice(rentalPrice)} 원",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Gray800
+            )
+        }
+        LabelValueRow(Modifier.padding(bottom = 14.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(id = R.string.screen_resv_request_label_deposit),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Icon(
+                    modifier = Modifier.padding(start = 5.dp),
+                    painter = painterResource(id = R.drawable.ic_info),
+                    contentDescription = "",
+                    tint = Gray300
+                )
+            }
+            Text(
+                text = "${formatPrice(deposit)} 원",
+                style = MaterialTheme.typography.bodyMedium,
+                color = PrimaryBlue500
+            )
+        }
+        CommonDivider()
+        LabelValueRow(Modifier.padding(top = 14.dp)) {
+            Text(
+                text = stringResource(
+                    id = R.string.screen_resv_request_label_total_fee
+                ), style = MaterialTheme.typography.bodyLarge
+            )
+            Text(
+                text = "${formatPrice(totalPrice)} 원",
+                style = MaterialTheme.typography.bodyLarge,
+                color = PrimaryBlue500
+            )
+        }
     }
 }
 
 @Composable
 fun LabelValueRow(modifier: Modifier, content: @Composable () -> Unit) {
-    Row(modifier = modifier.fillMaxWidth(),
+    Row(
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween) {
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
         content()
     }
 }
 
-@Composable
-fun ResvResultHandler(resvRequestViewModel: ResvRequestViewModel, onResvSuccess: () -> Unit){
-    val resvResult by resvRequestViewModel.resvResult.collectAsStateWithLifecycle()
-    LaunchedEffect(resvResult) {
-        resvResult?.onSuccess {
-            onResvSuccess()
-        }?.onFailure {
-            /* 예약 실패 시 */
-        }
-    }
-}
 @RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
-private fun Preview() {
+fun ResvRequestScreenPreview() {
     RentItTheme {
-        ResvRequestScreen(rememberNavController(), 0)
+        ResvRequestScreen(
+            rentalStartDate = LocalDate.now(),
+            rentalEndDate = LocalDate.now(),
+            rentalPeriod = 5, // 대여일수
+            reservedDateList = listOf("2025-09-12", "2025-09-13"), // 이미 예약된 날짜
+            rentalPrice = 90_000,
+            totalPrice = 120_000,
+            deposit = 30_000,
+            onBackClick = { /* 뒤로가기 처리 */ },
+            onResvRequestClick = { /* 예약 요청 처리 */ },
+            onSetRentalStartDate = { /* 시작일 선택 처리 */ },
+            onSetRentalEndDate = { /* 종료일 선택 처리 */ }
+        )
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestSideEffect.kt
@@ -1,0 +1,5 @@
+package com.example.rentit.presentation.productdetail.reservation.request
+
+sealed class ResvRequestSideEffect {
+
+}

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestSideEffect.kt
@@ -6,4 +6,5 @@ sealed class ResvRequestSideEffect {
         val rentalEndDate: String,
         val totalPrice: Int
     ): ResvRequestSideEffect()
+    data object ToastInvalidPeriod: ResvRequestSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestSideEffect.kt
@@ -1,5 +1,9 @@
 package com.example.rentit.presentation.productdetail.reservation.request
 
 sealed class ResvRequestSideEffect {
-
+    data class NavigateToResvRequestComplete(
+        val rentalStartDate: String,
+        val rentalEndDate: String,
+        val totalPrice: Int
+    ): ResvRequestSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestState.kt
@@ -11,9 +11,8 @@ data class ResvRequestState(
     val rentalEndDate: LocalDate? = null,
     val minPeriod: Int? = 0,
     val maxPeriod: Int? = 0,
-    val rentalPrice: Int = 0,
+    private val rentalPrice: Int = 0,
     val deposit: Int = 0,
-    val totalRentalPrice: Int = 0,
     val reservedDateList: List<String> = emptyList(),
     val isLoading: Boolean = false,
     val showNetworkErrorDialog: Boolean = false,
@@ -24,6 +23,9 @@ data class ResvRequestState(
     val selectedPeriod: Int
         get() = inclusiveDaysBetween(rentalStartDate, rentalEndDate)
 
+    val totalRentalPrice: Int
+        get() = rentalPrice * selectedPeriod
+
     val totalPrice: Int
-        get() = rentalPrice * selectedPeriod + deposit
+        get() = totalRentalPrice + deposit
 }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestState.kt
@@ -1,0 +1,24 @@
+package com.example.rentit.presentation.productdetail.reservation.request
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.example.rentit.common.util.inclusiveDaysBetween
+import java.time.LocalDate
+
+@RequiresApi(Build.VERSION_CODES.O)
+data class ResvRequestState(
+    val rentalStartDate: LocalDate? = null,
+    val rentalEndDate: LocalDate? = null,
+    val minPeriod: Int? = 0,
+    val maxPeriod: Int? = 0,
+    val rentalPrice: Int = 0,
+    val deposit: Int = 0,
+    val totalRentalPrice: Int = 0,
+    val reservedDateList: List<String> = emptyList(),
+) {
+    val rentalPeriod: Int
+        get() = inclusiveDaysBetween(rentalStartDate, rentalEndDate)
+
+    val totalPrice: Int
+        get() = rentalPrice * rentalPeriod + deposit
+}

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestState.kt
@@ -21,9 +21,9 @@ data class ResvRequestState(
     val showAccessNotAllowedDialog: Boolean = false,
     val showResvAlreadyExistDialog: Boolean = false
 ) {
-    val rentalPeriod: Int
+    val selectedPeriod: Int
         get() = inclusiveDaysBetween(rentalStartDate, rentalEndDate)
 
     val totalPrice: Int
-        get() = rentalPrice * rentalPeriod + deposit
+        get() = rentalPrice * selectedPeriod + deposit
 }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestState.kt
@@ -15,6 +15,11 @@ data class ResvRequestState(
     val deposit: Int = 0,
     val totalRentalPrice: Int = 0,
     val reservedDateList: List<String> = emptyList(),
+    val isLoading: Boolean = false,
+    val showNetworkErrorDialog: Boolean = false,
+    val showServerErrorDialog: Boolean = false,
+    val showAccessNotAllowedDialog: Boolean = false,
+    val showResvAlreadyExistDialog: Boolean = false
 ) {
     val rentalPeriod: Int
         get() = inclusiveDaysBetween(rentalStartDate, rentalEndDate)

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestViewModel.kt
@@ -4,7 +4,10 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.data.product.dto.ResvRequestDto
+import com.example.rentit.domain.product.exception.AccessNotAllowedException
+import com.example.rentit.domain.product.exception.ResvAlreadyExistException
 import com.example.rentit.domain.product.repository.ProductRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -12,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import okio.IOException
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -36,34 +40,63 @@ class ResvRequestViewModel @Inject constructor(
         }
     }
 
-    fun setRentalStartDate(date: LocalDate?) {
-        _uiState.value = _uiState.value.copy(rentalStartDate = date)
+    private fun setLoading(isLoading: Boolean) {
+        _uiState.value = _uiState.value.copy(isLoading = isLoading)
     }
 
-    fun setRentalEndDate(date: LocalDate?) {
-        _uiState.value = _uiState.value.copy(rentalEndDate = date)
-    }
-
-    fun getProductDetail(productId: Int) {
-        viewModelScope.launch {
-            productRepository.getProductDetail(productId)
-                .onSuccess {
-                    _uiState.value = _uiState.value.copy(
-                        rentalPrice = it.product.price,
-                        deposit = it.product.price * DEFAULT_DEPOSIT_DAYS,
-                        minPeriod = it.product.period?.min,
-                        maxPeriod = it.product.period?.max
-                    )
-                }.onFailure { }
+    private fun handleFailure(e: Throwable) {
+        when(e) {
+            is MissingTokenException -> {
+                // TODO: 로그아웃 처리 및 로그인 화면으로 이동
+            }
+            is AccessNotAllowedException -> {
+                _uiState.value = _uiState.value.copy(showAccessNotAllowedDialog = true)
+            }
+            is ResvAlreadyExistException -> {
+                _uiState.value = _uiState.value.copy(showResvAlreadyExistDialog = true)
+            }
+            is IOException -> {
+                _uiState.value = _uiState.value.copy(showNetworkErrorDialog = true)
+            }
+            else -> {
+                _uiState.value = _uiState.value.copy(showServerErrorDialog = true)
+            }
         }
     }
 
-    fun getReservedDates(productId: Int) {
+    private suspend fun getProductDetail(productId: Int) {
+        productRepository.getProductDetail(productId)
+            .onSuccess {
+                _uiState.value = _uiState.value.copy(
+                    rentalPrice = it.product.price,
+                    deposit = it.product.price * DEFAULT_DEPOSIT_DAYS,
+                    minPeriod = it.product.period?.min,
+                    maxPeriod = it.product.period?.max
+                )
+            }.onFailure { e -> handleFailure(e) }
+    }
+
+    private suspend fun getReservedDates(productId: Int) {
+        productRepository.getReservedDates(productId)
+            .onSuccess {
+                _uiState.value = _uiState.value.copy(reservedDateList = it.disabledDates)
+            }.onFailure { e -> handleFailure(e) }
+    }
+
+    suspend fun loadInitialData(productId: Int) {
+        setLoading(true)
+        getProductDetail(productId)
+        getReservedDates(productId)
+        setLoading(false)
+    }
+
+    fun onRetryLoadData(productId: Int) {
+        _uiState.value = _uiState.value.copy(
+            showNetworkErrorDialog = false,
+            showServerErrorDialog = false,
+        )
         viewModelScope.launch {
-            productRepository.getReservedDates(productId)
-                .onSuccess {
-                    _uiState.value = _uiState.value.copy(reservedDateList = it.disabledDates)
-                }.onFailure { }
+            loadInitialData(productId)
         }
     }
 
@@ -82,7 +115,32 @@ class ResvRequestViewModel @Inject constructor(
                         rentalEndDate = endDate,
                         totalPrice = totalPrice
                     ))
-                }.onFailure { }
+                }.onFailure { e -> handleFailure(e) }
         }
+    }
+
+    fun setRentalStartDate(date: LocalDate?) {
+        _uiState.value = _uiState.value.copy(rentalStartDate = date)
+    }
+
+    fun setRentalEndDate(date: LocalDate?) {
+        _uiState.value = _uiState.value.copy(rentalEndDate = date)
+    }
+
+    fun dismissAccessNotAllowedDialog() {
+        _uiState.value = _uiState.value.copy(showAccessNotAllowedDialog = false)
+    }
+
+    fun dismissResvAlreadyExistDialog() {
+        _uiState.value = _uiState.value.copy(showResvAlreadyExistDialog = false)
+    }
+
+    fun dismissAllDialogs() {
+        _uiState.value = _uiState.value.copy(
+            showNetworkErrorDialog = false,
+            showServerErrorDialog = false,
+            showAccessNotAllowedDialog = false,
+            showResvAlreadyExistDialog = false
+        )
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.rentit.presentation.productdetail.reservation.request
 
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -77,14 +78,22 @@ class ResvRequestViewModel @Inject constructor(
                     minPeriod = it.product.period?.min,
                     maxPeriod = it.product.period?.max
                 )
-            }.onFailure { e -> handleFailure(e) }
+                Log.i(TAG, "상품 조회 성공: Product Id: $productId")
+            }.onFailure { e ->
+                Log.e(TAG, "상품 조회 실패", e)
+                handleFailure(e)
+            }
     }
 
     private suspend fun getReservedDates(productId: Int) {
         productRepository.getReservedDates(productId)
             .onSuccess {
                 _uiState.value = _uiState.value.copy(reservedDateList = it.disabledDates)
-            }.onFailure { e -> handleFailure(e) }
+                Log.i(TAG, "예약 불가일 조회 성공: 불가일 ${it.disabledDates.size}개")
+            }.onFailure { e ->
+                Log.e(TAG, "예약 불가일 조회 실패", e)
+                handleFailure(e)
+            }
     }
 
     suspend fun loadInitialData(productId: Int) {
@@ -128,7 +137,11 @@ class ResvRequestViewModel @Inject constructor(
                         totalPrice = totalPrice
                     )
                 )
-            }.onFailure { e -> handleFailure(e) }
+                Log.i(TAG, "대여 예약 성공: ${it.data.reservationId}")
+            }.onFailure { e ->
+                Log.e(TAG, "대여 예약 실패", e)
+                handleFailure(e)
+            }
         }
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/components/DateRangePicker.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/components/DateRangePicker.kt
@@ -44,7 +44,7 @@ fun DateRangePicker(
     modifier: Modifier = Modifier,
     rentalStartDate: LocalDate?,
     rentalEndDate: LocalDate?,
-    rentalPeriod: Int,
+    selectedPeriod: Int,
     disabledDates: List<String> = emptyList(),
     setRentalStartDate: (LocalDate?) -> Unit,
     setRentalEndDate: (LocalDate?) -> Unit,
@@ -61,7 +61,7 @@ fun DateRangePicker(
     Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         CalendarHeader(yearMonth.value, { changeMonth(-1) }, { changeMonth(1) })
         DayOfWeek(cellWidth)
-        CalendarDate(yearMonth = yearMonth.value, disabledDates = disabledDates, cellWidth = cellWidth, isPastDateDisabled = true, rentalStartDate, rentalEndDate, rentalPeriod) { date ->
+        CalendarDate(yearMonth = yearMonth.value, disabledDates = disabledDates, cellWidth = cellWidth, isPastDateDisabled = true, rentalStartDate, rentalEndDate, selectedPeriod) { date ->
             if (!isSelectingStartDate && rentalStartDate != null) {
                 if (date.isBefore(rentalStartDate)) {
                     if (isSelectingEndDate) {
@@ -95,7 +95,7 @@ fun DateRangePicker(
                 }
                 Text(modifier = Modifier.padding(horizontal = 5.dp), text = "까지", style = MaterialTheme.typography.bodyMedium)
             }
-            TotalPeriodText(rentalPeriod)
+            TotalPeriodText(selectedPeriod)
         }
     }
 }
@@ -136,7 +136,7 @@ private fun Preview() {
             hiltViewModel(),
             rentalStartDate = null,
             rentalEndDate = null,
-            rentalPeriod = 0,
+            selectedPeriod = 0,
             setRentalStartDate = { },
             setRentalEndDate = { },
         )

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/components/DateRangePicker.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/components/DateRangePicker.kt
@@ -82,6 +82,7 @@ fun DateRangePicker(
             }
         }
         Column(modifier = Modifier
+            .padding(top = 20.dp)
             .fillMaxWidth()
             .screenHorizontalPadding(), horizontalAlignment = Alignment.CenterHorizontally) {
             Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,6 +143,7 @@
 
     <!-- 대여 예약 요청 -->
     <string name="screen_resv_request_app_bar_title">예약 기간을 설정해주세요.</string>
+    <string name="screen_resv_request_period_guide">이 상품은 %s까지 대여가 가능해요</string>
     <string name="screen_resv_request_label_total_rental_fee">총 대여 비용</string>
     <string name="screen_resv_request_label_deposit">보증금</string>
     <string name="screen_resv_request_label_total_fee">합계</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,12 @@
     <string name="screen_resv_request_label_total_fee">합계</string>
     <string name="screen_resv_request_btn_resv_request">예약 요청</string>
 
+    <string name="dialog_owner_access_not_allowed_title">예약할 수 없어요</string>
+    <string name="dialog_owner_access_not_allowed_content">이 상품은 등록하신 상품이라 예약할 수 없어요.</string>
+
+    <string name="dialog_resv_already_exist_title">이미 예약한 상품이에요</string>
+    <string name="dialog_resv_already_exist_content">이 상품에 대한 예약 내역이 있어요. 예약 내역을 확인해주세요.</string>
+
     <!-- 예약 요청 확인 -->
     <string name="screen_request_confirm_title">요청이 전달되었어요!</string>
     <string name="screen_request_confirm_resv_period">예약 기간</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,8 @@
     <string name="screen_resv_request_label_total_fee">합계</string>
     <string name="screen_resv_request_btn_resv_request">예약 요청</string>
 
+    <string name="toast_invalid_period">상품의 최소/최대 대여 기간을 확인해주세요.</string>
+
     <string name="dialog_owner_access_not_allowed_title">예약할 수 없어요</string>
     <string name="dialog_owner_access_not_allowed_content">이 상품은 등록하신 상품이라 예약할 수 없어요.</string>
 


### PR DESCRIPTION
# Pull Request

## Summary  
`ResvRequestScreen`을 Screen, Route, ViewModel, State, SideEffect를 사용하는 구조로 리팩토링하고, UI/UX를 개선

## Related Issue  
- Close: #146

## Changes  
**Route 분리**
- `ResvRequestRoute.kt` 추가: Navigation, ViewModel, UI 상태 처리
- `ResvRequestScreen.kt`를 Pure UI로 리팩토링
- Navigation 파라미터를 non-null `productId`로 수정

**UI 상태 관리 및 일회성 이벤트**
- `ResvRequestState`, `ResvRequestSideEffect` 추가로 UI 상태 및 일회성 이벤트 (Navigation/Toast) 관리
- ViewModel에서 하나의 StateFlow/SharedFlow 로 통합 관리

**Repository 개선**
- `getReservedDates`, `postResv`을 `runCatching`을 사용하도록 리팩토링하여 서버 결과 처리를 명확히 분기함
- `403` 에러 (접근 권한 없음)에 대해 `AccessNotAllowedException`으로 통일함

**기간 제한 확인 로직 추가**
- PostResvRequestUseCase 도입: 상품 소유자가 제한한 기간과 사용자가 선택한 기간을 비교하고, 범위를 벗어날 경우 `IllegalArgumentException`
- UI 변경: 선택한 날짜 텍스트 하단에 기간 범위 제한 안내 텍스트 추가

**화면 스크롤 추가**
- 화면 VerticalScroll을 추가하여 달력 높이의 변화에도 모든 화면을 안정적으로 볼 수 있도록 개선

**ViewModel 통합 에러처리**
- 서버 통신 및 비즈니스 로직 수행시 발생하는 에러를 `handleFailure`로 하나로 관리, 각 케이스에 따라 Dialog나 ToastMessage를 Trigger함

## Screenshots
수정 전 -> 수정 후(스크롤 전/후)
<div>
<img width="25%" src="https://github.com/user-attachments/assets/a3372a81-fdf2-4b50-90d1-9e06b9f6421d"/>
&nbsp;&nbsp;&nbsp;->&nbsp;&nbsp;&nbsp;
<img width="25%" src="https://github.com/user-attachments/assets/4ae23750-0ef3-4e06-8519-d6f76fcd4e8a"/>
<img width="25%" src="https://github.com/user-attachments/assets/9292491e-f01f-435b-aae4-a5a8c373010c"/>
</div>
