### PR TITLE
Feat/167 multi images create post

### DIFF
--- a/app/src/main/java/com/example/rentit/common/util/MultipartUtil.kt
+++ b/app/src/main/java/com/example/rentit/common/util/MultipartUtil.kt
@@ -22,7 +22,7 @@ object MultipartUtil {
         val requestBody = file.asRequestBody(mimeType.toMediaTypeOrNull())
 
         return MultipartBody.Part.createFormData(
-            "thumbnailImg",
+            "thumbnailImgs",
             file.name,
             requestBody
         )

--- a/app/src/main/java/com/example/rentit/data/product/dto/ProductListResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/product/dto/ProductListResponseDto.kt
@@ -30,6 +30,9 @@ data class ProductDto(
     @SerializedName("thumbnailImgUrl")
     val thumbnailImgUrl: String?,
 
+    @SerializedName("thumbnailImgs")
+    val imageUrls: List<String>,
+
     @SerializedName("region")
     val region: String?,
 

--- a/app/src/main/java/com/example/rentit/data/product/mapper/ProductDetailMapper.kt
+++ b/app/src/main/java/com/example/rentit/data/product/mapper/ProductDetailMapper.kt
@@ -12,7 +12,7 @@ fun ProductDto.toProductDetailModel(categoryMap: Map<Int, CategoryModel>) =
         category = categories.mapNotNull { categoryMap[it]?.name },
         content = description,
         createdAt = createdAt,
-        imgUrlList = listOfNotNull(thumbnailImgUrl), // 서버에서 아직 이미지 여러 장을 지원하지 않음
+        imageUrls = imageUrls, // 서버에서 아직 이미지 여러 장을 지원하지 않음
         minPeriod = period?.min,
         maxPeriod = period?.max
     )

--- a/app/src/main/java/com/example/rentit/data/product/remote/ProductApiService.kt
+++ b/app/src/main/java/com/example/rentit/data/product/remote/ProductApiService.kt
@@ -44,7 +44,7 @@ interface ProductApiService {
     @POST("api/v1/products")
     suspend fun createPost(
         @Part("payload") payload: RequestBody,
-        @Part thumbnailImg: MultipartBody.Part?
+        @Part imageParts: List<MultipartBody.Part>?
     ): Response<CreatePostResponseDto>
 
     @GET("api/v1/products/{productId}/reservations/chat-access")

--- a/app/src/main/java/com/example/rentit/data/product/remote/ProductRemoteDataSource.kt
+++ b/app/src/main/java/com/example/rentit/data/product/remote/ProductRemoteDataSource.kt
@@ -31,8 +31,8 @@ class ProductRemoteDataSource @Inject constructor(
     suspend fun getCategories(): Response<CategoryListResponseDto> {
         return productApiService.getCategories()
     }
-    suspend fun createPost(payLoad: RequestBody, thumbnailImg: MultipartBody.Part?): Response<CreatePostResponseDto> {
-        return productApiService.createPost(payLoad, thumbnailImg)
+    suspend fun createPost(payLoad: RequestBody, imageParts: List<MultipartBody.Part>?): Response<CreatePostResponseDto> {
+        return productApiService.createPost(payLoad, imageParts)
     }
     suspend fun getChatAccessibility(productId: Int): Response<ChatAccessibilityResponseDto> {
         return productApiService.getChatAccessibility(productId)

--- a/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/product/repositoryImpl/ProductRepositoryImpl.kt
@@ -38,8 +38,8 @@ class ProductRepositoryImpl @Inject constructor(
         return safeApiCall(productRemoteDataSource::getCategories)
     }
 
-    override suspend fun createPost(payLoad: RequestBody, thumbnailImg: MultipartBody.Part?): Result<CreatePostResponseDto> {
-        return safeApiCall { productRemoteDataSource.createPost(payLoad, thumbnailImg) }
+    override suspend fun createPost(payLoad: RequestBody, imageParts: List<MultipartBody.Part>?): Result<CreatePostResponseDto> {
+        return safeApiCall { productRemoteDataSource.createPost(payLoad, imageParts) }
     }
 
     override suspend fun getChatAccessibility(productId: Int): Result<ChatAccessibilityResponseDto> {

--- a/app/src/main/java/com/example/rentit/domain/product/model/ProductDetailModel.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/model/ProductDetailModel.kt
@@ -9,7 +9,7 @@ data class ProductDetailModel(
     val category: List<String>,
     val content: String,
     val createdAt: String,
-    val imgUrlList: List<String?>,
+    val imageUrls: List<String?>,
 ) {
     companion object {
         val EMPTY = ProductDetailModel(
@@ -21,7 +21,7 @@ data class ProductDetailModel(
             category = emptyList(),
             content = "",
             createdAt = "",
-            imgUrlList = emptyList()
+            imageUrls = emptyList()
         )
     }
 }

--- a/app/src/main/java/com/example/rentit/domain/product/repository/ProductRepository.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/repository/ProductRepository.kt
@@ -22,7 +22,7 @@ interface ProductRepository {
 
     suspend fun getCategories(): Result<CategoryListResponseDto>
 
-    suspend fun createPost(payLoad: RequestBody, thumbnailImg: MultipartBody.Part?): Result<CreatePostResponseDto>
+    suspend fun createPost(payLoad: RequestBody, imageParts: List<MultipartBody.Part>?): Result<CreatePostResponseDto>
 
     suspend fun getChatAccessibility(productId: Int): Result<ChatAccessibilityResponseDto>
 }

--- a/app/src/main/java/com/example/rentit/domain/product/usecase/CreatePostUseCase.kt
+++ b/app/src/main/java/com/example/rentit/domain/product/usecase/CreatePostUseCase.kt
@@ -22,7 +22,7 @@ class CreatePostUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(
-        thumbnailPart: MultipartBody.Part?,
+        imageParts: List<MultipartBody.Part>?,
         title: String,
         content: String,
         selectedCategoryIdList: List<Int>,
@@ -36,7 +36,7 @@ class CreatePostUseCase @Inject constructor(
             val payloadJson = Gson().toJson(postData)
             val requestBody = payloadJson.toRequestBody("application/json".toMediaTypeOrNull())
 
-            productRepository.createPost(requestBody, thumbnailPart).getOrThrow()
+            productRepository.createPost(requestBody, imageParts).getOrThrow()
         }
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/main/createpost/CreatePostScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/main/createpost/CreatePostScreen.kt
@@ -21,15 +21,16 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.RangeSlider
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.RangeSlider
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SliderDefaults
+import androidx.compose.material.SliderDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -206,14 +207,6 @@ fun ImageSelectSection(
                 }
             }
         }
-
-        Text(
-            modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
-            text = stringResource(id = R.string.screen_product_create_add_image_guide),
-            style = MaterialTheme.typography.labelMedium,
-            color = Gray400,
-            textAlign = TextAlign.Start
-        )
     }
 }
 
@@ -329,6 +322,7 @@ fun RemovableTagButton(text: String, onRemoveClick: () -> Unit) {
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun RentalPeriodSection(sliderPosition: ClosedFloatingPointRange<Float>, onValueChange: (ClosedFloatingPointRange<Float>) -> Unit) {
     LabeledContent(stringResource(id = R.string.screen_product_create_rental_period_label)) {

--- a/app/src/main/java/com/example/rentit/presentation/main/createpost/CreatePostViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/main/createpost/CreatePostViewModel.kt
@@ -72,7 +72,7 @@ class CreatePostViewModel @Inject constructor(
     }
 
     fun updateImageUriList(uriList: List<Uri>) {
-        updateState { copy(selectedImgUriList = uriList) }
+        updateState { copy(selectedImgUriList = _uiState.value.selectedImgUriList + uriList) }
     }
 
     fun removeImageUri(uri: Uri){

--- a/app/src/main/java/com/example/rentit/presentation/main/createpost/CreatePostViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/main/createpost/CreatePostViewModel.kt
@@ -153,18 +153,16 @@ class CreatePostViewModel @Inject constructor(
 
         viewModelScope.launch {
             updateState { copy(isLoading = true) }
-            // 서버는 단일 이미지만 지원(임시)하므로 첫 번째 선택 이미지를 업로드 대상으로 사용
             val selectedImageUriList = _uiState.value.selectedImgUriList
-            val thumbnailPart =
+            val imageParts =
                 if (selectedImageUriList.isNotEmpty()) {
-                    MultipartUtil.uriToMultipart(
-                        context = context,
-                        uri = selectedImageUriList[0]
-                    )
+                    selectedImageUriList.mapNotNull {
+                        MultipartUtil.uriToMultipart(context, it)
+                    }
                 } else null
 
             createPostUseCase(
-                thumbnailPart = thumbnailPart,
+                imageParts = imageParts,
                 title = _uiState.value.title,
                 content = _uiState.value.content,
                 selectedCategoryIdList = _uiState.value.selectedCategoryIdList,

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/ProductDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/ProductDetailRoute.kt
@@ -37,8 +37,8 @@ fun ProductDetailRoute(navHostController: NavHostController, productId: Int) {
 
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val menuDrawerState = rememberModalBottomSheetState()
-    val imagePagerState = rememberPagerState { uiState.productDetail.imgUrlList.size }
-    val fullImagePagerState = rememberPagerState { uiState.productDetail.imgUrlList.size }
+    val imagePagerState = rememberPagerState { uiState.productDetail.imageUrls.size }
+    val fullImagePagerState = rememberPagerState { uiState.productDetail.imageUrls.size }
 
     LaunchedEffect(Unit) {
         viewModel.loadProductDetail(productId)

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/ProductDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/ProductDetailScreen.kt
@@ -121,7 +121,7 @@ fun ProductDetailScreen(
                     .padding(innerPadding)
                     .verticalScroll(state = rememberScrollState())
             ) {
-                ImagePager(imagePagerState, productDetail.imgUrlList, onFullImageShow)
+                ImagePager(imagePagerState, productDetail.imageUrls, onFullImageShow)
                 PostHeader(
                     productDetail.title,
                     productDetail.category,
@@ -159,7 +159,7 @@ fun ProductDetailScreen(
         }
     }
 
-    if(showFullImage) FullImageDialog(fullImagePagerState, productDetail.imgUrlList, onFullImageDismiss)
+    if(showFullImage) FullImageDialog(fullImagePagerState, productDetail.imageUrls, onFullImageDismiss)
 }
 
 @Composable
@@ -344,7 +344,7 @@ private fun Preview() {
         category = listOf("Sports"),
         content = "A sturdy mountain bike suitable for off-road trails.",
         createdAt = "2025-09-01T10:00:00",
-        imgUrlList = listOf("sample.jpg"),
+        imageUrls = listOf("sample.jpg"),
         minPeriod = 3,
         maxPeriod = 5
     )


### PR DESCRIPTION
# Pull Request

## Summary  
상품 등록 화면에서 여러 장 이미지를 업로드할 수 있도록 개선

## Related Issue  
- Close: #170

## Changes  
**Data / Domain**
- `createPost`: 단일 `thumbnailImg` → `List<MultipartBody.Part>` 처리로 변경
- `MultipartUtil`: multipart part name을 `thumbnailImg` → `thumbnailImgs`로 수정

**Presentation**
- `CreatePostViewModel`: 모든 선택 이미지를 업로드하도록 수정
- `updateImageUriList`: 리스트 교체 방식 → append 방식으로 변경
- 단일 이미지 업로드 가능 안내 문구 제거

**Model / Mapper**
- `ProductDetailModel`: `imgUrlList` → `imageUrls`로 리네이밍
- `ProductDetailMapper`: DTO의 `imageUrls` 매핑 반영
- `ProductDetailScreen`, `ProductDetailRoute`: `imageUrls` 변경 반영
