### PR TITLE
Feat/153 server response handling

### DIFF
--- a/app/src/main/java/com/example/rentit/common/exception/ExpiredTokenException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/ExpiredTokenException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.common.exception
-
-class ExpiredTokenException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/common/exception/MissingTokenException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/MissingTokenException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.common.exception
-
-class MissingTokenException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/common/exception/ServerException.kt
+++ b/app/src/main/java/com/example/rentit/common/exception/ServerException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.common.exception
-
-class ServerException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/core/error/BadRequestException.kt
+++ b/app/src/main/java/com/example/rentit/core/error/BadRequestException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.core.error
+
+class BadRequestException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/core/error/ConflictException.kt
+++ b/app/src/main/java/com/example/rentit/core/error/ConflictException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.core.error
+
+class ConflictException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/core/error/ForbiddenException.kt
+++ b/app/src/main/java/com/example/rentit/core/error/ForbiddenException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.core.error
+
+class ForbiddenException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/core/error/NotFoundException.kt
+++ b/app/src/main/java/com/example/rentit/core/error/NotFoundException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.core.error
+
+class NotFoundException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/core/error/ServerErrorException.kt
+++ b/app/src/main/java/com/example/rentit/core/error/ServerErrorException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.core.error
+
+class ServerErrorException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/core/error/UnauthorizedException.kt
+++ b/app/src/main/java/com/example/rentit/core/error/UnauthorizedException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.core.error
+
+class UnauthorizedException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/core/error/UnknownException.kt
+++ b/app/src/main/java/com/example/rentit/core/error/UnknownException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.core.error
+
+class UnknownException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/core/error/UnprocessableEntityException.kt
+++ b/app/src/main/java/com/example/rentit/core/error/UnprocessableEntityException.kt
@@ -1,0 +1,3 @@
+package com.example.rentit.core.error
+
+class UnprocessableEntityException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/core/network/ResponseHandlingExtension.kt
+++ b/app/src/main/java/com/example/rentit/core/network/ResponseHandlingExtension.kt
@@ -1,6 +1,5 @@
 package com.example.rentit.core.network
 
-import com.example.rentit.common.exception.ServerException
 import com.example.rentit.core.error.BadRequestException
 import com.example.rentit.core.error.ConflictException
 import com.example.rentit.core.error.ForbiddenException
@@ -14,7 +13,7 @@ import retrofit2.Response
 fun <T> Response<T>.getOrThrow(): Result<T> {
     return runCatching {
         if(isSuccessful) {
-            body() ?: throw ServerException("Response body is null")
+            body() ?: throw ServerErrorException("Response body is null")
         } else {
             val errorMessage = errorBody()?.string() ?: "Client Error"
             throw when(code()) {

--- a/app/src/main/java/com/example/rentit/core/network/ResponseHandlingExtension.kt
+++ b/app/src/main/java/com/example/rentit/core/network/ResponseHandlingExtension.kt
@@ -1,0 +1,32 @@
+package com.example.rentit.core.network
+
+import com.example.rentit.common.exception.ServerException
+import com.example.rentit.core.error.BadRequestException
+import com.example.rentit.core.error.ConflictException
+import com.example.rentit.core.error.ForbiddenException
+import com.example.rentit.core.error.NotFoundException
+import com.example.rentit.core.error.ServerErrorException
+import com.example.rentit.core.error.UnauthorizedException
+import com.example.rentit.core.error.UnknownException
+import com.example.rentit.core.error.UnprocessableEntityException
+import retrofit2.Response
+
+fun <T> Response<T>.getOrThrow(): Result<T> {
+    return runCatching {
+        if(isSuccessful) {
+            body() ?: throw ServerException("Response body is null")
+        } else {
+            val errorMessage = errorBody()?.string() ?: "Client Error"
+            throw when(code()) {
+                400 -> BadRequestException(errorMessage)
+                401 -> UnauthorizedException(errorMessage)
+                403 -> ForbiddenException(errorMessage)
+                404 -> NotFoundException(errorMessage)
+                409 -> ConflictException(errorMessage)
+                422 -> UnprocessableEntityException(errorMessage)
+                in 500..599 -> ServerErrorException(errorMessage)
+                else -> UnknownException(errorMessage)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/data/chat/repositoryImpl/ChatRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/repositoryImpl/ChatRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.example.rentit.data.chat.repositoryImpl
 
-import com.example.rentit.core.network.getOrThrow
+import com.example.rentit.core.network.safeApiCall
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
 import com.example.rentit.data.chat.dto.NewChatResponseDto
@@ -13,17 +13,14 @@ class ChatRepositoryImpl @Inject constructor(
 ): ChatRepository {
 
     override suspend fun getChatList(): Result<ChatListResponseDto> {
-        val response = chatRemoteDataSource.getChatList()
-        return response.getOrThrow()
+        return safeApiCall(chatRemoteDataSource::getChatList)
     }
 
     override suspend fun getChatDetail(chatRoomId: String, skip: Int, size: Int): Result<ChatDetailResponseDto> {
-        val response = chatRemoteDataSource.getChatDetail(chatRoomId, skip, size)
-        return response.getOrThrow()
+        return safeApiCall { chatRemoteDataSource.getChatDetail(chatRoomId, skip, size) }
     }
 
     override suspend fun postNewChat(productId: Int): Result<NewChatResponseDto> {
-        val response = chatRemoteDataSource.postNewChat(productId)
-        return response.getOrThrow()
+        return safeApiCall { chatRemoteDataSource.postNewChat(productId) }
     }
 }

--- a/app/src/main/java/com/example/rentit/data/chat/repositoryImpl/ChatRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/repositoryImpl/ChatRepositoryImpl.kt
@@ -1,72 +1,29 @@
 package com.example.rentit.data.chat.repositoryImpl
 
-import android.util.Log
-import com.example.rentit.common.exception.MissingTokenException
-import com.example.rentit.domain.chat.exception.ForbiddenChatAccessException
-import com.example.rentit.common.exception.ServerException
-import com.example.rentit.domain.chat.exception.ChatRoomAlreadyExistsException
+import com.example.rentit.core.network.getOrThrow
 import com.example.rentit.data.chat.dto.ChatDetailResponseDto
 import com.example.rentit.data.chat.dto.ChatListResponseDto
 import com.example.rentit.data.chat.dto.NewChatResponseDto
 import com.example.rentit.data.chat.remote.ChatRemoteDataSource
 import com.example.rentit.domain.chat.repository.ChatRepository
-import com.example.rentit.domain.product.exception.AccessNotAllowedException
-import com.example.rentit.domain.rental.exception.EmptyBodyException
 import javax.inject.Inject
-
-private const val TAG = "ChatRepository"
 
 class ChatRepositoryImpl @Inject constructor(
     private val chatRemoteDataSource: ChatRemoteDataSource,
 ): ChatRepository {
 
     override suspend fun getChatList(): Result<ChatListResponseDto> {
-        return runCatching {
-            val response = chatRemoteDataSource.getChatList()
-            if(response.isSuccessful){
-                response.body() ?: throw EmptyBodyException()
-            } else {
-                val errorMsg = response.errorBody()?.string() ?: "Client Error"
-                throw if(response.code() == 401) MissingTokenException(errorMsg) else Exception(errorMsg)
-            }
-        }
+        val response = chatRemoteDataSource.getChatList()
+        return response.getOrThrow()
     }
 
     override suspend fun getChatDetail(chatRoomId: String, skip: Int, size: Int): Result<ChatDetailResponseDto> {
-        return runCatching {
-            val response = chatRemoteDataSource.getChatDetail(chatRoomId, skip, size)
-            val errorMsg = response.errorBody()?.string() ?: "Client Error"
-            when(response.code()) {
-                200 -> response.body() ?: throw EmptyBodyException()
-                401 -> throw MissingTokenException(errorMsg)
-                403 -> throw ForbiddenChatAccessException(errorMsg)
-                else -> throw Exception(errorMsg)
-            }
-        }
+        val response = chatRemoteDataSource.getChatDetail(chatRoomId, skip, size)
+        return response.getOrThrow()
     }
 
     override suspend fun postNewChat(productId: Int): Result<NewChatResponseDto> {
-        return runCatching {
-            val response = chatRemoteDataSource.postNewChat(productId)
-            when (response.code()) {
-                200 -> response.body() ?: throw Exception("Empty response body")
-                403 -> {
-                    Log.e(TAG, "Server error 403: ${response.errorBody()?.string()}")
-                    throw AccessNotAllowedException()
-                }
-                409 -> {
-                    Log.e(TAG, "Server error 409: ${response.errorBody()?.string()}")
-                    throw ChatRoomAlreadyExistsException()
-                }
-                500 -> {
-                    Log.e(TAG, "Server error 500: ${response.errorBody()?.string()}")
-                    throw ServerException("Server error")
-                }
-                else -> {
-                    Log.e(TAG, "Unexpected error: code=${response.code()}, ${response.errorBody()?.string()}")
-                    throw Exception("Unexpected error")
-                }
-            }
-        }
+        val response = chatRemoteDataSource.postNewChat(productId)
+        return response.getOrThrow()
     }
 }

--- a/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.example.rentit.data.product.repositoryImpl
 
-import com.example.rentit.core.network.getOrThrow
+import com.example.rentit.core.network.safeApiCall
 import com.example.rentit.data.product.dto.ResvRequestDto
 import com.example.rentit.data.product.dto.ResvResponseDto
 import com.example.rentit.data.product.dto.CategoryListResponseDto
@@ -19,37 +19,30 @@ class ProductRepositoryImpl @Inject constructor(
     private val productRemoteDataSource: ProductRemoteDataSource
 ): ProductRepository {
     override suspend fun getProductList(): Result<ProductListResponseDto> {
-        val response = productRemoteDataSource.getProductList()
-        return response.getOrThrow()
+        return safeApiCall(productRemoteDataSource::getProductList)
     }
 
     override suspend fun getProductDetail(productId: Int): Result<ProductDetailResponseDto> {
-        val response = productRemoteDataSource.getProductDetail(productId)
-        return response.getOrThrow()
+        return safeApiCall { productRemoteDataSource.getProductDetail(productId) }
     }
 
     override suspend fun getReservedDates(productId: Int): Result<ProductReservedDatesResponseDto> {
-        val response = productRemoteDataSource.getReservedDates(productId)
-        return response.getOrThrow()
+        return safeApiCall { productRemoteDataSource.getReservedDates(productId) }
     }
 
     override suspend fun postResv(productId: Int, request: ResvRequestDto): Result<ResvResponseDto> {
-        val response = productRemoteDataSource.postResv(productId, request)
-        return response.getOrThrow()
+        return safeApiCall { productRemoteDataSource.postResv(productId, request) }
     }
 
     override suspend fun getCategories(): Result<CategoryListResponseDto> {
-        val response = productRemoteDataSource.getCategories()
-        return response.getOrThrow()
+        return safeApiCall(productRemoteDataSource::getCategories)
     }
 
     override suspend fun createPost(payLoad: RequestBody, thumbnailImg: MultipartBody.Part?): Result<CreatePostResponseDto> {
-        val response = productRemoteDataSource.createPost(payLoad, thumbnailImg)
-        return response.getOrThrow()
+        return safeApiCall { productRemoteDataSource.createPost(payLoad, thumbnailImg) }
     }
 
     override suspend fun getProductRequestList(productId: Int): Result<RequestHistoryResponseDto> {
-        val response = productRemoteDataSource.getProductRequestList(productId)
-        return response.getOrThrow()
+        return safeApiCall { productRemoteDataSource.getProductRequestList(productId) }
     }
 }

--- a/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
@@ -1,9 +1,6 @@
 package com.example.rentit.data.product.repositoryImpl
 
-import com.example.rentit.common.exception.ExpiredTokenException
-import com.example.rentit.common.exception.MissingTokenException
-import com.example.rentit.common.exception.ServerException
-import com.example.rentit.domain.rental.exception.EmptyBodyException
+import com.example.rentit.core.network.getOrThrow
 import com.example.rentit.data.product.dto.ResvRequestDto
 import com.example.rentit.data.product.dto.ResvResponseDto
 import com.example.rentit.data.product.dto.CategoryListResponseDto
@@ -13,8 +10,6 @@ import com.example.rentit.data.product.dto.ProductReservedDatesResponseDto
 import com.example.rentit.data.product.dto.ProductListResponseDto
 import com.example.rentit.data.product.dto.RequestHistoryResponseDto
 import com.example.rentit.data.product.remote.ProductRemoteDataSource
-import com.example.rentit.domain.product.exception.AccessNotAllowedException
-import com.example.rentit.domain.product.exception.ResvAlreadyExistException
 import com.example.rentit.domain.product.repository.ProductRepository
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -24,117 +19,37 @@ class ProductRepositoryImpl @Inject constructor(
     private val productRemoteDataSource: ProductRemoteDataSource
 ): ProductRepository {
     override suspend fun getProductList(): Result<ProductListResponseDto> {
-        return runCatching {
-            val response = productRemoteDataSource.getProductList()
-            if(response.isSuccessful) {
-                response.body() ?: throw EmptyBodyException()
-            } else {
-                val errorMsg = response.errorBody()?.string() ?: "Client Error"
-                throw when(response.code()) {
-                    401 -> ExpiredTokenException(errorMsg)
-                    500 -> ServerException(errorMsg)
-                    else -> Exception(errorMsg)
-                }
-            }
-        }
+        val response = productRemoteDataSource.getProductList()
+        return response.getOrThrow()
     }
 
     override suspend fun getProductDetail(productId: Int): Result<ProductDetailResponseDto> {
-        return runCatching {
-            val response = productRemoteDataSource.getProductDetail(productId)
-            if(response.isSuccessful) {
-                response.body() ?: throw EmptyBodyException()
-            } else {
-                val errorMsg = response.errorBody()?.string() ?: "Client Error"
-                throw if(response.code() == 401) MissingTokenException(errorMsg) else Exception(errorMsg)
-            }
-        }
+        val response = productRemoteDataSource.getProductDetail(productId)
+        return response.getOrThrow()
     }
 
     override suspend fun getReservedDates(productId: Int): Result<ProductReservedDatesResponseDto> {
-        return runCatching {
-            val response = productRemoteDataSource.getReservedDates(productId)
-            if(response.isSuccessful) {
-                response.body() ?: throw EmptyBodyException()
-            } else {
-                val errorMsg = response.errorBody()?.string() ?: "Client Error"
-                when(response.code()) {
-                    401 -> throw MissingTokenException(errorMsg)
-                    500 -> throw ServerException(errorMsg)
-                    else -> throw Exception(errorMsg)
-                }
-            }
-        }
+        val response = productRemoteDataSource.getReservedDates(productId)
+        return response.getOrThrow()
     }
 
     override suspend fun postResv(productId: Int, request: ResvRequestDto): Result<ResvResponseDto> {
-        return runCatching {
-            val response = productRemoteDataSource.postResv(productId, request)
-            if(response.isSuccessful) {
-                response.body() ?: throw EmptyBodyException()
-            } else {
-                val errorMsg = response.errorBody()?.string() ?: "Client Error"
-                throw when(response.code()) {
-                    401 -> MissingTokenException(errorMsg)
-                    403 -> AccessNotAllowedException(errorMsg)   // 판매자가 요청한 경우
-                    409 -> ResvAlreadyExistException(errorMsg)  // 이미 동일 기간의 예약이 1건 이상 존재하는 경우
-                    500 -> ServerException(errorMsg)
-                    else -> Exception(errorMsg)
-                }
-            }
-        }
+        val response = productRemoteDataSource.postResv(productId, request)
+        return response.getOrThrow()
     }
 
     override suspend fun getCategories(): Result<CategoryListResponseDto> {
-        return runCatching {
-            val response = productRemoteDataSource.getCategories()
-            if(response.isSuccessful) {
-                response.body() ?: throw EmptyBodyException()
-            } else {
-                val errorMsg = response.errorBody()?.string() ?: "Client Error"
-                throw Exception(errorMsg)
-            }
-        }
+        val response = productRemoteDataSource.getCategories()
+        return response.getOrThrow()
     }
 
     override suspend fun createPost(payLoad: RequestBody, thumbnailImg: MultipartBody.Part?): Result<CreatePostResponseDto> {
-        return try {
-            val response = productRemoteDataSource.createPost(payLoad, thumbnailImg)
-            when(response.code()) {
-                200 -> {
-                    val body = response.body()
-                    if(body != null) {
-                        Result.success(body)
-                    } else {
-                        Result.failure(Exception("Empty response body"))
-                    }
-                }
-                500 -> {
-                    Result.failure(Exception("Server error"))
-                }
-                else -> {
-                    Result.failure(Exception("Unexpected error"))
-                }
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
+        val response = productRemoteDataSource.createPost(payLoad, thumbnailImg)
+        return response.getOrThrow()
     }
 
     override suspend fun getProductRequestList(productId: Int): Result<RequestHistoryResponseDto> {
-        return runCatching {
-            val response = productRemoteDataSource.getProductRequestList(productId)
-            if(response.isSuccessful){
-                response.body() ?: throw EmptyBodyException()
-            } else {
-                val errorMsg = response.errorBody()?.string() ?: "Client Error"
-                throw when(response.code()) {
-                    401 -> MissingTokenException(errorMsg)
-                    403 -> AccessNotAllowedException(errorMsg)
-                    500 -> ServerException(errorMsg)
-                    else -> Exception(errorMsg)
-                }
-            }
-        }
+        val response = productRemoteDataSource.getProductRequestList(productId)
+        return response.getOrThrow()
     }
 }

--- a/app/src/main/java/com/example/rentit/data/rental/repositoryImpl/RentalRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/repositoryImpl/RentalRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.example.rentit.data.rental.repositoryImpl
 
 import com.example.rentit.common.enums.PhotoRegistrationType
-import com.example.rentit.core.network.getOrThrow
+import com.example.rentit.core.network.safeApiCall
 import com.example.rentit.data.rental.dto.CourierNamesResponseDto
 import com.example.rentit.data.rental.dto.PhotoRegistrationResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
@@ -18,32 +18,26 @@ class RentalRepositoryImpl @Inject constructor(
     private val rentalRemoteDataSource: RentalRemoteDataSource
 ): RentalRepository {
     override suspend fun getRentalDetail(productId: Int, reservationId: Int): Result<RentalDetailResponseDto> {
-        val response = rentalRemoteDataSource.getRentalDetail(productId, reservationId)
-        return response.getOrThrow()
+        return safeApiCall { rentalRemoteDataSource.getRentalDetail(productId, reservationId) }
     }
 
     override suspend fun postTrackingRegistration(productId: Int, reservationId: Int, body: TrackingRegistrationRequestDto): Result<TrackingRegistrationResponseDto?> {
-        val response = rentalRemoteDataSource.postTrackingRegistration(productId, reservationId, body)
-        return response.getOrThrow()
+        return safeApiCall { rentalRemoteDataSource.postTrackingRegistration(productId, reservationId, body) }
     }
 
     override suspend fun getCourierNames(): Result<CourierNamesResponseDto> {
-        val response = rentalRemoteDataSource.getCourierNames()
-        return response.getOrThrow()
+        return safeApiCall(rentalRemoteDataSource::getCourierNames)
     }
 
     override suspend fun updateRentalStatus(productId: Int, reservationId: Int, request: UpdateRentalStatusRequestDto): Result<Unit> {
-        val response = rentalRemoteDataSource.updateRentalStatus(productId, reservationId, request)
-        return response.getOrThrow()
+        return safeApiCall { rentalRemoteDataSource.updateRentalStatus(productId, reservationId, request) }
     }
 
     override suspend fun postPhotoRegistration(productId: Int, reservationId: Int, type: PhotoRegistrationType, images: List<MultipartBody.Part>): Result<PhotoRegistrationResponseDto> {
-        val response = rentalRemoteDataSource.postPhotoRegistration(productId, reservationId, type, images)
-        return response.getOrThrow()
+        return safeApiCall { rentalRemoteDataSource.postPhotoRegistration(productId, reservationId, type, images) }
     }
 
     override suspend fun getRentalPhotos(productId: Int, reservationId: Int): Result<RentalPhotoResponseDto> {
-        val response = rentalRemoteDataSource.getRentalPhotos(productId, reservationId)
-        return response.getOrThrow()
+        return safeApiCall { rentalRemoteDataSource.getRentalPhotos(productId, reservationId) }
     }
 }

--- a/app/src/main/java/com/example/rentit/data/rental/repositoryImpl/RentalRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/rental/repositoryImpl/RentalRepositoryImpl.kt
@@ -1,11 +1,9 @@
 package com.example.rentit.data.rental.repositoryImpl
 
 import com.example.rentit.common.enums.PhotoRegistrationType
-import com.example.rentit.common.exception.MissingTokenException
-import com.example.rentit.common.exception.ServerException
-import com.example.rentit.domain.rental.exception.RentalNotFoundException
-import com.example.rentit.domain.rental.exception.EmptyBodyException
+import com.example.rentit.core.network.getOrThrow
 import com.example.rentit.data.rental.dto.CourierNamesResponseDto
+import com.example.rentit.data.rental.dto.PhotoRegistrationResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.RentalPhotoResponseDto
 import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
@@ -20,70 +18,32 @@ class RentalRepositoryImpl @Inject constructor(
     private val rentalRemoteDataSource: RentalRemoteDataSource
 ): RentalRepository {
     override suspend fun getRentalDetail(productId: Int, reservationId: Int): Result<RentalDetailResponseDto> {
-        return runCatching {
-            val response = rentalRemoteDataSource.getRentalDetail(productId, reservationId)
-            if (response.isSuccessful) {
-                response.body() ?: throw EmptyBodyException()
-            } else {
-                throw ServerException()
-            }
-        }
+        val response = rentalRemoteDataSource.getRentalDetail(productId, reservationId)
+        return response.getOrThrow()
     }
 
     override suspend fun postTrackingRegistration(productId: Int, reservationId: Int, body: TrackingRegistrationRequestDto): Result<TrackingRegistrationResponseDto?> {
-        return runCatching {
-            val response = rentalRemoteDataSource.postTrackingRegistration(productId, reservationId, body)
-            if (response.isSuccessful) {
-                response.body()
-            } else {
-                throw ServerException()
-            }
-        }
+        val response = rentalRemoteDataSource.postTrackingRegistration(productId, reservationId, body)
+        return response.getOrThrow()
     }
 
     override suspend fun getCourierNames(): Result<CourierNamesResponseDto> {
-        return runCatching {
-            val response = rentalRemoteDataSource.getCourierNames()
-            if (response.isSuccessful) {
-                response.body() ?: throw EmptyBodyException()
-            } else {
-                throw ServerException()
-            }
-        }
+        val response = rentalRemoteDataSource.getCourierNames()
+        return response.getOrThrow()
     }
 
     override suspend fun updateRentalStatus(productId: Int, reservationId: Int, request: UpdateRentalStatusRequestDto): Result<Unit> {
-        return runCatching {
-            val response = rentalRemoteDataSource.updateRentalStatus(productId, reservationId, request)
-            if (!response.isSuccessful) {
-                throw when (response.code()) {
-                    401 -> MissingTokenException()
-                    404 -> RentalNotFoundException()
-                    else -> ServerException()
-                }
-            }
-            Unit
-        }
+        val response = rentalRemoteDataSource.updateRentalStatus(productId, reservationId, request)
+        return response.getOrThrow()
     }
 
-    override suspend fun postPhotoRegistration(productId: Int, reservationId: Int, type: PhotoRegistrationType, images: List<MultipartBody.Part>): Result<Unit> {
-        return runCatching {
-            val response = rentalRemoteDataSource.postPhotoRegistration(productId, reservationId, type, images)
-            if (!response.isSuccessful) {
-                throw Exception()
-            }
-            Unit
-        }
+    override suspend fun postPhotoRegistration(productId: Int, reservationId: Int, type: PhotoRegistrationType, images: List<MultipartBody.Part>): Result<PhotoRegistrationResponseDto> {
+        val response = rentalRemoteDataSource.postPhotoRegistration(productId, reservationId, type, images)
+        return response.getOrThrow()
     }
 
     override suspend fun getRentalPhotos(productId: Int, reservationId: Int): Result<RentalPhotoResponseDto> {
-        return runCatching {
-            val response = rentalRemoteDataSource.getRentalPhotos(productId, reservationId)
-            if (response.isSuccessful) {
-                response.body() ?: throw EmptyBodyException()
-            } else {
-                throw ServerException()
-            }
-        }
+        val response = rentalRemoteDataSource.getRentalPhotos(productId, reservationId)
+        return response.getOrThrow()
     }
 }

--- a/app/src/main/java/com/example/rentit/data/user/repositoryImpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/user/repositoryImpl/UserRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.example.rentit.data.user.repositoryImpl
 
-import com.example.rentit.core.network.getOrThrow
+import com.example.rentit.core.network.safeApiCall
 import com.example.rentit.data.user.dto.GoogleLoginResponseDto
 import com.example.rentit.data.user.dto.MyInfoResponseDto
 import com.example.rentit.data.user.dto.MyProductListResponseDto
@@ -17,38 +17,31 @@ class UserRepositoryImpl @Inject constructor(
     private val remoteDataSource: UserRemoteDataSource
 ): UserRepository {
     override suspend fun googleLogin(code: String, redirectUri: String): Result<GoogleLoginResponseDto> {
-        val response = remoteDataSource.googleLogin(code, redirectUri)
-        return response.getOrThrow()
+        return safeApiCall { remoteDataSource.googleLogin(code, redirectUri) }
     }
 
     override suspend fun sendPhoneCode(phoneNumber: String): Result<SendPhoneCodeResponseDto> {
-        val response = remoteDataSource.sendPhoneCode(phoneNumber)
-        return response.getOrThrow()
+        return safeApiCall { remoteDataSource.sendPhoneCode(phoneNumber) }
     }
 
     override suspend fun verifyPhoneCode(phoneNumber: String, code: String): Result<VerifyPhoneCodeResponseDto> {
-        val response = remoteDataSource.verifyPhoneCode(phoneNumber, code)
-        return response.getOrThrow()
+        return safeApiCall { remoteDataSource.verifyPhoneCode(phoneNumber, code) }
     }
 
     override suspend fun signUp(name: String, email: String, nickname: String, profileImageUrl: String): Result<Unit> {
-        val response = remoteDataSource.signUp(name, email, nickname, profileImageUrl)
-        return response.getOrThrow()
+        return safeApiCall { remoteDataSource.signUp(name, email, nickname, profileImageUrl) }
     }
 
     override suspend fun getMyInfo(): Result<MyInfoResponseDto> {
-        val response = remoteDataSource.getMyInfo()
-        return response.getOrThrow()
+        return safeApiCall(remoteDataSource::getMyInfo)
     }
 
     override suspend fun getMyProductList(): Result<MyProductListResponseDto> {
-        val response = remoteDataSource.getMyProductList()
-        return response.getOrThrow()
+        return safeApiCall(remoteDataSource::getMyProductList)
     }
 
     override suspend fun getMyRentalList(): Result<MyRentalListResponseDto> {
-        val response = remoteDataSource.getMyRentalList()
-        return response.getOrThrow()
+        return safeApiCall(remoteDataSource::getMyRentalList)
     }
 
     override fun getAuthUserIdFromPrefs(): Long = prefsDataSource.getAuthUserIdFromPrefs()

--- a/app/src/main/java/com/example/rentit/domain/chat/exception/ChatRoomAlreadyExistsException.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/exception/ChatRoomAlreadyExistsException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.chat.exception
-
-class ChatRoomAlreadyExistsException: Exception()

--- a/app/src/main/java/com/example/rentit/domain/chat/exception/ForbiddenChatAccessException.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/exception/ForbiddenChatAccessException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.chat.exception
-
-class ForbiddenChatAccessException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/chat/exception/NotChatRoomMemberException.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/exception/NotChatRoomMemberException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.chat.exception
-
-class NotChatRoomMemberException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/chat/usecase/ConvertMessageUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/usecase/ConvertMessageUseCase.kt
@@ -8,6 +8,13 @@ import com.example.rentit.domain.chat.model.ChatMessageModel
 import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
 
+/**
+ * 서버에서 받은 MessageResponseDto를 도메인 모델(ChatMessageModel)로 변환하는 UseCase
+ *
+ * - 현재 로그인한 사용자의 ID를 기준으로 메시지가 본인 메시지인지 구분
+ * - Presentation Layer 또는 다른 도메인 로직에서 바로 사용할 수 있는 모델 반환
+ */
+
 @RequiresApi(Build.VERSION_CODES.O)
 class ConvertMessageUseCase @Inject constructor(
     private val userRepository: UserRepository

--- a/app/src/main/java/com/example/rentit/domain/chat/usecase/GetChatRoomDetailUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/usecase/GetChatRoomDetailUseCase.kt
@@ -2,12 +2,20 @@ package com.example.rentit.domain.chat.usecase
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import com.example.rentit.domain.chat.exception.NotChatRoomMemberException
+import com.example.rentit.core.error.ForbiddenException
 import com.example.rentit.domain.chat.model.ChatMessageModel
 import com.example.rentit.domain.chat.model.ChatRoomDetailModel
 import com.example.rentit.domain.chat.repository.ChatRepository
 import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
+
+/**
+ * 채팅방 상세 정보를 가져오는 UseCase
+ *
+ * - 현재 로그인한 사용자가 채팅방 참가자인지 확인
+ * - 채팅 참가자가 아닌 경우 ForbiddenException 발생
+ * - 채팅방의 상대방 정보와 메시지 리스트를 도메인 모델로 변환
+ */
 
 @RequiresApi(Build.VERSION_CODES.O)
 class GetChatRoomDetailUseCase @Inject constructor(
@@ -25,7 +33,7 @@ class GetChatRoomDetailUseCase @Inject constructor(
             val chatRoomDetail = chatRepository.getChatDetail(chatRoomId, DEFAULT_PAGE, DEFAULT_PAGE_SIZE).getOrThrow()
             val participants = chatRoomDetail.chatRoom.participants
 
-            if(participants.find { it.userId == authUserId } == null) throw NotChatRoomMemberException()
+            if(participants.find { it.userId == authUserId } == null) throw ForbiddenException()
 
             val partner = participants.find { it.userId != authUserId }
 

--- a/app/src/main/java/com/example/rentit/domain/chat/usecase/GetChatRoomSummariesUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/usecase/GetChatRoomSummariesUseCase.kt
@@ -7,6 +7,14 @@ import com.example.rentit.domain.chat.repository.ChatRepository
 import java.time.OffsetDateTime
 import javax.inject.Inject
 
+/**
+ * 채팅방 목록 요약 정보를 가져오는 UseCase
+ *
+ * - 서버에서 채팅방 리스트를 가져옴
+ * - 각 채팅방의 마지막 메시지 시간과 기본 정보를 도메인 모델(ChatRoomSummaryModel)로 변환
+ * - Presentation Layer에서 바로 사용 가능
+ */
+
 @RequiresApi(Build.VERSION_CODES.O)
 class GetChatRoomSummariesUseCase @Inject constructor(
     private val chatRepository: ChatRepository

--- a/app/src/main/java/com/example/rentit/domain/product/exception/AccessNotAllowedException.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/exception/AccessNotAllowedException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.product.exception
-
-class AccessNotAllowedException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/product/exception/ResvAlreadyExistException.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/exception/ResvAlreadyExistException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.product.exception
-
-class ResvAlreadyExistException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/product/usecase/GetChatRoomProductSummaryUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/usecase/GetChatRoomProductSummaryUseCase.kt
@@ -7,6 +7,13 @@ import com.example.rentit.domain.product.model.ProductChatRoomSummaryModel
 import com.example.rentit.domain.product.repository.ProductRepository
 import javax.inject.Inject
 
+/**
+ * 특정 상품에 대한 채팅방 요약 정보를 가져오는 UseCase
+ *
+ * - 상품 ID를 기반으로 상품 상세 정보를 가져옴
+ * - 상품 정보를 채팅방 요약 도메인 모델(ProductChatRoomSummaryModel)로 변환
+ */
+
 class GetChatRoomProductSummaryUseCase @Inject constructor(
     private val productRepository: ProductRepository
 ) {

--- a/app/src/main/java/com/example/rentit/domain/product/usecase/GetProductListWithCategoryUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/usecase/GetProductListWithCategoryUseCase.kt
@@ -5,6 +5,13 @@ import com.example.rentit.domain.product.model.ProductWithCategory
 import com.example.rentit.domain.product.repository.ProductRepository
 import javax.inject.Inject
 
+/**
+ * 상품 리스트를 카테고리 정보와 함께 가져오는 UseCase
+ *
+ * - 서버에서 상품 리스트를 조회
+ * - 각 상품에 대해 카테고리 정보를 매핑하여 도메인 모델(ProductWithCategory)로 변환
+ */
+
 class GetProductListWithCategoryUseCase @Inject constructor(
     private val productRepository: ProductRepository
 ) {

--- a/app/src/main/java/com/example/rentit/domain/product/usecase/PostResvRequestUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/usecase/PostResvRequestUseCase.kt
@@ -4,13 +4,14 @@ import com.example.rentit.data.product.dto.ResvRequestDto
 import com.example.rentit.data.product.dto.ResvResponseDto
 import com.example.rentit.domain.product.repository.ProductRepository
 import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
- *  선택한 기간이 유효한지 확인하고 예약 요청을 보내는 UseCase
+ * 상품 예약 요청을 처리하는 UseCase
+ *
+ * - 선택한 대여 기간이 상품의 최소/최대 대여 기간 범위 내인지 검증
+ * - 유효한 경우 서버에 예약 요청 전송
  */
 
-@Singleton
 class PostResvRequestUseCase @Inject constructor(
     private val productRepository: ProductRepository,
 ) {

--- a/app/src/main/java/com/example/rentit/domain/rental/exception/EmptyBodyException.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/exception/EmptyBodyException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.rental.exception
-
-class EmptyBodyException(message: String = "Empty response body"): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/rental/exception/RentalNotFoundException.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/exception/RentalNotFoundException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.rental.exception
-
-class RentalNotFoundException: Exception()

--- a/app/src/main/java/com/example/rentit/domain/rental/exception/TooManyRequestException.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/exception/TooManyRequestException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.rental.exception
-
-class TooManyRequestException: Exception()

--- a/app/src/main/java/com/example/rentit/domain/rental/exception/VerificationFailedException.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/exception/VerificationFailedException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.rental.exception
-
-class VerificationFailedException(message: String) : Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/rental/exception/VerificationRequestNotFoundException.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/exception/VerificationRequestNotFoundException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.rental.exception
-
-class VerificationRequestNotFoundException : Exception()

--- a/app/src/main/java/com/example/rentit/domain/rental/repository/RentalRepository.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/repository/RentalRepository.kt
@@ -2,6 +2,7 @@ package com.example.rentit.domain.rental.repository
 
 import com.example.rentit.common.enums.PhotoRegistrationType
 import com.example.rentit.data.rental.dto.CourierNamesResponseDto
+import com.example.rentit.data.rental.dto.PhotoRegistrationResponseDto
 import com.example.rentit.data.rental.dto.RentalDetailResponseDto
 import com.example.rentit.data.rental.dto.RentalPhotoResponseDto
 import com.example.rentit.data.rental.dto.TrackingRegistrationRequestDto
@@ -18,7 +19,7 @@ interface RentalRepository {
 
     suspend fun updateRentalStatus(productId: Int, reservationId: Int, request: UpdateRentalStatusRequestDto): Result<Unit>
 
-    suspend fun postPhotoRegistration(productId: Int, reservationId: Int, type: PhotoRegistrationType, images: List<MultipartBody.Part>): Result<Unit>
+    suspend fun postPhotoRegistration(productId: Int, reservationId: Int, type: PhotoRegistrationType, images: List<MultipartBody.Part>): Result<PhotoRegistrationResponseDto>
 
     suspend fun getRentalPhotos(productId: Int, reservationId: Int): Result<RentalPhotoResponseDto>
 }

--- a/app/src/main/java/com/example/rentit/domain/rental/usecase/GetChatRoomRentalSummaryUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/usecase/GetChatRoomRentalSummaryUseCase.kt
@@ -7,6 +7,13 @@ import com.example.rentit.domain.rental.model.RentalChatRoomSummaryModel
 import com.example.rentit.domain.rental.repository.RentalRepository
 import javax.inject.Inject
 
+/**
+ * 특정 예약에 대한 채팅방 요약 정보를 가져오는 UseCase
+ *
+ * - 상품 ID와 예약 ID를 기반으로 예약 상세 정보를 조회
+ * - 예약 정보를 채팅방 요약 도메인 모델(RentalChatRoomSummaryModel)로 변환
+ */
+
 class GetChatRoomRentalSummaryUseCase @Inject constructor(
     private val rentalRepository: RentalRepository
 ) {

--- a/app/src/main/java/com/example/rentit/domain/rental/usecase/GetRentalDetailUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/usecase/GetRentalDetailUseCase.kt
@@ -11,6 +11,14 @@ import com.example.rentit.domain.rental.repository.RentalRepository
 import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
 
+/**
+ * 특정 예약의 상세 정보를 조회하는 UseCase
+ *
+ * - 서버에서 예약 상세 정보를 가져옴
+ * - 대여 상태를 도메인 모델(RentalDetailStatusModel)로 변환
+ * - 현재 로그인한 사용자가 예약자인지 상품 소유자인지 판단하여 역할 설정
+ */
+
 class GetRentalDetailUseCase @Inject constructor(
     private val rentalRepository: RentalRepository,
     private val userRepository: UserRepository

--- a/app/src/main/java/com/example/rentit/domain/rental/usecase/RegisterTrackingUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/rental/usecase/RegisterTrackingUseCase.kt
@@ -6,6 +6,13 @@ import com.example.rentit.data.rental.dto.TrackingRegistrationResponseDto
 import com.example.rentit.domain.rental.repository.RentalRepository
 import javax.inject.Inject
 
+/**
+ * 배송/운송장 정보를 등록하는 UseCase
+ *
+ * - 예약 ID와 상품 ID를 기반으로 운송장 정보를 서버에 등록
+ * - 입력값 검증 후, 유효한 요청만 전송
+ */
+
 class RegisterTrackingUseCase @Inject constructor(
     private val rentalRepository: RentalRepository
 ) {
@@ -16,10 +23,14 @@ class RegisterTrackingUseCase @Inject constructor(
         courierName: String,
         trackingNumber: String
     ): Result<TrackingRegistrationResponseDto?> {
-        if(trackingNumber.isBlank())
+
+        if(trackingNumber.isBlank()) {
             return Result.failure(IllegalArgumentException())
-        if(type == TrackingRegistrationRequestType.NONE)
+        }
+
+        if(type == TrackingRegistrationRequestType.NONE) {
             return Result.failure(Exception("Tracking Register type is NONE"))
+        }
 
         return rentalRepository.postTrackingRegistration(
             productId = productId,

--- a/app/src/main/java/com/example/rentit/domain/user/exception/GoogleSsoFailedException.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/exception/GoogleSsoFailedException.kt
@@ -1,3 +1,0 @@
-package com.example.rentit.domain.user.exception
-
-class GoogleSsoFailedException(message: String? = null): Exception(message)

--- a/app/src/main/java/com/example/rentit/domain/user/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/repository/UserRepository.kt
@@ -5,13 +5,14 @@ import com.example.rentit.data.user.dto.MyInfoResponseDto
 import com.example.rentit.data.user.dto.MyProductListResponseDto
 import com.example.rentit.data.user.dto.MyRentalListResponseDto
 import com.example.rentit.data.user.dto.SendPhoneCodeResponseDto
+import com.example.rentit.data.user.dto.VerifyPhoneCodeResponseDto
 
 interface UserRepository {
     suspend fun googleLogin(code: String, redirectUri: String): Result<GoogleLoginResponseDto>
 
     suspend fun sendPhoneCode(phoneNumber: String): Result<SendPhoneCodeResponseDto>
 
-    suspend fun verifyPhoneCode(phoneNumber: String, code: String): Result<Unit>
+    suspend fun verifyPhoneCode(phoneNumber: String, code: String): Result<VerifyPhoneCodeResponseDto>
 
     suspend fun signUp(name: String, email: String, nickname: String, profileImageUrl: String): Result<Unit>
 

--- a/app/src/main/java/com/example/rentit/domain/user/usecase/CheckUserSessionUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/usecase/CheckUserSessionUseCase.kt
@@ -1,6 +1,6 @@
 package com.example.rentit.domain.user.usecase
 
-import com.example.rentit.common.exception.MissingTokenException
+import com.example.rentit.core.error.UnauthorizedException
 import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
 
@@ -19,7 +19,7 @@ class CheckUserSessionUseCase @Inject constructor(
     suspend operator fun invoke(): Result<Long> {
         return runCatching {
             val token = userRepository.getTokenFromPrefs()
-            if(token.isNullOrEmpty()) throw MissingTokenException()
+            if(token.isNullOrEmpty()) throw UnauthorizedException()
 
             val localUserId = userRepository.getAuthUserIdFromPrefs()
             if(localUserId == -1L){
@@ -30,7 +30,7 @@ class CheckUserSessionUseCase @Inject constructor(
                 localUserId // 로그 출력용
             }
         }.onFailure { e ->
-            if(e is MissingTokenException) userRepository.clearPrefs()
+            if(e is UnauthorizedException) userRepository.clearPrefs()
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/domain/user/usecase/CheckUserSessionUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/usecase/CheckUserSessionUseCase.kt
@@ -4,6 +4,15 @@ import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
 
+/**
+ * 사용자 세션을 확인하는 UseCase
+ *
+ * - 로컬에 저장된 토큰과 사용자 ID를 확인
+ * - 토큰이 없으면 MissingTokenException 발생 및 로컬 prefs 초기화
+ * - 사용자 ID가 없으면 서버에서 가져와 로컬에 저장
+ * - 앱 시작 시 사용자 인증/세션 상태 확인에 사용
+ */
+
 class CheckUserSessionUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {

--- a/app/src/main/java/com/example/rentit/domain/user/usecase/GetMyProductsWithCategoryUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/usecase/GetMyProductsWithCategoryUseCase.kt
@@ -8,6 +8,13 @@ import com.example.rentit.domain.user.model.MyProductItemModel
 import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
 
+/**
+ * 사용자가 등록한 상품 리스트를 카테고리 정보와 함께 가져오는 UseCase
+ *
+ * - 서버에서 사용자의 상품 리스트 조회
+ * - 각 상품에 대해 카테고리 정보를 매핑하여 도메인 모델(MyProductItemModel)로 변환
+ */
+
 class GetMyProductsWithCategoryUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val getCategoryMapUseCase: GetCategoryMapUseCase

--- a/app/src/main/java/com/example/rentit/domain/user/usecase/GetMyRentalsWithNearestDueUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/usecase/GetMyRentalsWithNearestDueUseCase.kt
@@ -9,6 +9,15 @@ import com.example.rentit.domain.user.model.MyRentalsWithNearestDueModel
 import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
 
+/**
+ * 사용자의 대여 리스트를 가져오고, 가장 가까운 반납 예정 아이템과 유효한 대여 수를 계산하는 UseCase
+ *
+ * - 서버에서 사용자의 모든 예약 정보를 조회
+ * - 각 예약 정보를 도메인 모델(MyRentalItemModel)로 변환
+ * - 가장 가까운 반납 예정 아이템(nearestDueItem)을 도메인 모델로 변환
+ * - 취소, 거절, 대기 상태가 아닌 유효한 대여 수를 계산
+ */
+
 class GetMyRentalsWithNearestDueUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {

--- a/app/src/main/java/com/example/rentit/domain/user/usecase/InitializeAuthUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/usecase/InitializeAuthUseCase.kt
@@ -3,6 +3,14 @@ package com.example.rentit.domain.user.usecase
 import com.example.rentit.domain.user.repository.UserRepository
 import javax.inject.Inject
 
+/**
+ * 사용자 인증 초기화를 처리하는 UseCase
+ *
+ * - 서버에서 발급받은 토큰을 로컬에 저장
+ * - 서버에서 사용자 정보를 조회하여 사용자 ID를 로컬에 저장
+ * - 실패 시 로컬 prefs 초기화
+ */
+
 class InitializeAuthUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {

--- a/app/src/main/java/com/example/rentit/presentation/auth/join/phoneverification/JoinPhoneVerificationViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/join/phoneverification/JoinPhoneVerificationViewModel.kt
@@ -2,9 +2,7 @@ package com.example.rentit.presentation.auth.join.phoneverification
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.domain.rental.exception.TooManyRequestException
-import com.example.rentit.domain.rental.exception.VerificationFailedException
-import com.example.rentit.domain.rental.exception.VerificationRequestNotFoundException
+import com.example.rentit.core.error.ForbiddenException
 import com.example.rentit.domain.user.repository.UserRepository
 import com.example.rentit.presentation.auth.join.phoneverification.model.VerificationError
 import com.example.rentit.presentation.auth.join.phoneverification.model.toUiMessage
@@ -41,7 +39,7 @@ class JoinPhoneVerificationViewModel @Inject constructor(
                 }
                 .onFailure { e ->
                     when(e) {
-                        is TooManyRequestException -> _sideEffect.emit(JoinPhoneVerificationSideEffect.ToastTooManyRequests)
+                        is ForbiddenException -> _sideEffect.emit(JoinPhoneVerificationSideEffect.ToastTooManyRequests)
                         else -> _sideEffect.emit(JoinPhoneVerificationSideEffect.ToastSendCodeFailed)
                     }
                 }
@@ -65,18 +63,18 @@ class JoinPhoneVerificationViewModel @Inject constructor(
         viewModelScope.launch {
             userRepository.verifyPhoneCode(phoneNumber, code)
                 .onSuccess {
-                    _sideEffect.emit(JoinPhoneVerificationSideEffect.ToastVerificationSuccess)
-                    navigateToNickname()
+                    if (!it.verified) {
+                        updateErrorMessage(VerificationError.from(it.message))
+                    } else {
+                        _sideEffect.emit(JoinPhoneVerificationSideEffect.ToastVerificationSuccess)
+                        navigateToNickname()
+                    }
                 }
                 .onFailure { e ->
                         println(e.message)
                     when (e) {
-                        // 서버 호출은 성공했지만, 인증은 실패한 경우
-                        is VerificationFailedException -> {
-                            updateErrorMessage(VerificationError.from(e.message))
-                        }
                         // 인증 요청 자체가 없는 경우 (사용자가 인증번호 요청을 하지 않은 상태)
-                        is VerificationRequestNotFoundException -> {
+                        is ForbiddenException -> {
                             updateErrorMessage(VerificationError.Failed)
                         }
                         // 서버 문제나 네트워크 오류 등 시스템적 실패

--- a/app/src/main/java/com/example/rentit/presentation/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/login/LoginViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.BuildConfig
 import com.example.rentit.common.exception.MissingTokenException
-import com.example.rentit.domain.user.exception.GoogleSsoFailedException
+import com.example.rentit.core.error.ConflictException
 import com.example.rentit.domain.user.repository.UserRepository
 import com.example.rentit.domain.user.usecase.InitializeAuthUseCase
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 import java.net.URLEncoder
 import javax.inject.Inject
 
-private const val TAG = "GoogleLogin"
+private const val TAG = "LoginViewModel"
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
@@ -42,7 +42,7 @@ class LoginViewModel @Inject constructor(
                     Log.i(TAG, "로그인 성공: $userName")
                 }
                 .onFailure { e ->
-                    if (e is GoogleSsoFailedException) {
+                    if (e is ConflictException) {
                         emitLoginFailure()
                         Log.w(TAG, "구글 SSO 충돌: $e")
                     } else {

--- a/app/src/main/java/com/example/rentit/presentation/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/login/LoginViewModel.kt
@@ -5,8 +5,8 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.BuildConfig
-import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.core.error.ConflictException
+import com.example.rentit.core.error.UnauthorizedException
 import com.example.rentit.domain.user.repository.UserRepository
 import com.example.rentit.domain.user.usecase.InitializeAuthUseCase
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -63,7 +63,7 @@ class LoginViewModel @Inject constructor(
                 _sideEffect.emit(LoginSideEffect.ToastGreetingMessage(name))
                 _sideEffect.emit(LoginSideEffect.NavigateToHome)
             }.onFailure { e ->
-                if (e is MissingTokenException) {
+                if (e is UnauthorizedException) {
                     emitLoginFailure()
                     Log.w(TAG, "유효하지 않은 토큰으로 사용자 정보 조회 실패: $e")
                 } else {

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/ChatRoomViewModel.kt
@@ -5,8 +5,8 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.rentit.core.error.ForbiddenException
 import com.example.rentit.data.chat.dto.MessageResponseDto
-import com.example.rentit.domain.chat.exception.ForbiddenChatAccessException
 import com.example.rentit.domain.chat.usecase.ConvertMessageUseCase
 import com.example.rentit.domain.chat.usecase.GetChatRoomDetailUseCase
 import com.example.rentit.domain.chat.websocket.WebSocketManager
@@ -94,7 +94,7 @@ class ChatRoomViewModel @Inject constructor(
                     Log.e(TAG, "네트워크 오류 발생", e)
                     showNetworkErrorDialog()
                 }
-                is ForbiddenChatAccessException -> {
+                is ForbiddenException -> {
                     Log.e(TAG, "채팅방 접근 권한 없음", e)
                     showForbiddenChatAccessDialog()
                 }

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageViewModel.kt
@@ -4,7 +4,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.common.exception.MissingTokenException
+import com.example.rentit.core.error.UnauthorizedException
 import com.example.rentit.domain.user.repository.UserRepository
 import com.example.rentit.domain.user.usecase.GetMyProductsWithCategoryUseCase
 import com.example.rentit.domain.user.usecase.GetMyRentalsWithNearestDueUseCase
@@ -39,7 +39,7 @@ class MyPageViewModel @Inject constructor(
 
     private fun errorHandling(e: Throwable) {
         when(e) {
-            is MissingTokenException -> {
+            is UnauthorizedException -> {
                 // TODO: 로그아웃 및 로그인 화면으로 이동
             }
             is IOException -> {

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestViewModel.kt
@@ -5,9 +5,9 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.core.error.ConflictException
 import com.example.rentit.core.error.ForbiddenException
+import com.example.rentit.core.error.UnauthorizedException
 import com.example.rentit.domain.product.repository.ProductRepository
 import com.example.rentit.domain.product.usecase.PostResvRequestUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -48,7 +48,7 @@ class ResvRequestViewModel @Inject constructor(
 
     private fun handleFailure(e: Throwable) {
         when(e) {
-            is MissingTokenException -> {
+            is UnauthorizedException -> {
                 // TODO: 로그아웃 처리 및 로그인 화면으로 이동
             }
             is ForbiddenException -> {

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/request/ResvRequestViewModel.kt
@@ -6,8 +6,8 @@ import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.exception.MissingTokenException
-import com.example.rentit.domain.product.exception.AccessNotAllowedException
-import com.example.rentit.domain.product.exception.ResvAlreadyExistException
+import com.example.rentit.core.error.ConflictException
+import com.example.rentit.core.error.ForbiddenException
 import com.example.rentit.domain.product.repository.ProductRepository
 import com.example.rentit.domain.product.usecase.PostResvRequestUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -51,10 +51,10 @@ class ResvRequestViewModel @Inject constructor(
             is MissingTokenException -> {
                 // TODO: 로그아웃 처리 및 로그인 화면으로 이동
             }
-            is AccessNotAllowedException -> {
+            is ForbiddenException -> {
                 _uiState.value = _uiState.value.copy(showAccessNotAllowedDialog = true)
             }
-            is ResvAlreadyExistException -> {
+            is ConflictException -> {
                 _uiState.value = _uiState.value.copy(showResvAlreadyExistDialog = true)
             }
             is IllegalArgumentException -> {

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.enums.TrackingRegistrationRequestType
-import com.example.rentit.common.exception.MissingTokenException
 import com.example.rentit.common.uimodel.RequestAcceptDialogUiModel
+import com.example.rentit.core.error.UnauthorizedException
 import com.example.rentit.data.rental.dto.UpdateRentalStatusRequestDto
 import com.example.rentit.domain.rental.exception.RentalStatusUnknownException
 import com.example.rentit.domain.rental.usecase.RegisterTrackingUseCase
@@ -86,7 +86,7 @@ class RentalDetailViewModel @Inject constructor(
 
     private fun handleFetchError(e: Throwable) {
         when(e) {
-            is MissingTokenException -> {
+            is UnauthorizedException -> {
                 // TODO: 로그아웃 및 로그인 이동
             }
             is RentalStatusUnknownException -> {
@@ -141,7 +141,7 @@ class RentalDetailViewModel @Inject constructor(
 
     private fun handleAcceptError(e: Throwable) {
         when (e) {
-            is MissingTokenException -> {
+            is UnauthorizedException -> {
                 println("Logout") // TODO: 로그아웃 및 로그인 이동
             }
             else -> {
@@ -184,7 +184,7 @@ class RentalDetailViewModel @Inject constructor(
 
     private fun handleCancelError(e: Throwable) {
         when (e) {
-            is MissingTokenException -> {
+            is UnauthorizedException -> {
                 println("Logout") // TODO: 로그아웃 및 로그인 이동
             }
             else -> {

--- a/app/src/main/java/com/example/rentit/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/splash/SplashViewModel.kt
@@ -3,7 +3,7 @@ package com.example.rentit.presentation.splash
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.rentit.common.exception.MissingTokenException
+import com.example.rentit.core.error.UnauthorizedException
 import com.example.rentit.domain.user.usecase.CheckUserSessionUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -40,7 +40,7 @@ class SplashViewModel @Inject constructor(
                 }
                 .onFailure { e ->
                     when(e) {
-                        is MissingTokenException -> {
+                        is UnauthorizedException -> {
                             navigateToLogin()
                             Log.w(TAG, "토큰 누락으로 사용자 정보 조회 실패", e)
                         }


### PR DESCRIPTION
# Pull Request

## Summary  
Repository에서 서버 응답을 공통으로 처리하는 공통 함수 도입

## Related Issue  
- Close: #153 

## Changes  
**SafeApiCall**
- runCatching 내부에서 Api를 안전하게 호출
- 에러 분기 및 에러 코드에 맞는 Exception 을 던짐
- 에러는 서버에서 받을 수 있는 8가지 케이스로 분기함

```
400 -> BadRequestException
401 -> UnauthorizedException
403 -> ForbiddenException
404 -> NotFoundException
409 -> ConflictException
422 -> UnprocessableEntityException
in 500..599 -> ServerErrorException
else -> UnknownException
```

**Repository**
- safeApiCall 함수를 사용하도록 코드 수정

**Exceptions**
- 도메인 별 응답 처리용 커스텀 Exception 제거
