### PR TITLE
Feat/168 refresh and common UI update

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,7 +120,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material3:material3:1.3.2")
 
     testImplementation("junit:junit:4.13.2")
     debugImplementation("androidx.compose.ui:ui-tooling")

--- a/app/src/main/java/com/example/rentit/common/component/dialog/BaseDialog.kt
+++ b/app/src/main/java/com/example/rentit/common/component/dialog/BaseDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.Gray300
 import com.example.rentit.common.theme.Gray800
@@ -47,7 +48,10 @@ fun BaseDialog(
     customContent: @Composable ColumnScope.() -> Unit = {}
 ) {
     Dialog(
-        onDismissRequest = onDismissRequest
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false
+        )
     ) {
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/example/rentit/common/component/dialog/FullImageDialog.kt
+++ b/app/src/main/java/com/example/rentit/common/component/dialog/FullImageDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.example.rentit.R
 import com.example.rentit.common.component.LoadableUrlImage
 import com.example.rentit.common.theme.AppBlack
@@ -28,7 +29,10 @@ fun FullImageDialog(
     onDismiss: () -> Unit,
 ) {
     Dialog(
-        onDismissRequest = onDismiss
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false
+        )
     ) {
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/example/rentit/common/component/item/ProductListItem.kt
+++ b/app/src/main/java/com/example/rentit/common/component/item/ProductListItem.kt
@@ -8,13 +8,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,7 +71,8 @@ fun ProductListItem(
         ) {
             LoadableUrlImage(
                 modifier = Modifier
-                    .size(100.dp)
+                    .fillMaxWidth(0.3f)
+                    .aspectRatio(1f)
                     .clip(RoundedCornerShape(20.dp)),
                 imgUrl = thumbnailImgUrl,
                 defaultImageResId = R.drawable.img_thumbnail_placeholder,
@@ -84,11 +84,11 @@ fun ProductListItem(
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        modifier = Modifier.width(160.dp),
+                        modifier = Modifier.weight(1f),
                         maxLines = 1,
                         text = title,
                         overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/example/rentit/common/component/layout/PullToRefreshLayout.kt
+++ b/app/src/main/java/com/example/rentit/common/component/layout/PullToRefreshLayout.kt
@@ -1,0 +1,41 @@
+package com.example.rentit.common.component.layout
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.example.rentit.common.theme.PrimaryBlue500
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PullToRefreshLayout(
+    isRefreshing: Boolean,
+    pullToRefreshState: PullToRefreshState,
+    onRefresh: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        state = pullToRefreshState,
+        indicator = {
+            Box(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                PullToRefreshDefaults.Indicator(
+                    modifier = Modifier.align(Alignment.Center),
+                    state = pullToRefreshState,
+                    isRefreshing = isRefreshing,
+                    color = PrimaryBlue500,
+                )
+            }
+        }
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/example/rentit/common/theme/Theme.kt
+++ b/app/src/main/java/com/example/rentit/common/theme/Theme.kt
@@ -58,7 +58,7 @@ private val DarkColorScheme = darkColorScheme(
 fun RentItTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {

--- a/app/src/main/java/com/example/rentit/presentation/chat/ChatListRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/ChatListRoute.kt
@@ -2,6 +2,8 @@ package com.example.rentit.presentation.chat
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -15,6 +17,7 @@ import com.example.rentit.common.component.layout.LoadingScreen
 import com.example.rentit.navigation.chatroom.navigateToChatRoom
 import com.example.rentit.presentation.main.MainViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun ChatListRoute(navHostController: NavHostController) {
@@ -24,6 +27,8 @@ fun ChatListRoute(navHostController: NavHostController) {
     val viewModel: ChatListViewModel = hiltViewModel()
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val pullToRefreshState = rememberPullToRefreshState()
 
     LaunchedEffect(Unit) {
         viewModel.fetchChatRoomSummaries()
@@ -42,8 +47,11 @@ fun ChatListRoute(navHostController: NavHostController) {
 
     ChatListScreen(
         chatRoomSummaries = uiState.activeChatRoomSummaries,
-        isActiveChatRooms = uiState.isActiveChatRooms,
         scrollState = uiState.scrollState,
+        pullToRefreshState = pullToRefreshState,
+        isActiveChatRooms = uiState.isActiveChatRooms,
+        isRefreshing = uiState.isRefreshing,
+        onRefresh = viewModel::refreshChatRoomSummaries,
         onToggleFilter = viewModel::onToggledFilter,
         onItemClick = { navHostController.navigateToChatRoom(it) }
     )

--- a/app/src/main/java/com/example/rentit/presentation/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/ChatListScreen.kt
@@ -19,8 +19,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,6 +36,7 @@ import com.example.rentit.R
 import com.example.rentit.common.component.FilterButton
 import com.example.rentit.common.component.LoadableUrlImage
 import com.example.rentit.common.component.layout.EmptyContentScreen
+import com.example.rentit.common.component.layout.PullToRefreshLayout
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.enums.AutoMessageType
 import com.example.rentit.common.theme.AppBlack
@@ -45,12 +48,16 @@ import com.example.rentit.domain.chat.model.ChatRoomSummaryModel
 import com.example.rentit.presentation.chat.model.ChatListFilter
 import java.time.OffsetDateTime
 
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun ChatListScreen(
     chatRoomSummaries: List<ChatRoomSummaryModel> = emptyList(),
     scrollState: LazyListState = LazyListState(),
+    pullToRefreshState: PullToRefreshState = PullToRefreshState(),
     isActiveChatRooms: Boolean = true,
+    isRefreshing: Boolean = false,
+    onRefresh: () -> Unit = {},
     onToggleFilter: (ChatListFilter) -> Unit = {},
     onItemClick: (String) -> Unit = {},
 ) {
@@ -68,7 +75,13 @@ fun ChatListScreen(
 
         RentalHistoryFilterSection(isActiveChatRooms, onToggleFilter)
 
-        ChatListSection(isActiveChatRooms, chatRoomSummaries, scrollState, onItemClick)
+        PullToRefreshLayout(
+            isRefreshing = isRefreshing,
+            pullToRefreshState = pullToRefreshState,
+            onRefresh = onRefresh
+        ) {
+            ChatListSection(isActiveChatRooms, chatRoomSummaries, scrollState, onItemClick)
+        }
     }
 }
 
@@ -209,6 +222,7 @@ fun ChatListItem(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/example/rentit/presentation/chat/ChatListState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/ChatListState.kt
@@ -6,6 +6,7 @@ import com.example.rentit.domain.chat.model.ChatRoomSummaryModel
 data class ChatListState(
     val chatRoomSummaries: List<ChatRoomSummaryModel> = emptyList(),
     val scrollState: LazyListState = LazyListState(),
+    val isRefreshing: Boolean = false,
     val isActiveChatRooms: Boolean = true,
     val isLoading: Boolean = false,
 ) {

--- a/app/src/main/java/com/example/rentit/presentation/chat/ChatListViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/ChatListViewModel.kt
@@ -57,6 +57,14 @@ class ChatListViewModel @Inject constructor(
         }
     }
 
+    fun refreshChatRoomSummaries() {
+        viewModelScope.launch {
+            updateUiState { copy(isRefreshing = true) }
+            fetchChatRoomSummaries()
+            updateUiState { copy(isRefreshing = false) }
+        }
+    }
+
     fun onToggledFilter(filterMode: ChatListFilter) {
         when(filterMode) {
             ChatListFilter.ACTIVE -> updateUiState { copy(isActiveChatRooms = true) }

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeRoute.kt
@@ -2,6 +2,8 @@ package com.example.rentit.presentation.home
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -14,6 +16,7 @@ import androidx.navigation.NavHostController
 import com.example.rentit.navigation.productdetail.navigateToProductDetail
 import com.example.rentit.presentation.main.MainViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun HomeRoute(navHostController: NavHostController) {
@@ -24,9 +27,11 @@ fun HomeRoute(navHostController: NavHostController) {
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val uiState by viewModel.uiState.collectAsState()
 
+    val pullRefreshState = rememberPullToRefreshState()
+
     LaunchedEffect(Unit) {
         viewModel.fetchHomeData()
-        mainViewModel?.setRetryAction(viewModel::fetchHomeData)
+        mainViewModel?.setRetryAction(viewModel::retryFetchHomeData)
     }
 
     LaunchedEffect(Unit) {
@@ -50,12 +55,12 @@ fun HomeRoute(navHostController: NavHostController) {
         parentIdToNameCategoryMap = uiState.parentIdToNameCategoryMap,
         filterParentCategoryId = uiState.filterParentCategoryId,
         onlyRentalAvailable = uiState.onlyRentalAvailable,
+        pullToRefreshState = pullRefreshState,
         isLoading = uiState.isLoading,
-        showNetworkErrorDialog = uiState.showNetworkErrorDialog,
-        showServerErrorDialog = uiState.showServerErrorDialog,
+        isRefreshing = uiState.isRefreshing,
+        onRefresh = viewModel::refreshHomeData,
         onToggleRentalAvailableFilter = viewModel::toggleOnlyRentalAvailable,
         onSelectCategory = viewModel::filterByParentCategory,
         onProductClick = navHostController::navigateToProductDetail,
-        onRetry = viewModel::retryFetchProductList
     )
 }

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeScreen.kt
@@ -17,13 +17,14 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.IconButton
-import androidx.compose.material.Text
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,13 +43,13 @@ import com.example.rentit.common.component.basicRoundedGrayBorder
 import com.example.rentit.common.component.screenHorizontalPadding
 import com.example.rentit.common.theme.RentItTheme
 import com.example.rentit.common.component.item.ProductListItem
-import com.example.rentit.common.component.dialog.NetworkErrorDialog
-import com.example.rentit.common.component.dialog.ServerErrorDialog
 import com.example.rentit.common.component.layout.LoadingScreen
+import com.example.rentit.common.component.layout.PullToRefreshLayout
 import com.example.rentit.common.theme.Gray200
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.domain.product.model.ProductWithCategoryModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun HomeScreen(
@@ -56,14 +57,14 @@ fun HomeScreen(
     sortedProducts: List<ProductWithCategoryModel> = emptyList(),
     parentIdToNameCategoryMap: Map<Int, String> = emptyMap(),
     filterParentCategoryId: Int = -1,
+    pullToRefreshState: PullToRefreshState = PullToRefreshState(),
     onlyRentalAvailable: Boolean = false,
     isLoading: Boolean = false,
-    showNetworkErrorDialog: Boolean = false,
-    showServerErrorDialog: Boolean = false,
+    isRefreshing: Boolean = false,
+    onRefresh: () -> Unit = {},
     onToggleRentalAvailableFilter: () -> Unit = {},
     onSelectCategory: (Int) -> Unit = {},
     onProductClick: (Int) -> Unit = {},
-    onRetry: () -> Unit = {}
 ) {
     Column {
 
@@ -77,14 +78,17 @@ fun HomeScreen(
             onSelectCategory
         )
 
-        HomeProductListSection(scrollState, sortedProducts, onProductClick)
+
+        PullToRefreshLayout(
+            isRefreshing = isRefreshing,
+            pullToRefreshState = pullToRefreshState,
+            onRefresh = onRefresh
+        ) {
+            HomeProductListSection(scrollState, sortedProducts, onProductClick)
+        }
     }
 
     LoadingScreen(isLoading)
-
-    if(showNetworkErrorDialog) NetworkErrorDialog({}, onRetry)
-
-    if(showServerErrorDialog) ServerErrorDialog({}, onRetry)
 }
 
 @Composable
@@ -186,8 +190,6 @@ fun CategoryDropDown(
         filterCategoryId,
         stringResource(R.string.screen_home_label_btn_filter_category_default)
     )
-
-
     ExposedDropdownMenuBox(
         modifier = Modifier
             .height(30.dp)
@@ -197,7 +199,10 @@ fun CategoryDropDown(
         onExpandedChange = { expanded = !expanded }
     ) {
         Row(
-            modifier = Modifier.menuAnchor().padding(12.dp, 6.dp).widthIn(min = 50.dp),
+            modifier = Modifier
+                .menuAnchor()
+                .padding(12.dp, 6.dp)
+                .widthIn(min = 50.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
@@ -226,6 +231,7 @@ fun CategoryDropDown(
 }
 
 
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeSideEffect.kt
@@ -1,5 +1,6 @@
 package com.example.rentit.presentation.home
 
 sealed class HomeSideEffect {
+    data object ScrollToTop: HomeSideEffect()
     data class CommonError(val throwable: Throwable): HomeSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeState.kt
@@ -12,9 +12,8 @@ data class HomeState(
     val filterParentCategoryId: Int = -1,
     val scrollState: LazyListState = LazyListState(),
     val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
     val onlyRentalAvailable: Boolean = false,
-    val showServerErrorDialog: Boolean = false,
-    val showNetworkErrorDialog: Boolean = false,
 ) {
     val filteredProductList: List<ProductWithCategoryModel>
         get() = productList

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeState.kt
@@ -1,5 +1,6 @@
 package com.example.rentit.presentation.home
 
+import androidx.compose.foundation.lazy.LazyListState
 import com.example.rentit.common.enums.ProductStatus
 import com.example.rentit.domain.product.model.CategoryModel
 import com.example.rentit.domain.product.model.ProductWithCategoryModel
@@ -9,6 +10,7 @@ data class HomeState(
     val categoryMap: Map<Int, CategoryModel> = emptyMap(),
     val parentIdToNameCategoryMap: Map<Int, String> = emptyMap(),
     val filterParentCategoryId: Int = -1,
+    val scrollState: LazyListState = LazyListState(),
     val isLoading: Boolean = false,
     val onlyRentalAvailable: Boolean = false,
     val showServerErrorDialog: Boolean = false,

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeViewModel.kt
@@ -77,6 +77,7 @@ class HomeViewModel @Inject constructor(
 
     fun filterByParentCategory(parentCategoryId: Int) {
         _uiState.value = _uiState.value.copy(filterParentCategoryId = parentCategoryId)
+        emitSideEffect(HomeSideEffect.ScrollToTop)
     }
 
     fun retryFetchProductList(){

--- a/app/src/main/java/com/example/rentit/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/home/HomeViewModel.kt
@@ -33,13 +33,11 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun fetchHomeData() {
-        viewModelScope.launch {
-            setIsLoading(true)
-            fetchCategoryMap()
-            fetchProductList()
-            setIsLoading(false)
-        }
+    suspend fun fetchHomeData() {
+        setIsLoading(true)
+        fetchCategoryMap()
+        fetchProductList()
+        setIsLoading(false)
     }
 
     private suspend fun fetchCategoryMap() {
@@ -80,12 +78,21 @@ class HomeViewModel @Inject constructor(
         emitSideEffect(HomeSideEffect.ScrollToTop)
     }
 
-    fun retryFetchProductList(){
-        _uiState.value = _uiState.value.copy(showServerErrorDialog = false, showNetworkErrorDialog = false)
-        fetchHomeData()
-    }
-
     private fun setIsLoading(isLoading: Boolean) {
         _uiState.value = _uiState.value.copy(isLoading = isLoading)
+    }
+
+    fun retryFetchHomeData() {
+        viewModelScope.launch {
+            fetchHomeData()
+        }
+    }
+
+    fun refreshHomeData() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isRefreshing = true)
+            fetchProductList()
+            _uiState.value = _uiState.value.copy(isRefreshing = false)
+        }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/main/MainScreen.kt
@@ -2,6 +2,10 @@ package com.example.rentit.presentation.main
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
@@ -43,7 +47,7 @@ fun MainScreen(
     onCreatePostClick: () -> Unit = {}
 ) {
     Scaffold(
-        bottomBar = { if (showBottomBar) MainBottomBar(currentRoute, onBottomItemClick) },
+        bottomBar = { MainBottomBar(showBottomBar, currentRoute, onBottomItemClick) },
         floatingActionButton = { if (showCreatePostBtn) CreatePostFloatingButton(onCreatePostClick) }
     ) {
         MainNavHost(navHostController, it)
@@ -51,27 +55,32 @@ fun MainScreen(
 }
 
 @Composable
-fun MainBottomBar(currentRoute: String?, onBottomItemClick: (String) -> Unit) {
-    NavigationBar(modifier = Modifier.fillMaxHeight(0.1f), containerColor = Color.White) {
-        BottomNavItem.entries.forEach { item ->
-            NavigationBarItem(
-                modifier = Modifier.fillMaxHeight(),
-                icon = {
-                    Icon(
-                        painter = painterResource(item.iconFor(currentRoute)),
-                        contentDescription = stringResource(item.title),
-                        modifier = Modifier.size(28.dp)
-                    )
-                },
-                colors = NavigationBarItemDefaults.colors(
-                    unselectedIconColor = Gray400,
-                    selectedIconColor = PrimaryBlue500,
-                    indicatorColor = White
-                ),
-                selected = item.isSelected(currentRoute),
-                alwaysShowLabel = false,
-                onClick = { onBottomItemClick(item.screenRoute) },
-            )
+fun MainBottomBar(showBottomBar: Boolean, currentRoute: String?, onBottomItemClick: (String) -> Unit) {
+    AnimatedVisibility(
+        visible = showBottomBar,
+        enter = slideInVertically { it },
+    ) {
+        NavigationBar(modifier = Modifier.fillMaxHeight(0.1f), containerColor = Color.White) {
+            BottomNavItem.entries.forEach { item ->
+                NavigationBarItem(
+                    modifier = Modifier.fillMaxHeight(),
+                    icon = {
+                        Icon(
+                            painter = painterResource(item.iconFor(currentRoute)),
+                            contentDescription = stringResource(item.title),
+                            modifier = Modifier.size(28.dp)
+                        )
+                    },
+                    colors = NavigationBarItemDefaults.colors(
+                        unselectedIconColor = Gray400,
+                        selectedIconColor = PrimaryBlue500,
+                        indicatorColor = White
+                    ),
+                    selected = item.isSelected(currentRoute),
+                    alwaysShowLabel = false,
+                    onClick = { onBottomItemClick(item.screenRoute) },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/main/MainScreen.kt
@@ -3,7 +3,6 @@ package com.example.rentit.presentation.main
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
@@ -59,6 +58,7 @@ fun MainBottomBar(showBottomBar: Boolean, currentRoute: String?, onBottomItemCli
     AnimatedVisibility(
         visible = showBottomBar,
         enter = slideInVertically { it },
+        exit = slideOutVertically { it }
     ) {
         NavigationBar(modifier = Modifier.fillMaxHeight(0.1f), containerColor = Color.White) {
             BottomNavItem.entries.forEach { item ->

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageRoute.kt
@@ -3,6 +3,8 @@ package com.example.rentit.presentation.mypage
 import android.os.Build
 import android.widget.Toast
 import androidx.annotation.RequiresApi
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -20,6 +22,7 @@ import com.example.rentit.navigation.rentaldetail.navigateToRentalDetail
 import com.example.rentit.navigation.setting.navigateToSetting
 import com.example.rentit.presentation.main.MainViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun MyPageRoute(navHostController: NavHostController) {
@@ -31,6 +34,8 @@ fun MyPageRoute(navHostController: NavHostController) {
     val lifecycle = LocalLifecycleOwner.current.lifecycle
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val pullToRefreshState = rememberPullToRefreshState()
 
     LaunchedEffect(Unit) {
         viewModel.loadInitialData()
@@ -70,7 +75,10 @@ fun MyPageRoute(navHostController: NavHostController) {
         nearestDueItem = uiState.nearestDueItem,
         myProductList = uiState.myProductList,
         myRentalList = uiState.myRentalList,
+        pullToRefreshState = pullToRefreshState,
         isFirstTabSelected = uiState.isFirstTabSelected,
+        isRefreshing = uiState.isRefreshing,
+        onRefresh = viewModel::refreshData,
         onAlertClick = viewModel::showComingSoonMessage,
         onInfoRentalDetailClick = viewModel::onInfoRentalDetailClicked,
         onTabActive = viewModel::setTabSelected,

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageScreen.kt
@@ -18,9 +18,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.IconButton
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,6 +46,7 @@ import com.example.rentit.common.theme.Gray400
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.component.item.ProductListItem
 import com.example.rentit.common.component.layout.EmptyContentScreen
+import com.example.rentit.common.component.layout.PullToRefreshLayout
 import com.example.rentit.common.enums.ProductStatus
 import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.common.theme.Gray100
@@ -55,6 +58,7 @@ import com.example.rentit.domain.user.model.MyRentalItemModel
 import com.example.rentit.domain.user.model.NearestDueItemModel
 import java.time.LocalDateTime
 
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun MyPageScreen(
@@ -66,7 +70,10 @@ fun MyPageScreen(
     nearestDueItem: NearestDueItemModel?,
     myProductList: List<MyProductItemModel>,
     myRentalList: List<MyRentalItemModel>,
+    pullToRefreshState: PullToRefreshState = PullToRefreshState(),
     isFirstTabSelected: Boolean,
+    isRefreshing: Boolean = false,
+    onRefresh: () -> Unit = {},
     onSettingClick: () -> Unit,
     onAlertClick: () -> Unit,
     onMyPendingRentalClick: () -> Unit,
@@ -75,36 +82,43 @@ fun MyPageScreen(
     onProductItemClick: (Int) -> Unit,
     onRentalItemClick: (Int, Int) -> Unit
 ) {
-    Column {
-        Column(modifier = Modifier.screenHorizontalPadding()) {
+    PullToRefreshLayout(
+        isRefreshing = isRefreshing,
+        pullToRefreshState = pullToRefreshState,
+        onRefresh = onRefresh
+    ) {
+        Column {
+            Column(modifier = Modifier.screenHorizontalPadding()) {
 
-            TopSection(onAlertClick, onSettingClick)
+                TopSection(onAlertClick, onSettingClick)
 
-            ProfileSection(
-                profileImgUrl = profileImgUrl,
-                nickName = nickName,
-                myProductCount = myProductCount,
-                myValidRentalCount = myValidRentalCount,
-                myPendingRentalCount = myPendingRentalCount,
-                onMyPendingRentalClick = onMyPendingRentalClick
-            )
-
-            if(nearestDueItem != null) {
-                InfoBox(
-                    productTitle = nearestDueItem.productTitle,
-                    remainingRentalDays = nearestDueItem.remainingRentalDays,
-                    onRentalDetailClick = onInfoRentalDetailClick
+                ProfileSection(
+                    profileImgUrl = profileImgUrl,
+                    nickName = nickName,
+                    myProductCount = myProductCount,
+                    myValidRentalCount = myValidRentalCount,
+                    myPendingRentalCount = myPendingRentalCount,
+                    onMyPendingRentalClick = onMyPendingRentalClick
                 )
+
+                if (nearestDueItem != null) {
+                    InfoBox(
+                        productTitle = nearestDueItem.productTitle,
+                        remainingRentalDays = nearestDueItem.remainingRentalDays,
+                        onRentalDetailClick = onInfoRentalDetailClick
+                    )
+                }
             }
+
+            TabbedListSection(
+                isFirstTabSelected = isFirstTabSelected,
+                myProductList = myProductList,
+                myRentList = myRentalList,
+                onTabActive = onTabActive,
+                onProductItemClick = onProductItemClick,
+                onRentalItemClick = onRentalItemClick
+            )
         }
-        TabbedListSection(
-            isFirstTabSelected = isFirstTabSelected,
-            myProductList = myProductList,
-            myRentList = myRentalList,
-            onTabActive = onTabActive,
-            onProductItemClick = onProductItemClick,
-            onRentalItemClick = onRentalItemClick
-        )
     }
 }
 
@@ -414,6 +428,7 @@ fun MyRentalHistoryListItem(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 @Preview(showBackground = true)

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageState.kt
@@ -13,6 +13,7 @@ data class MyPageState(
     val nearestDueItem: NearestDueItemModel? = null,
     val myProductList: List<MyProductItemModel> = emptyList(),
     val myRentalList: List<MyRentalItemModel> = emptyList(),
+    val isRefreshing: Boolean = false,
     val isFirstTabSelected: Boolean = true,
     val isLoading: Boolean = false,
 )

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageViewModel.kt
@@ -117,4 +117,12 @@ class MyPageViewModel @Inject constructor(
             loadInitialData()
         }
     }
+
+    fun refreshData() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isRefreshing = true)
+            loadInitialData()
+            _uiState.value = _uiState.value.copy(isRefreshing = false)
+        }
+    }
 }


### PR DESCRIPTION
# Pull Request

## Summary  
- 홈, 채팅, 마이페이지 Pull-to-Refresh 추가, 일부 메인/공통 UI 및 테마 수정

## Related Issue  
- Close: #168 

## Changes  
**Pull-to-Refresh 적용**
- PullToRefreshLayout 컴포저블 구현 (Material3 PullToRefreshBox 사용)
- HomeScreen, ChatListScreen, MyPageScreen에 공통 Pull-to-Refresh 레이아웃 추가
- 각 스크린 상태에 isRefreshing 추가
- ViewModel에 데이터 새로고침 로직 추가

**MainBottomBar 애니메이션**
- AnimatedVisibility로 슬라이드 인/아웃 구현

**HomeScreen 스크롤 위치 유지**
- scrollState를 HomeState로 이동하여 ViewModel에서 관리
- 필터 적용 시 ScrollToTop 사이드 이펙트 적용

**수정 / UI 개선**
- BaseDialog와 FullImageDialog에서 플랫폼 기본 폭 비활성화
- ProductListItem 레이아웃 반응형 개선
  - 이미지 사이즈 비율(전체 너비의 0.3, 정사각형)로 수정
  - 제목 텍스트 너비 weight(1f)으로 수정
- BottomBar 시작/종료 애니메이션 각각 slideInVertically , slideOutVertically 적용
- RentItTheme에서 Dynamic Color 기본 비활성화 (기본 배경 색상 White로 일관성 유지)

## Screenshots 
- 왼쪽부터 Pull-to-Refresh, 이전 Dialog UI (일부 기종), 수정 후 Dialog UI
<div>
<img width="32%" src="https://github.com/user-attachments/assets/100f1549-4c0b-4a9a-9553-b87336714621" />
<img width="32%" src="https://github.com/user-attachments/assets/21dc885d-b199-4c97-a2cb-08d6fdcc2b49" />
<img width="32%" src="https://github.com/user-attachments/assets/fa3c8971-603b-48fd-8670-6c4fcb1555a8" />
</div>
