### PR TITLE
Feat/170 my products rental screen

### DIFF
--- a/app/src/main/java/com/example/rentit/common/Constants.kt
+++ b/app/src/main/java/com/example/rentit/common/Constants.kt
@@ -1,4 +1,5 @@
 package com.example.rentit.common
 
 const val DEPOSIT_BASIS_DAYS = 3
+const val D_DAY_ALERT_THRESHOLD_DAYS = 3
 const val PRICE_LIMIT = 5_000_000

--- a/app/src/main/java/com/example/rentit/common/component/AnimatedNoticeBanner.kt
+++ b/app/src/main/java/com/example/rentit/common/component/AnimatedNoticeBanner.kt
@@ -3,7 +3,7 @@ package com.example.rentit.common.component
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.scaleIn
+import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -49,9 +49,7 @@ fun AnimatedNoticeBanner(
 
     AnimatedVisibility(
         visible = visible,
-        enter = scaleIn(
-            initialScale = 0.5f
-        )
+        enter = slideInVertically()
     ) {
         Box(
             modifier = modifier

--- a/app/src/main/java/com/example/rentit/common/component/AnimatedNoticeBanner.kt
+++ b/app/src/main/java/com/example/rentit/common/component/AnimatedNoticeBanner.kt
@@ -1,0 +1,88 @@
+package com.example.rentit.common.component
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.scaleIn
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.rentit.common.theme.PrimaryBlue300
+import com.example.rentit.common.theme.RentItTheme
+
+/**
+ * 공지 영역을 위한 UI 컴포넌트
+ */
+
+private val bannerPadding = 13.dp
+private val bannerCornerRadius = 15.dp
+
+@Composable
+fun AnimatedNoticeBanner(
+    modifier: Modifier = Modifier,
+    noticeText: AnnotatedString,
+    bgColor: Color = PrimaryBlue300
+) {
+    var visible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        visible = true
+    }
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = scaleIn(
+            initialScale = 0.5f
+        )
+    ) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(
+                    color = bgColor,
+                    shape = RoundedCornerShape(bannerCornerRadius)
+                )
+                .padding(bannerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = noticeText,
+                style = MaterialTheme.typography.labelLarge
+            )
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+@Preview(showBackground = true)
+private fun Preview() {
+    RentItTheme {
+        AnimatedNoticeBanner(
+            noticeText = buildAnnotatedString {
+                withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle()) {
+                    append("렌팃")
+                }
+                append(" 테스트 텍스트")
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/example/rentit/common/component/LoadableImages.kt
+++ b/app/src/main/java/com/example/rentit/common/component/LoadableImages.kt
@@ -16,7 +16,7 @@ import com.example.rentit.R
 fun LoadableUrlImage(
     modifier: Modifier = Modifier,
     imgUrl: String?,
-    @DrawableRes defaultImageResId: Int,
+    @DrawableRes defaultImageResId: Int = R.drawable.img_thumbnail_placeholder,
     @StringRes defaultDescResId: Int = R.string.common_img_placeholder_description,
     contentScale: ContentScale = ContentScale.Crop
 ) {

--- a/app/src/main/java/com/example/rentit/data/user/dto/MyProductsRentalListResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/user/dto/MyProductsRentalListResponseDto.kt
@@ -1,0 +1,38 @@
+package com.example.rentit.data.user.dto
+
+import com.example.rentit.common.enums.RentalStatus
+import com.google.gson.annotations.SerializedName
+
+data class MyProductsRentalListResponseDto(
+    @SerializedName("rentalHistory")
+    val rentalHistory: List<MyProductsRentalDto>,
+)
+
+data class MyProductsRentalDto(
+    @SerializedName("productId")
+    val productId: Int,
+
+    @SerializedName("reservationId")
+    val reservationId: Int,
+
+    @SerializedName("productTitle")
+    val productTitle: String,
+
+    @SerializedName("productThumbnailImg")
+    val productThumbnailImg: String?,
+
+    @SerializedName("startDate")
+    val startDate: String, // "YYYY-MM-DD"
+
+    @SerializedName("endDate")
+    val endDate: String, // "YYYY-MM-DD"
+
+    @SerializedName("status")
+    val status: RentalStatus,
+
+    @SerializedName("totalPrice")
+    val totalPrice: Int,
+
+    @SerializedName("renterNickname")
+    val renterNickname: String
+)

--- a/app/src/main/java/com/example/rentit/data/user/dto/MyProductsRentalListResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/user/dto/MyProductsRentalListResponseDto.kt
@@ -18,8 +18,8 @@ data class MyProductsRentalDto(
     @SerializedName("productTitle")
     val productTitle: String,
 
-    @SerializedName("productThumbnailImg")
-    val productThumbnailImg: String?,
+    @SerializedName("productThumbnailImgUrl")
+    val productThumbnailImgUrl: String?,
 
     @SerializedName("startDate")
     val startDate: String, // "YYYY-MM-DD"

--- a/app/src/main/java/com/example/rentit/data/user/remote/UserApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/user/remote/UserApiService.kt
@@ -4,6 +4,7 @@ import com.example.rentit.data.user.dto.GoogleLoginRequestDto
 import com.example.rentit.data.user.dto.GoogleLoginResponseDto
 import com.example.rentit.data.user.dto.MyInfoResponseDto
 import com.example.rentit.data.user.dto.MyProductListResponseDto
+import com.example.rentit.data.user.dto.MyProductsRentalListResponseDto
 import com.example.rentit.data.user.dto.MyRentalListResponseDto
 import com.example.rentit.data.user.dto.SendPhoneCodeRequestDto
 import com.example.rentit.data.user.dto.SendPhoneCodeResponseDto
@@ -46,4 +47,7 @@ interface UserApiService {
     @Headers("Content-Type: application/json")
     suspend fun getMyRentalList(): Response<MyRentalListResponseDto>
 
+    @GET("api/v1/users/rental-history")
+    @Headers("Content-Type: application/json")
+    suspend fun getMyProductsRentalList(): Response<MyProductsRentalListResponseDto>
 }

--- a/app/src/main/java/com/example/rentit/data/user/remote/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/user/remote/UserRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.example.rentit.data.user.dto.GoogleLoginRequestDto
 import com.example.rentit.data.user.dto.GoogleLoginResponseDto
 import com.example.rentit.data.user.dto.MyInfoResponseDto
 import com.example.rentit.data.user.dto.MyProductListResponseDto
+import com.example.rentit.data.user.dto.MyProductsRentalListResponseDto
 import com.example.rentit.data.user.dto.MyRentalListResponseDto
 import com.example.rentit.data.user.dto.SendPhoneCodeRequestDto
 import com.example.rentit.data.user.dto.SendPhoneCodeResponseDto
@@ -46,5 +47,9 @@ class UserRemoteDataSource @Inject constructor(
 
     suspend fun getMyRentalList(): Response<MyRentalListResponseDto> {
         return userApiService.getMyRentalList()
+    }
+
+    suspend fun getMyProductsRentalList(): Response<MyProductsRentalListResponseDto> {
+        return userApiService.getMyProductsRentalList()
     }
 }

--- a/app/src/main/java/com/example/rentit/data/user/repositoryImpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/user/repositoryImpl/UserRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.example.rentit.core.network.safeApiCall
 import com.example.rentit.data.user.dto.GoogleLoginResponseDto
 import com.example.rentit.data.user.dto.MyInfoResponseDto
 import com.example.rentit.data.user.dto.MyProductListResponseDto
+import com.example.rentit.data.user.dto.MyProductsRentalListResponseDto
 import com.example.rentit.data.user.dto.MyRentalListResponseDto
 import com.example.rentit.data.user.dto.SendPhoneCodeResponseDto
 import com.example.rentit.data.user.dto.VerifyPhoneCodeResponseDto
@@ -42,6 +43,10 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun getMyRentalList(): Result<MyRentalListResponseDto> {
         return safeApiCall(remoteDataSource::getMyRentalList)
+    }
+
+    override suspend fun getMyProductsRentalList(): Result<MyProductsRentalListResponseDto> {
+        return safeApiCall(remoteDataSource::getMyProductsRentalList)
     }
 
     override fun getAuthUserIdFromPrefs(): Long = prefsDataSource.getAuthUserIdFromPrefs()

--- a/app/src/main/java/com/example/rentit/domain/user/model/MyProductsRentalModel.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/model/MyProductsRentalModel.kt
@@ -1,15 +1,13 @@
 package com.example.rentit.domain.user.model
 
-import com.example.rentit.common.enums.RentalStatus
-
 data class MyProductsRentalModel(
     val productId: Int,
     val reservationId: Int,
-    val rentalStatus: RentalStatus,
-    val rentalCount: Int,
+    val productThumbnailUrl: String?,
+    val rentalCount: Int = 0,
     val productTitle: String,
-    val renterNickname: String,
-    val totalExpectRevenue: Int,
-    val daysBeforeStart: Int,
-    val daysBeforeReturn: Int
+    val renterNickname: String = "",
+    val totalExpectRevenue: Int = 0,
+    val daysBeforeStart: Int = 0,
+    val daysBeforeReturn: Int = 0
 )

--- a/app/src/main/java/com/example/rentit/domain/user/model/MyProductsRentalModel.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/model/MyProductsRentalModel.kt
@@ -1,0 +1,15 @@
+package com.example.rentit.domain.user.model
+
+import com.example.rentit.common.enums.RentalStatus
+
+data class MyProductsRentalModel(
+    val productId: Int,
+    val reservationId: Int,
+    val rentalStatus: RentalStatus,
+    val rentalCount: Int,
+    val productTitle: String,
+    val renterNickname: String,
+    val totalExpectRevenue: Int,
+    val daysBeforeStart: Int,
+    val daysBeforeReturn: Int
+)

--- a/app/src/main/java/com/example/rentit/domain/user/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/repository/UserRepository.kt
@@ -3,6 +3,7 @@ package com.example.rentit.domain.user.repository
 import com.example.rentit.data.user.dto.GoogleLoginResponseDto
 import com.example.rentit.data.user.dto.MyInfoResponseDto
 import com.example.rentit.data.user.dto.MyProductListResponseDto
+import com.example.rentit.data.user.dto.MyProductsRentalListResponseDto
 import com.example.rentit.data.user.dto.MyRentalListResponseDto
 import com.example.rentit.data.user.dto.SendPhoneCodeResponseDto
 import com.example.rentit.data.user.dto.VerifyPhoneCodeResponseDto
@@ -21,6 +22,8 @@ interface UserRepository {
     suspend fun getMyProductList(): Result<MyProductListResponseDto>
 
     suspend fun getMyRentalList(): Result<MyRentalListResponseDto>
+
+    suspend fun getMyProductsRentalList(): Result<MyProductsRentalListResponseDto>
 
     fun getAuthUserIdFromPrefs(): Long
 

--- a/app/src/main/java/com/example/rentit/domain/user/usecase/GetMyProductsRentalListUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/usecase/GetMyProductsRentalListUseCase.kt
@@ -1,0 +1,62 @@
+package com.example.rentit.domain.user.usecase
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.example.rentit.common.enums.RentalStatus
+import com.example.rentit.common.util.daysFromToday
+import com.example.rentit.domain.user.model.MyProductsRentalModel
+import com.example.rentit.domain.user.repository.UserRepository
+import javax.inject.Inject
+
+/**
+ * 내 상품 대여 내역을 가져와서 상태(RentalStatus)별로 그룹화하고,
+ * 각 상태별로 UI/화면에 필요한 형태로 가공하여 반환하는 UseCase
+ */
+
+class GetMyProductsRentalHistoryUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    @RequiresApi(Build.VERSION_CODES.O)
+    suspend operator fun invoke(): Result<Map<RentalStatus, List<MyProductsRentalModel>>> {
+        return runCatching {
+            val rentalHistories =
+                userRepository.getMyProductsRentalList().getOrThrow().rentalHistory
+
+            rentalHistories.groupBy { it.status }
+                .mapValues { (status, histories) ->
+                    when (status) {
+                        RentalStatus.PENDING, RentalStatus.ACCEPTED -> {
+                            histories.groupBy { it.productId }
+                                .map { (productId, records) ->
+                                    val first = records.first()
+                                    MyProductsRentalModel(
+                                        productId = productId,
+                                        reservationId = first.reservationId,
+                                        rentalCount = records.size,
+                                        productThumbnailUrl = first.productThumbnailImg,
+                                        productTitle = first.productTitle,
+                                        totalExpectRevenue = records.sumOf { it.totalPrice },
+                                    )
+                                }
+                        }
+
+                        RentalStatus.PAID, RentalStatus.RENTING -> {
+                            histories.map {
+                                MyProductsRentalModel(
+                                    productId = it.productId,
+                                    reservationId = it.reservationId,
+                                    productThumbnailUrl = it.productThumbnailImg,
+                                    productTitle = it.productTitle,
+                                    renterNickname = it.renterNickname,
+                                    daysBeforeStart = daysFromToday(it.startDate),
+                                    daysBeforeReturn = daysFromToday(it.endDate)
+                                )
+                            }
+                        }
+
+                        else -> emptyList()
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/example/rentit/domain/user/usecase/GetMyProductsRentalListUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/usecase/GetMyProductsRentalListUseCase.kt
@@ -41,7 +41,7 @@ class GetMyProductsRentalHistoryUseCase @Inject constructor(
                         }
 
                         RentalStatus.PAID, RentalStatus.RENTING -> {
-                            histories.map {
+                            val newHistories = histories.map {
                                 MyProductsRentalModel(
                                     productId = it.productId,
                                     reservationId = it.reservationId,
@@ -51,6 +51,11 @@ class GetMyProductsRentalHistoryUseCase @Inject constructor(
                                     daysBeforeStart = daysFromToday(it.startDate),
                                     daysBeforeReturn = daysFromToday(it.endDate)
                                 )
+                            }
+                            if(status == RentalStatus.PAID) {
+                                newHistories.sortedBy { it.daysBeforeStart }
+                            } else {
+                                newHistories.sortedBy { it.daysBeforeReturn }
                             }
                         }
 

--- a/app/src/main/java/com/example/rentit/domain/user/usecase/GetMyProductsRentalListUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/user/usecase/GetMyProductsRentalListUseCase.kt
@@ -33,7 +33,7 @@ class GetMyProductsRentalHistoryUseCase @Inject constructor(
                                         productId = productId,
                                         reservationId = first.reservationId,
                                         rentalCount = records.size,
-                                        productThumbnailUrl = first.productThumbnailImg,
+                                        productThumbnailUrl = first.productThumbnailImgUrl,
                                         productTitle = first.productTitle,
                                         totalExpectRevenue = records.sumOf { it.totalPrice },
                                     )
@@ -45,7 +45,7 @@ class GetMyProductsRentalHistoryUseCase @Inject constructor(
                                 MyProductsRentalModel(
                                     productId = it.productId,
                                     reservationId = it.reservationId,
-                                    productThumbnailUrl = it.productThumbnailImg,
+                                    productThumbnailUrl = it.productThumbnailImgUrl,
                                     productTitle = it.productTitle,
                                     renterNickname = it.renterNickname,
                                     daysBeforeStart = daysFromToday(it.startDate),

--- a/app/src/main/java/com/example/rentit/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/example/rentit/navigation/MainNavHost.kt
@@ -14,6 +14,7 @@ import com.example.rentit.navigation.auth.authGraph
 import com.example.rentit.navigation.bottomtab.bottomTabGraph
 import com.example.rentit.navigation.chatroom.chatRoomGraph
 import com.example.rentit.navigation.createpost.createPostGraph
+import com.example.rentit.navigation.myproductsrental.myProductsRentalGraph
 import com.example.rentit.navigation.pay.payGraph
 import com.example.rentit.navigation.productdetail.productDetailGraph
 import com.example.rentit.navigation.rentaldetail.rentalDetailGraph
@@ -38,5 +39,6 @@ fun MainNavHost(navHostController: NavHostController, paddingValues: PaddingValu
         createPostGraph(navHostController)
         payGraph(navHostController)
         settingNavGraph(navHostController)
+        myProductsRentalGraph(navHostController)
     }
 }

--- a/app/src/main/java/com/example/rentit/navigation/myproductsrental/MyProductsRentalNavigation.kt
+++ b/app/src/main/java/com/example/rentit/navigation/myproductsrental/MyProductsRentalNavigation.kt
@@ -1,0 +1,21 @@
+package com.example.rentit.navigation.myproductsrental
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import com.example.rentit.presentation.mypage.myproductsrental.MyProductsRentalRoute
+
+fun NavHostController.navigateToMyProductsRental() {
+    navigate(
+        route = MyProductsRentalRoute.MyProductsRental
+    )
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+fun NavGraphBuilder.myProductsRentalGraph(navHostController: NavHostController) {
+    composable<MyProductsRentalRoute.MyProductsRental> {
+        MyProductsRentalRoute(navHostController)
+    }
+}

--- a/app/src/main/java/com/example/rentit/navigation/myproductsrental/MyProductsRentalRoute.kt
+++ b/app/src/main/java/com/example/rentit/navigation/myproductsrental/MyProductsRentalRoute.kt
@@ -1,0 +1,8 @@
+package com.example.rentit.navigation.myproductsrental
+
+import kotlinx.serialization.Serializable
+
+sealed class MyProductsRentalRoute {
+    @Serializable
+    data object MyProductsRental : MyProductsRentalRoute()
+}

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageRoute.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
 import com.example.rentit.R
 import com.example.rentit.common.component.layout.LoadingScreen
+import com.example.rentit.navigation.myproductsrental.navigateToMyProductsRental
 import com.example.rentit.navigation.productdetail.navigateToProductDetail
 import com.example.rentit.navigation.rentaldetail.navigateToRentalDetail
 import com.example.rentit.navigation.setting.navigateToSetting
@@ -47,6 +48,9 @@ fun MyPageRoute(navHostController: NavHostController) {
                     is MyPageSideEffect.NavigateToRentalDetail -> {
                         navHostController.navigateToRentalDetail(it.productId, it.reservationId)
                     }
+                    is MyPageSideEffect.NavigateToMyProductsRental -> {
+                        navHostController.navigateToMyProductsRental()
+                    }
                     MyPageSideEffect.NavigateToSetting -> {
                         navHostController.navigateToSetting()
                     }
@@ -77,7 +81,7 @@ fun MyPageRoute(navHostController: NavHostController) {
         onProductItemClick = viewModel::onProductItemClicked,
         onRentalItemClick = viewModel::onRentalItemClicked,
         onSettingClick = viewModel::onSettingClicked,
-        onMyPendingRentalClick = viewModel::showComingSoonMessage // TODO: 승인/발송 대기 리스트 화면 구현 후 Navigation 연결
+        onMyPendingRentalClick = viewModel::onPendingRentalClicked, // TODO: 승인/발송 대기 리스트 화면 구현 후 Navigation 연결
     )
 
     LoadingScreen(uiState.isLoading)

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageRoute.kt
@@ -81,7 +81,7 @@ fun MyPageRoute(navHostController: NavHostController) {
         onProductItemClick = viewModel::onProductItemClicked,
         onRentalItemClick = viewModel::onRentalItemClicked,
         onSettingClick = viewModel::onSettingClicked,
-        onMyPendingRentalClick = viewModel::onPendingRentalClicked, // TODO: 승인/발송 대기 리스트 화면 구현 후 Navigation 연결
+        onMyPendingRentalClick = viewModel::onPendingRentalClicked,
     )
 
     LoadingScreen(uiState.isLoading)

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageScreen.kt
@@ -190,7 +190,7 @@ fun ProfileSection(
 fun RowScope.CountBox(label: String, count: Int, clickable: Boolean = false, onClick: () -> Unit = {}) {
     Column(modifier = Modifier
         .weight(1f)
-        .clip(RoundedCornerShape(10.dp))
+        .clip(RoundedCornerShape(4.dp))
         .clickable(clickable) { onClick() }) {
         Text(
             modifier = Modifier.padding(bottom = 2.dp),

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageSideEffect.kt
@@ -3,6 +3,7 @@ package com.example.rentit.presentation.mypage
 sealed class MyPageSideEffect {
     data class NavigateToProductDetail(val productId: Int): MyPageSideEffect()
     data class NavigateToRentalDetail(val productId: Int, val reservationId: Int): MyPageSideEffect()
+    data object NavigateToMyProductsRental: MyPageSideEffect()
     data object NavigateToSetting: MyPageSideEffect()
     data object ToastComingSoon: MyPageSideEffect()
     data class CommonError(val throwable: Throwable): MyPageSideEffect()

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalRoute.kt
@@ -1,0 +1,29 @@
+package com.example.rentit.presentation.mypage.myproductsrental
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun MyProductsRentalRoute() {
+    val viewModel: MyProductsRentalViewModel = hiltViewModel()
+
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.getMyProductsRentalHistories()
+    }
+
+    MyProductsRentalScreen(
+        rentals = uiState.filteredRentalHistories,
+        selectedFilter = uiState.selectedFilter,
+        showNoticeBanner = uiState.showNoticeBanner,
+        onFilterChange = viewModel::onFilterChanged,
+        onBackClick = {},
+    )
+}

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalRoute.kt
@@ -22,6 +22,7 @@ fun MyProductsRentalRoute() {
     MyProductsRentalScreen(
         rentals = uiState.filteredRentalHistories,
         selectedFilter = uiState.selectedFilter,
+        historyCountMap = uiState.historyCountMap,
         upcomingShipmentCount = uiState.upcomingShipmentCount,
         showNoticeBanner = uiState.showNoticeBanner,
         onFilterChange = viewModel::onFilterChanged,

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalRoute.kt
@@ -6,18 +6,40 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
+import com.example.rentit.common.component.layout.LoadingScreen
+import com.example.rentit.presentation.main.MainViewModel
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun MyProductsRentalRoute(navHostController: NavHostController) {
+    val backStackEntry = navHostController.currentBackStackEntry
+    val mainViewModel: MainViewModel? = backStackEntry?.let { hiltViewModel(it) }
+
     val viewModel: MyProductsRentalViewModel = hiltViewModel()
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.getMyProductsRentalHistories()
+        mainViewModel?.setRetryAction(viewModel::reloadData)
+    }
+
+    LaunchedEffect(Unit) {
+        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.sideEffect.collect {
+                when(it) {
+                    is MyProductsRentalSideEffect.CommonError -> {
+                        mainViewModel?.handleError(it.throwable)
+                    }
+                }
+            }
+        }
     }
 
     MyProductsRentalScreen(
@@ -29,4 +51,6 @@ fun MyProductsRentalRoute(navHostController: NavHostController) {
         onFilterChange = viewModel::onFilterChanged,
         onBackClick = navHostController::popBackStack,
     )
+
+    LoadingScreen(uiState.isLoading)
 }

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalRoute.kt
@@ -22,6 +22,7 @@ fun MyProductsRentalRoute() {
     MyProductsRentalScreen(
         rentals = uiState.filteredRentalHistories,
         selectedFilter = uiState.selectedFilter,
+        upcomingShipmentCount = uiState.upcomingShipmentCount,
         showNoticeBanner = uiState.showNoticeBanner,
         onFilterChange = viewModel::onFilterChanged,
         onBackClick = {},

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalRoute.kt
@@ -7,10 +7,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun MyProductsRentalRoute() {
+fun MyProductsRentalRoute(navHostController: NavHostController) {
     val viewModel: MyProductsRentalViewModel = hiltViewModel()
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -26,6 +27,6 @@ fun MyProductsRentalRoute() {
         upcomingShipmentCount = uiState.upcomingShipmentCount,
         showNoticeBanner = uiState.showNoticeBanner,
         onFilterChange = viewModel::onFilterChanged,
-        onBackClick = {},
+        onBackClick = navHostController::popBackStack,
     )
 }

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalScreen.kt
@@ -273,6 +273,7 @@ fun getRentalInfoText(
                 }
             }
         }
+        else -> return buildAnnotatedString {  }
     }
 }
 

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalScreen.kt
@@ -49,6 +49,7 @@ import kotlin.math.abs
 fun MyProductsRentalScreen(
     rentals: List<MyProductsRentalModel> = emptyList(),
     selectedFilter: MyProductsRentalFilter = MyProductsRentalFilter.WAITING_FOR_RESPONSE,
+    historyCountMap: Map<MyProductsRentalFilter, Int> = emptyMap(),
     upcomingShipmentCount: Int = 0,
     showNoticeBanner: Boolean = true,
     onFilterChange: (MyProductsRentalFilter) -> Unit = {},
@@ -68,7 +69,7 @@ fun MyProductsRentalScreen(
                 .padding(it)
                 .screenHorizontalPadding()
         ) {
-            FilterSection(selectedFilter, onFilterChange)
+            FilterSection(selectedFilter, historyCountMap, onFilterChange)
 
             if(showNoticeBanner) {
                 NoticeBannerSection(selectedFilter, upcomingShipmentCount)
@@ -82,6 +83,7 @@ fun MyProductsRentalScreen(
 @Composable
 fun FilterSection(
     selectedFilter: MyProductsRentalFilter = MyProductsRentalFilter.WAITING_FOR_RESPONSE,
+    historyCountMap: Map<MyProductsRentalFilter, Int> = emptyMap(),
     onFilterChange: (MyProductsRentalFilter) -> Unit = {}
 ) {
     Row(
@@ -90,30 +92,15 @@ fun FilterSection(
             .horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        FilterButton(
-            title = stringResource(R.string.screen_my_products_rental_filter_waiting_for_response),
-            contentDesc = "",
-            isSelected = selectedFilter == MyProductsRentalFilter.WAITING_FOR_RESPONSE,
-            onClick = { onFilterChange(MyProductsRentalFilter.WAITING_FOR_RESPONSE) }
-        )
-        FilterButton(
-            title = stringResource(R.string.screen_my_products_rental_filter_waiting_for_shipment),
-            contentDesc = "",
-            isSelected = selectedFilter == MyProductsRentalFilter.WAITING_FOR_SHIPMENT,
-            onClick = { onFilterChange(MyProductsRentalFilter.WAITING_FOR_SHIPMENT) }
-        )
-        FilterButton(
-            title = stringResource(R.string.screen_my_products_rental_filter_renting),
-            contentDesc = "",
-            isSelected = selectedFilter == MyProductsRentalFilter.RENTING,
-            onClick = { onFilterChange(MyProductsRentalFilter.RENTING) }
-        )
-        FilterButton(
-            title = stringResource(R.string.screen_my_products_rental_filter_accepted),
-            contentDesc = "",
-            isSelected = selectedFilter == MyProductsRentalFilter.ACCEPTED,
-            onClick = { onFilterChange(MyProductsRentalFilter.ACCEPTED) }
-        )
+        MyProductsRentalFilter.entries.forEach {
+            if(it == MyProductsRentalFilter.NONE) return
+            FilterButton(
+                title = stringResource(it.titleRes) + " ${historyCountMap[it]}",
+                contentDesc = stringResource(it.contentDescRes),
+                isSelected = selectedFilter == it,
+                onClick = { onFilterChange(it) }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalScreen.kt
@@ -1,0 +1,291 @@
+package com.example.rentit.presentation.mypage.myproductsrental
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.rentit.R
+import com.example.rentit.common.D_DAY_ALERT_THRESHOLD_DAYS
+import com.example.rentit.common.component.CommonTopAppBar
+import com.example.rentit.common.component.FilterButton
+import com.example.rentit.common.component.LoadableUrlImage
+import com.example.rentit.common.component.AnimatedNoticeBanner
+import com.example.rentit.common.component.layout.EmptyContentScreen
+import com.example.rentit.common.component.screenHorizontalPadding
+import com.example.rentit.common.theme.AppRed
+import com.example.rentit.common.theme.Gray400
+import com.example.rentit.common.theme.PrimaryBlue500
+import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.common.util.formatPrice
+import com.example.rentit.domain.user.model.MyProductsRentalModel
+import com.example.rentit.presentation.mypage.myproductsrental.model.MyProductsRentalFilter
+import kotlin.math.abs
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun MyProductsRentalScreen(
+    rentals: List<MyProductsRentalModel> = emptyList(),
+    selectedFilter: MyProductsRentalFilter = MyProductsRentalFilter.WAITING_FOR_RESPONSE,
+    showNoticeBanner: Boolean = true,
+    onFilterChange: (MyProductsRentalFilter) -> Unit = {},
+    onBackClick: () -> Unit = {}
+) {
+    Scaffold(
+        topBar = {
+            CommonTopAppBar(
+                title = stringResource(R.string.screen_my_products_rental_title),
+                onBackClick = onBackClick
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(it)
+                .screenHorizontalPadding()
+        ) {
+            FilterSection(selectedFilter, onFilterChange)
+
+            if(showNoticeBanner) {
+                NoticeBannerSection(selectedFilter)
+            }
+
+            RentalHistoriesSection(selectedFilter, rentals)
+        }
+    }
+}
+
+@Composable
+fun FilterSection(
+    selectedFilter: MyProductsRentalFilter = MyProductsRentalFilter.WAITING_FOR_RESPONSE,
+    onFilterChange: (MyProductsRentalFilter) -> Unit = {}
+) {
+    Row(
+        modifier = Modifier
+            .padding(vertical = 20.dp)
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        FilterButton(
+            title = stringResource(R.string.screen_my_products_rental_filter_waiting_for_response),
+            contentDesc = "",
+            isSelected = selectedFilter == MyProductsRentalFilter.WAITING_FOR_RESPONSE,
+            onClick = { onFilterChange(MyProductsRentalFilter.WAITING_FOR_RESPONSE) }
+        )
+        FilterButton(
+            title = stringResource(R.string.screen_my_products_rental_filter_waiting_for_shipment),
+            contentDesc = "",
+            isSelected = selectedFilter == MyProductsRentalFilter.WAITING_FOR_SHIPMENT,
+            onClick = { onFilterChange(MyProductsRentalFilter.WAITING_FOR_SHIPMENT) }
+        )
+        FilterButton(
+            title = stringResource(R.string.screen_my_products_rental_filter_renting),
+            contentDesc = "",
+            isSelected = selectedFilter == MyProductsRentalFilter.RENTING,
+            onClick = { onFilterChange(MyProductsRentalFilter.RENTING) }
+        )
+        FilterButton(
+            title = stringResource(R.string.screen_my_products_rental_filter_accepted),
+            contentDesc = "",
+            isSelected = selectedFilter == MyProductsRentalFilter.ACCEPTED,
+            onClick = { onFilterChange(MyProductsRentalFilter.ACCEPTED) }
+        )
+    }
+}
+
+@Composable
+fun NoticeBannerSection(selectedFilter: MyProductsRentalFilter) {
+    val noticeText =
+        buildAnnotatedString {
+            when (selectedFilter) {
+                MyProductsRentalFilter.WAITING_FOR_RESPONSE -> {
+                    withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle().copy(PrimaryBlue500)) {
+                        append(stringResource(R.string.screen_my_products_rental_notice_waiting_for_response_1))
+                    }
+                    append(stringResource(R.string.screen_my_products_rental_notice_waiting_for_response_2))
+                }
+
+                MyProductsRentalFilter.WAITING_FOR_SHIPMENT -> {
+                    append(stringResource(R.string.screen_my_products_rental_notice_waiting_for_shipment_1))
+                    withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle().copy(PrimaryBlue500)) {
+                        append("0 " + stringResource(R.string.common_case_unit))
+                    }
+                    append(stringResource(R.string.screen_my_products_rental_notice_waiting_for_shipment_2))
+                }
+
+                else -> { }
+        }
+    }
+    AnimatedNoticeBanner(
+        modifier = Modifier.padding(bottom = 10.dp),
+        noticeText = noticeText
+    )
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun RentalHistoriesSection(
+    selectedFilter: MyProductsRentalFilter = MyProductsRentalFilter.WAITING_FOR_RESPONSE,
+    rentals: List<MyProductsRentalModel> = emptyList()
+) {
+    if(rentals.isEmpty()) return EmptyContentScreen(text = stringResource(R.string.screen_my_products_rental_empty_list))
+
+    LazyColumn {
+        items(rentals.size) { i ->
+            RentalHistoryItem(
+                selectedFilter = selectedFilter,
+                productTitle = rentals[i].productTitle,
+                rentalCount = rentals[i].rentalCount,
+                totalExpectRevenue = rentals[i].totalExpectRevenue,
+                renterNickname = rentals[i].renterNickname,
+                daysBeforeStart = rentals[i].daysBeforeStart,
+                daysBeforeReturn = rentals[i].daysBeforeReturn
+            )
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun RentalHistoryItem(
+    selectedFilter: MyProductsRentalFilter = MyProductsRentalFilter.WAITING_FOR_RESPONSE,
+    productTitle: String = "",
+    rentalCount: Int = 0,
+    totalExpectRevenue: Int = 0,
+    renterNickname: String = "",
+    daysBeforeStart: Int = 0,
+    daysBeforeReturn: Int = 0
+) {
+    val rentalInfoText = getRentalInfoText(
+        selectedFilter = selectedFilter,
+        rentalCount = rentalCount,
+        totalExpectRevenue = totalExpectRevenue,
+        renterNickname = renterNickname,
+        daysBeforeStart = daysBeforeStart,
+        daysBeforeReturn = daysBeforeReturn
+    )
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        LoadableUrlImage(
+            modifier = Modifier
+                .fillMaxWidth(0.25f)
+                .aspectRatio(1f),
+            imgUrl = null,
+        )
+
+        Column {
+            Text(
+                modifier = Modifier.padding(vertical = 8.dp),
+                text = productTitle,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodyLarge
+            )
+
+            Text(
+                text = rentalInfoText,
+                style = MaterialTheme.typography.labelMedium
+            )
+        }
+    }
+}
+
+@Composable
+@RequiresApi(Build.VERSION_CODES.O)
+fun getRentalInfoText(
+    selectedFilter: MyProductsRentalFilter = MyProductsRentalFilter.WAITING_FOR_RESPONSE,
+    rentalCount: Int = 0,
+    totalExpectRevenue: Int = 0,
+    renterNickname: String = "",
+    daysBeforeStart: Int = 0,
+    daysBeforeReturn: Int = 0
+): AnnotatedString {
+    when (selectedFilter) {
+        MyProductsRentalFilter.WAITING_FOR_RESPONSE -> {
+            return buildAnnotatedString {
+                withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle().copy(PrimaryBlue500)) {
+                    append("$rentalCount " + stringResource(R.string.common_case_unit))
+                }
+                append(stringResource(R.string.screen_my_products_rental_info_text_waiting_for_response))
+                withStyle(style = MaterialTheme.typography.labelMedium.toSpanStyle().copy(Gray400)) {
+                    append(" · " + stringResource(R.string.common_total) + " ${formatPrice(totalExpectRevenue)}" + stringResource(R.string.common_price_unit))
+                }
+            }
+        }
+        MyProductsRentalFilter.WAITING_FOR_SHIPMENT -> {
+            val dDayText = if(daysBeforeStart >= 0) " D-$daysBeforeStart" else " D+${abs(daysBeforeStart)}"
+            val dDayColor = if(daysBeforeStart > D_DAY_ALERT_THRESHOLD_DAYS) PrimaryBlue500 else AppRed
+            return buildAnnotatedString {
+                withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle()) {
+                    append("$renterNickname ")
+                }
+                append(stringResource(R.string.screen_my_products_rental_info_text_waiting_for_shipment))
+                withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle().copy(dDayColor)) {
+                    append(dDayText)
+                }
+            }
+        }
+        MyProductsRentalFilter.RENTING -> {
+            val dDayText = if(daysBeforeReturn >= 0) " D-$daysBeforeReturn" else " D+${abs(daysBeforeReturn)}"
+            val dDayColor = if(daysBeforeReturn > D_DAY_ALERT_THRESHOLD_DAYS) PrimaryBlue500 else AppRed
+            return buildAnnotatedString {
+                withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle()) {
+                    append("$renterNickname ")
+                }
+                append(stringResource(R.string.screen_my_products_rental_info_text_renting))
+                withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle().copy(dDayColor)) {
+                    append(dDayText)
+                }
+            }
+        }
+        MyProductsRentalFilter.ACCEPTED -> {
+            return buildAnnotatedString {
+                withStyle(style = MaterialTheme.typography.labelLarge.toSpanStyle().copy(PrimaryBlue500)) {
+                    append("$rentalCount " + stringResource(R.string.common_case_unit))
+                }
+                append(stringResource(R.string.screen_my_products_rental_info_text_accepted))
+                withStyle(style = MaterialTheme.typography.labelMedium.toSpanStyle().copy(Gray400)) {
+                    append(" · " + stringResource(R.string.common_total) + " ${formatPrice(totalExpectRevenue)}" + stringResource(R.string.common_price_unit))
+                }
+            }
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+@Preview(showBackground = true)
+fun MyProductsRentalPreview() {
+    RentItTheme {
+        MyProductsRentalScreen(
+            rentals = emptyList(),
+            selectedFilter = MyProductsRentalFilter.WAITING_FOR_RESPONSE,
+            onFilterChange = {},
+            onBackClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalSideEffect.kt
@@ -1,0 +1,4 @@
+package com.example.rentit.presentation.mypage.myproductsrental
+
+class MyProductsRentalSideEffect {
+}

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalSideEffect.kt
@@ -1,4 +1,5 @@
 package com.example.rentit.presentation.mypage.myproductsrental
 
-class MyProductsRentalSideEffect {
+sealed class MyProductsRentalSideEffect {
+    data class CommonError(val throwable: Throwable): MyProductsRentalSideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalState.kt
@@ -1,0 +1,15 @@
+package com.example.rentit.presentation.mypage.myproductsrental
+
+import com.example.rentit.domain.user.model.MyProductsRentalModel
+import com.example.rentit.presentation.mypage.myproductsrental.model.MyProductsRentalFilter
+
+data class MyProductsRentalState(
+    val rentalHistories: Map<MyProductsRentalFilter, List<MyProductsRentalModel>> = emptyMap(),
+    val selectedFilter: MyProductsRentalFilter = MyProductsRentalFilter.WAITING_FOR_RESPONSE,
+    val isLoading: Boolean = false,
+    val showNoticeBanner: Boolean = true
+) {
+    val filteredRentalHistories: List<MyProductsRentalModel>
+        get() = rentalHistories[selectedFilter] ?: emptyList()
+
+}

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalState.kt
@@ -17,4 +17,16 @@ data class MyProductsRentalState(
         get() = rentalHistories[MyProductsRentalFilter.WAITING_FOR_SHIPMENT]
             ?.count { it.daysBeforeStart <= D_DAY_ALERT_THRESHOLD_DAYS } ?: 0
 
+    val historyCountMap: Map<MyProductsRentalFilter, Int>
+        get() {
+            val initialMap = MyProductsRentalFilter.entries.associateWith { 0 }
+
+            return rentalHistories.mapValues {
+                when(it.key) {
+                    MyProductsRentalFilter.WAITING_FOR_RESPONSE, MyProductsRentalFilter.ACCEPTED
+                        -> it.value.sumOf { history -> history.rentalCount }
+                    else -> it.value.size
+                }
+            }.let { initialMap.plus(it) }
+        }
 }

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalState.kt
@@ -1,5 +1,6 @@
 package com.example.rentit.presentation.mypage.myproductsrental
 
+import com.example.rentit.common.D_DAY_ALERT_THRESHOLD_DAYS
 import com.example.rentit.domain.user.model.MyProductsRentalModel
 import com.example.rentit.presentation.mypage.myproductsrental.model.MyProductsRentalFilter
 
@@ -11,5 +12,9 @@ data class MyProductsRentalState(
 ) {
     val filteredRentalHistories: List<MyProductsRentalModel>
         get() = rentalHistories[selectedFilter] ?: emptyList()
+
+    val upcomingShipmentCount: Int
+        get() = rentalHistories[MyProductsRentalFilter.WAITING_FOR_SHIPMENT]
+            ?.count { it.daysBeforeStart <= D_DAY_ALERT_THRESHOLD_DAYS } ?: 0
 
 }

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalViewModel.kt
@@ -41,12 +41,17 @@ class MyProductsRentalViewModel @Inject constructor(
                         }
                     }
                     updateUiState { copy(rentalHistories = historiesByFilter) }
-                    println(it)
                 }
         }
     }
 
     fun onFilterChanged(filter: MyProductsRentalFilter) {
-        updateUiState { copy(selectedFilter = filter) }
+        updateUiState { copy(selectedFilter = filter, showNoticeBanner = false) }
+        when (filter) {
+            MyProductsRentalFilter.WAITING_FOR_RESPONSE, MyProductsRentalFilter.WAITING_FOR_SHIPMENT -> {
+                updateUiState { copy(showNoticeBanner = true) }
+            }
+            else -> {}
+        }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalViewModel.kt
@@ -1,0 +1,52 @@
+package com.example.rentit.presentation.mypage.myproductsrental
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.rentit.common.enums.RentalStatus
+import com.example.rentit.domain.user.model.MyProductsRentalModel
+import com.example.rentit.domain.user.usecase.GetMyProductsRentalHistoryUseCase
+import com.example.rentit.presentation.mypage.myproductsrental.model.MyProductsRentalFilter
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@RequiresApi(Build.VERSION_CODES.O)
+@HiltViewModel
+class MyProductsRentalViewModel @Inject constructor(
+    private val getMyProductsRentalHistoryUseCase: GetMyProductsRentalHistoryUseCase
+): ViewModel() {
+
+    private val _uiState = MutableStateFlow(MyProductsRentalState())
+    val uiState: StateFlow<MyProductsRentalState> = _uiState
+
+    private fun updateUiState(transform: MyProductsRentalState.() -> MyProductsRentalState) {
+        _uiState.value = _uiState.value.transform()
+    }
+
+    fun getMyProductsRentalHistories() {
+        viewModelScope.launch {
+            getMyProductsRentalHistoryUseCase()
+                .onSuccess {
+                    val historiesByFilter: Map<MyProductsRentalFilter, List<MyProductsRentalModel>> = it.mapKeys { (status, _) ->
+                        when (status) {
+                            RentalStatus.PENDING -> MyProductsRentalFilter.WAITING_FOR_RESPONSE
+                            RentalStatus.PAID -> MyProductsRentalFilter.WAITING_FOR_SHIPMENT
+                            RentalStatus.RENTING -> MyProductsRentalFilter.RENTING
+                            RentalStatus.ACCEPTED -> MyProductsRentalFilter.ACCEPTED
+                            else -> MyProductsRentalFilter.NONE
+                        }
+                    }
+                    updateUiState { copy(rentalHistories = historiesByFilter) }
+                    println(it)
+                }
+        }
+    }
+
+    fun onFilterChanged(filter: MyProductsRentalFilter) {
+        updateUiState { copy(selectedFilter = filter) }
+    }
+}

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/MyProductsRentalViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.rentit.presentation.mypage.myproductsrental
 
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -9,10 +10,14 @@ import com.example.rentit.domain.user.model.MyProductsRentalModel
 import com.example.rentit.domain.user.usecase.GetMyProductsRentalHistoryUseCase
 import com.example.rentit.presentation.mypage.myproductsrental.model.MyProductsRentalFilter
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+private const val TAG = "MyProductsRentalViewModel"
 
 @RequiresApi(Build.VERSION_CODES.O)
 @HiltViewModel
@@ -23,25 +28,48 @@ class MyProductsRentalViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(MyProductsRentalState())
     val uiState: StateFlow<MyProductsRentalState> = _uiState
 
+    private val _sideEffect = MutableSharedFlow<MyProductsRentalSideEffect>()
+    val sideEffect: SharedFlow<MyProductsRentalSideEffect> = _sideEffect
+
     private fun updateUiState(transform: MyProductsRentalState.() -> MyProductsRentalState) {
         _uiState.value = _uiState.value.transform()
     }
 
-    fun getMyProductsRentalHistories() {
+    private fun emitSideEffect(sideEffect: MyProductsRentalSideEffect) {
         viewModelScope.launch {
-            getMyProductsRentalHistoryUseCase()
-                .onSuccess {
-                    val historiesByFilter: Map<MyProductsRentalFilter, List<MyProductsRentalModel>> = it.mapKeys { (status, _) ->
-                        when (status) {
-                            RentalStatus.PENDING -> MyProductsRentalFilter.WAITING_FOR_RESPONSE
-                            RentalStatus.PAID -> MyProductsRentalFilter.WAITING_FOR_SHIPMENT
-                            RentalStatus.RENTING -> MyProductsRentalFilter.RENTING
-                            RentalStatus.ACCEPTED -> MyProductsRentalFilter.ACCEPTED
-                            else -> MyProductsRentalFilter.NONE
-                        }
+            _sideEffect.emit(sideEffect)
+        }
+    }
+
+    private fun setLoading(isLoading: Boolean) {
+        updateUiState { copy(isLoading = isLoading) }
+    }
+
+    suspend fun getMyProductsRentalHistories() {
+        setLoading(true)
+        getMyProductsRentalHistoryUseCase()
+            .onSuccess {
+                val historiesByFilter: Map<MyProductsRentalFilter, List<MyProductsRentalModel>> = it.mapKeys { (status, _) ->
+                    when (status) {
+                        RentalStatus.PENDING -> MyProductsRentalFilter.WAITING_FOR_RESPONSE
+                        RentalStatus.PAID -> MyProductsRentalFilter.WAITING_FOR_SHIPMENT
+                        RentalStatus.RENTING -> MyProductsRentalFilter.RENTING
+                        RentalStatus.ACCEPTED -> MyProductsRentalFilter.ACCEPTED
+                        else -> MyProductsRentalFilter.NONE
                     }
-                    updateUiState { copy(rentalHistories = historiesByFilter) }
                 }
+                updateUiState { copy(rentalHistories = historiesByFilter) }
+                Log.i(TAG, "내 상품에 대한 대여 내역 조회 성공: 총 ${it.size}개")
+            }.onFailure { e ->
+                Log.e(TAG, "내 상품에 대한 대여 내역 조회 실패", e)
+                emitSideEffect(MyProductsRentalSideEffect.CommonError(e))
+            }
+        setLoading(false)
+    }
+
+    fun reloadData() {
+        viewModelScope.launch {
+            getMyProductsRentalHistories()
         }
     }
 

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/model/MyProductsRentalFilter.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/model/MyProductsRentalFilter.kt
@@ -4,5 +4,6 @@ enum class MyProductsRentalFilter {
     WAITING_FOR_RESPONSE,
     WAITING_FOR_SHIPMENT,
     RENTING,
-    ACCEPTED
+    ACCEPTED,
+    NONE
 }

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/model/MyProductsRentalFilter.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/model/MyProductsRentalFilter.kt
@@ -1,9 +1,27 @@
 package com.example.rentit.presentation.mypage.myproductsrental.model
 
-enum class MyProductsRentalFilter {
-    WAITING_FOR_RESPONSE,
-    WAITING_FOR_SHIPMENT,
-    RENTING,
-    ACCEPTED,
-    NONE
+import androidx.annotation.StringRes
+import com.example.rentit.R
+
+enum class MyProductsRentalFilter(
+    @StringRes val titleRes: Int,
+    @StringRes val contentDescRes: Int
+) {
+    WAITING_FOR_RESPONSE(
+        R.string.screen_my_products_rental_filter_waiting_for_response,
+        R.string.screen_my_products_rental_filter_waiting_for_response_desc
+    ),
+    WAITING_FOR_SHIPMENT(
+        R.string.screen_my_products_rental_filter_waiting_for_shipment,
+        R.string.screen_my_products_rental_filter_waiting_for_shipment_desc
+    ),
+    RENTING(
+        R.string.screen_my_products_rental_filter_renting,
+        R.string.screen_my_products_rental_filter_renting_desc
+    ),
+    ACCEPTED(
+        R.string.screen_my_products_rental_filter_accepted,
+        R.string.screen_my_products_rental_filter_accepted_desc
+    ),
+    NONE(0, 0)
 }

--- a/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/model/MyProductsRentalFilter.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/myproductsrental/model/MyProductsRentalFilter.kt
@@ -1,0 +1,8 @@
+package com.example.rentit.presentation.mypage.myproductsrental.model
+
+enum class MyProductsRentalFilter {
+    WAITING_FOR_RESPONSE,
+    WAITING_FOR_SHIPMENT,
+    RENTING,
+    ACCEPTED
+}

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/rentalhistory/RentalHistoryScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/rentalhistory/RentalHistoryScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.rentit.R
+import com.example.rentit.common.D_DAY_ALERT_THRESHOLD_DAYS
 import com.example.rentit.common.component.CommonTopAppBar
 import com.example.rentit.common.component.FilterButton
 import com.example.rentit.common.component.screenHorizontalPadding
@@ -51,8 +52,6 @@ import com.example.rentit.presentation.productdetail.rentalhistory.model.RentalH
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
-
-private const val D_DAY_ALERT_THRESHOLD_DAYS = 3
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,7 +288,7 @@
 
     <string name="screen_my_products_rental_notice_waiting_for_response_1">응답</string>
     <string name="screen_my_products_rental_notice_waiting_for_response_2">을 기다리고 있어요!</string>
-    <string name="screen_my_products_rental_notice_waiting_for_shipment_1">곧 발송해야하는 상품</string>
+    <string name="screen_my_products_rental_notice_waiting_for_shipment_1">발송 임박 상품</string>
     <string name="screen_my_products_rental_notice_waiting_for_shipment_2">이 있어요!</string>
 
     <string name="screen_my_products_rental_info_text_waiting_for_response">의 대여 요청이 있어요</string>
@@ -296,7 +296,7 @@
     <string name="screen_my_products_rental_info_text_renting">님의 반납까지</string>
     <string name="screen_my_products_rental_info_text_accepted">의 요청 수락된 내역이 있어요</string>
 
-    <string name="screen_my_products_rental_empty_list">진행 중인 대여가 없어요.</string>
+    <string name="screen_my_products_rental_empty_list">내역이 없어요.</string>
 
     <!-- 설정 -->
     <string name="screen_setting_title">설정</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -281,10 +281,13 @@
     <string name="screen_my_products_rental_title">내 상품 대여 현황</string>
 
     <string name="screen_my_products_rental_filter_waiting_for_response">요청 응답 대기</string>
+    <string name="screen_my_products_rental_filter_waiting_for_response_desc">요청 응답 대기 중인 내역만 보기</string>
     <string name="screen_my_products_rental_filter_waiting_for_shipment">상품 발송 대기</string>
+    <string name="screen_my_products_rental_filter_waiting_for_shipment_desc">상품 발송 대기 중인 내역만 보기</string>
     <string name="screen_my_products_rental_filter_renting">대여 중</string>
+    <string name="screen_my_products_rental_filter_renting_desc">대여 중인 내역만 보기</string>
     <string name="screen_my_products_rental_filter_accepted">요청 수락</string>
-    <string name="screen_my_products_rental_filter_finished">종료됨</string>
+    <string name="screen_my_products_rental_filter_accepted_desc">요청 수락한 내역만 보기</string>
 
     <string name="screen_my_products_rental_notice_waiting_for_response_1">응답</string>
     <string name="screen_my_products_rental_notice_waiting_for_response_2">을 기다리고 있어요!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="common_top_app_bar_back_icon_description">뒤로가기</string>
     <string name="common_top_app_bar_menu_icon_description">메뉴</string>
     <string name="common_day_unit">일</string>
+    <string name="common_case_unit">건</string>
     <string name="common_price_unit_per_day">원/일</string>
     <string name="common_price_unit">원</string>
     <string name="common_total">총</string>
@@ -275,6 +276,27 @@
     <string name="screen_mypage_my_activity_count_label_post">게시글</string>
     <string name="screen_mypage_my_activity_count_label_rental">대여 현황</string>
     <string name="screen_mypage_my_activity_count_label_pending">승인/발송 대기</string>
+
+    <!-- 내 상품 대여 현황 -->
+    <string name="screen_my_products_rental_title">내 상품 대여 현황</string>
+
+    <string name="screen_my_products_rental_filter_waiting_for_response">요청 응답 대기</string>
+    <string name="screen_my_products_rental_filter_waiting_for_shipment">상품 발송 대기</string>
+    <string name="screen_my_products_rental_filter_renting">대여 중</string>
+    <string name="screen_my_products_rental_filter_accepted">요청 수락</string>
+    <string name="screen_my_products_rental_filter_finished">종료됨</string>
+
+    <string name="screen_my_products_rental_notice_waiting_for_response_1">응답</string>
+    <string name="screen_my_products_rental_notice_waiting_for_response_2">을 기다리고 있어요!</string>
+    <string name="screen_my_products_rental_notice_waiting_for_shipment_1">곧 발송해야하는 상품</string>
+    <string name="screen_my_products_rental_notice_waiting_for_shipment_2">이 있어요!</string>
+
+    <string name="screen_my_products_rental_info_text_waiting_for_response">의 대여 요청이 있어요</string>
+    <string name="screen_my_products_rental_info_text_waiting_for_shipment">님에게 대여 시작까지</string>
+    <string name="screen_my_products_rental_info_text_renting">님의 반납까지</string>
+    <string name="screen_my_products_rental_info_text_accepted">의 요청 수락된 내역이 있어요</string>
+
+    <string name="screen_my_products_rental_empty_list">진행 중인 대여가 없어요.</string>
 
     <!-- 설정 -->
     <string name="screen_setting_title">설정</string>


### PR DESCRIPTION
# Pull Request

## Summary  
변경한 주요 내용을 간단하게 요약. (어떤 기능을 추가하거나 수정했는지)

## Related Issue  
- Close: #170

## Changes  
**UI 구현**
- `MyProductsRentalScreen` 생성, 사용자 상품 대여 상태 표시
- 필터 버튼 추가: "Waiting for Response", "Waiting for Shipment", "Renting", "Accepted"
- `RentalHistoryItem`으로 상품 정보 표시, D-Day 등 상태별 텍스트 처리
- `AnimatedNoticeBanner` 추가 및 slideInVertically 애니메이션 적용
- 상품 썸네일 표시 및 클릭 가능
- 필터 버튼에 아이템 개수 표시
- 로딩/빈 화면 처리 및 접근성 개선 (`contentDescription`, string resources)

**데이터 및 도메인 레이어 구현**
- API 호출 (`getMyProductsRentalList`) 추가
- DTO 생성: `MyProductsRentalListResponseDto`, `MyProductsRentalDto`
- UseCase (`GetMyProductsRentalHistoryUseCase`)에서 rental 데이터를 `RentalStatus`별로 그룹핑하고 `MyProductsRentalModel`로 매핑

**화면 로직 및 상태 관리**
- `MyProductsRentalState`로 UI 상태 관리
- `MyProductsRentalViewModel`에서 데이터 fetch, 상태 필터링, 필터별 item count 계산
- `historyCountMap` 생성 후 ViewModel → Screen 전달
- PAID/RENTING 리스트 정렬 (D-Day 기준)
- notice banner 표시/숨김 상태 관리

**네비게이션**
- MyProductsRental 화면 route 및 nav graph 생성
- `navigateToMyProductsRental` 확장 함수, MyPageViewModel에서 side effect로 화면 이동
- back navigation 처리

**로딩 및 에러 처리**
- `isLoading` 상태 추가 → `LoadingScreen` 표시
- `MyProductsRentalSideEffect`로 에러 처리
- reload 기능 및 ViewModel에서 side effect emit

## Screenshots
- 구현 화면 UI (임시 데이터로 상태별 날짜 제한이 적용되지 않음)
<div>
<img width="24%" src="https://github.com/user-attachments/assets/733612f6-d50d-470c-bd01-04e0e8aed7c9"/>
<img width="24%" src="https://github.com/user-attachments/assets/65ce89a6-7bda-407c-a5d3-f5dab2880870"/>
<img width="24%" src="https://github.com/user-attachments/assets/90df49e6-d376-46f4-b605-6cbe425d49fb"/>
<img width="24%" src="https://github.com/user-attachments/assets/1483e4b2-06d1-4ea0-97a5-51e72bebe007"/>
</div>

## Notes
- 상품 클릭시 화면 이동은 상품 대여 내역 화면 수정 후 연결 예정


