### PR TITLE
Feat/179 mypage info overdue

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/Buttons.kt
+++ b/app/src/main/java/com/example/rentit/common/component/Buttons.kt
@@ -112,20 +112,27 @@ private val iconSize = 10.dp
 fun ArrowedTextButton(
     modifier: Modifier = Modifier,
     text: String,
+    color: Color = AppBlack,
     onClick: () -> Unit,
 ) {
     TextButton(
-        modifier = modifier.height(buttonHeight),
+        modifier = modifier.height(buttonHeight).semantics { contentDescription = text },
         onClick = onClick,
         contentPadding = PaddingValues(horizontal = buttonHorizontalPadding),
-        colors = ButtonDefaults.textButtonColors(contentColor = AppBlack)
+        colors = ButtonDefaults.textButtonColors(contentColor = color)
     ) {
         Text(
             text = text,
-            style = MaterialTheme.typography.labelLarge
+            style = MaterialTheme.typography.labelLarge,
+            color = color
         )
         Spacer(Modifier.padding(textIconSpacing))
-        Icon(modifier = Modifier.size(iconSize), painter = painterResource(R.drawable.ic_chevron_right), contentDescription = null)
+        Icon(
+            modifier = Modifier.size(iconSize),
+            painter = painterResource(R.drawable.ic_chevron_right),
+            contentDescription = null,
+            tint = color
+        )
     }
 }
 

--- a/app/src/main/java/com/example/rentit/data/user/dto/MyRentalListResponseDto.kt
+++ b/app/src/main/java/com/example/rentit/data/user/dto/MyRentalListResponseDto.kt
@@ -36,6 +36,9 @@ data class NearestDueItemDto(
     @SerializedName("reservationId")
     val reservationId: Int,
 
+    @SerializedName("productId")
+    val productId: Int,
+
     @SerializedName("productTitle")
     val productTitle: String,
 

--- a/app/src/main/java/com/example/rentit/data/user/mapper/NearestDueItemMapper.kt
+++ b/app/src/main/java/com/example/rentit/data/user/mapper/NearestDueItemMapper.kt
@@ -9,7 +9,7 @@ import com.example.rentit.domain.user.model.NearestDueItemModel
 fun NearestDueItemDto.toModel() =
     NearestDueItemModel(
         reservationId = reservationId,
-        productId = 0,  // TODO: API 수정 후 productId 값 변경
+        productId = productId,
         productTitle = productTitle,
         remainingRentalDays = daysUntilReturn
     )

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageRoute.kt
@@ -74,7 +74,7 @@ fun MyPageRoute(navHostController: NavHostController) {
         profileImgUrl = uiState.profileImgUrl,
         nickName = uiState.nickName,
         myProductCount = uiState.myProductCount,
-        myValidRentalCount = uiState.myValidRentalCount,
+        myRentingCount = uiState.myValidRentalCount,
         myPendingRentalCount = uiState.myPendingRentalCount,
         nearestDueItem = uiState.nearestDueItem,
         myProductList = uiState.myProductList,

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageRoute.kt
@@ -80,7 +80,7 @@ fun MyPageRoute(navHostController: NavHostController) {
         myProductList = uiState.myProductList,
         myRentalList = uiState.myRentalList,
         pullToRefreshState = pullToRefreshState,
-        isFirstTabSelected = uiState.isFirstTabSelected,
+        currentTab = uiState.currentTab,
         isRefreshing = uiState.isRefreshing,
         onRefresh = viewModel::refreshData,
         onAlertClick = viewModel::showComingSoonMessage,
@@ -89,7 +89,9 @@ fun MyPageRoute(navHostController: NavHostController) {
         onProductItemClick = viewModel::onProductItemClicked,
         onRentalItemClick = viewModel::onRentalItemClicked,
         onSettingClick = viewModel::onSettingClicked,
-        onMyPendingRentalClick = viewModel::onPendingRentalClicked,
+        onMyProductCountClick = viewModel::onMyProductCountClicked,
+        onMyRentingCountClick = viewModel::onMyRentingCountClicked,
+        onMyPendingRentalCountClick = viewModel::onMyPendingRentalClicked,
     )
 
     LoadingScreen(uiState.isLoading)

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageScreen.kt
@@ -65,7 +65,7 @@ fun MyPageScreen(
     profileImgUrl: String?,
     nickName: String = "",
     myProductCount: Int = 0,
-    myValidRentalCount: Int = 0,
+    myRentingCount: Int = 0,
     myPendingRentalCount: Int = 0,
     nearestDueItem: NearestDueItemModel?,
     myProductList: List<MyProductItemModel>,
@@ -96,7 +96,7 @@ fun MyPageScreen(
                     profileImgUrl = profileImgUrl,
                     nickName = nickName,
                     myProductCount = myProductCount,
-                    myValidRentalCount = myValidRentalCount,
+                    myRentingCount = myRentingCount,
                     myPendingRentalCount = myPendingRentalCount,
                     onMyPendingRentalClick = onMyPendingRentalClick
                 )
@@ -163,7 +163,7 @@ fun ProfileSection(
     profileImgUrl: String? = null,
     nickName: String = "",
     myProductCount: Int = 0,
-    myValidRentalCount: Int = 0,
+    myRentingCount: Int = 0,
     myPendingRentalCount: Int = 0,
     onMyPendingRentalClick: () -> Unit = {}
 ) {
@@ -193,7 +193,7 @@ fun ProfileSection(
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 CountBox(stringResource(R.string.screen_mypage_my_activity_count_label_post), myProductCount)
-                CountBox(stringResource(R.string.screen_mypage_my_activity_count_label_rental), myValidRentalCount)
+                CountBox(stringResource(R.string.screen_mypage_my_activity_count_label_rental), myRentingCount)
                 CountBox(stringResource(R.string.screen_mypage_my_activity_count_label_pending), myPendingRentalCount, true, onMyPendingRentalClick)
             }
         }
@@ -473,7 +473,7 @@ fun MyPageScreenPreview() {
             profileImgUrl = "https://example.com/profile.jpg",
             nickName = "홍길동",
             myProductCount = sampleMyProductList.size,
-            myValidRentalCount = sampleMyRentalList.size,
+            myRentingCount = sampleMyRentalList.size,
             myPendingRentalCount = 0,
             nearestDueItem = sampleNearestDueItem,
             myProductList = sampleMyProductList,

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageState.kt
@@ -3,8 +3,10 @@ package com.example.rentit.presentation.mypage
 import com.example.rentit.domain.user.model.MyProductItemModel
 import com.example.rentit.domain.user.model.MyRentalItemModel
 import com.example.rentit.domain.user.model.NearestDueItemModel
+import com.example.rentit.presentation.mypage.model.MyPageTab
 
 data class MyPageState(
+    val currentTab: MyPageTab = MyPageTab.MY_PRODUCT,
     val profileImgUrl: String? = "",
     val nickName: String = "",
     val myProductCount: Int = 0,
@@ -14,6 +16,5 @@ data class MyPageState(
     val myProductList: List<MyProductItemModel> = emptyList(),
     val myRentalList: List<MyRentalItemModel> = emptyList(),
     val isRefreshing: Boolean = false,
-    val isFirstTabSelected: Boolean = true,
     val isLoading: Boolean = false,
 )

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageViewModel.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val TAG = "MyPageViewModel"
+
 @RequiresApi(Build.VERSION_CODES.O)
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
@@ -49,7 +51,9 @@ class MyPageViewModel @Inject constructor(
                     myProductList = it,
                     myProductCount = it.size
                 )
+                Log.i(TAG, "내 상품 조회 성공: ${it.size}개")
             }.onFailure { e ->
+                Log.e(TAG, "내 상품 조회 실패", e)
                 emitSideEffect(MyPageSideEffect.CommonError(e))
             }
     }
@@ -62,8 +66,9 @@ class MyPageViewModel @Inject constructor(
                     myValidRentalCount = it.myValidRentalCount,
                     nearestDueItem = it.nearestDueItem
                 )
+                Log.i(TAG, "내 대여 조회 성공: ${it.myRentalList.size}개")
             }.onFailure { e ->
-                Log.e("MyPageViewModel", "getMyRentalList: $e")
+                Log.e(TAG, "내 대여 조회 실패", e)
                 emitSideEffect(MyPageSideEffect.CommonError(e))
             }
     }
@@ -75,7 +80,9 @@ class MyPageViewModel @Inject constructor(
                     myPendingRentalCount = it.rentalHistory
                         .filter { history -> history.status == RentalStatus.PENDING || history.status == RentalStatus.PAID }.size
                 )
+                Log.i(TAG, "내 상품에 대한 대여 조회 성공: ${it.rentalHistory.size}개")
             }.onFailure { e ->
+                Log.e(TAG, "내 상품에 대한 대여 조회 실패", e)
                 emitSideEffect(MyPageSideEffect.CommonError(e))
             }
     }

--- a/app/src/main/java/com/example/rentit/presentation/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/MyPageViewModel.kt
@@ -9,6 +9,7 @@ import com.example.rentit.common.enums.RentalStatus
 import com.example.rentit.domain.user.repository.UserRepository
 import com.example.rentit.domain.user.usecase.GetMyProductsWithCategoryUseCase
 import com.example.rentit.domain.user.usecase.GetMyRentalsWithNearestDueUseCase
+import com.example.rentit.presentation.mypage.model.MyPageTab
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -107,7 +108,15 @@ class MyPageViewModel @Inject constructor(
         emitSideEffect(MyPageSideEffect.NavigateToRentalDetail(productId, reservationId))
     }
 
-    fun onPendingRentalClicked() {
+    fun onMyProductCountClicked() {
+        _uiState.value = _uiState.value.copy(currentTab = MyPageTab.MY_PRODUCT)
+    }
+
+    fun onMyRentingCountClicked() {
+        _uiState.value = _uiState.value.copy(currentTab = MyPageTab.MY_RENTAL)
+    }
+
+    fun onMyPendingRentalClicked() {
         emitSideEffect(MyPageSideEffect.NavigateToMyProductsRental)
     }
 
@@ -122,8 +131,8 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    fun setTabSelected() {
-        _uiState.value = _uiState.value.copy(isFirstTabSelected = !uiState.value.isFirstTabSelected)
+    fun setTabSelected(selectedTab: MyPageTab) {
+        _uiState.value = _uiState.value.copy(currentTab = selectedTab)
     }
 
     fun showComingSoonMessage() {

--- a/app/src/main/java/com/example/rentit/presentation/mypage/model/MyPageTab.kt
+++ b/app/src/main/java/com/example/rentit/presentation/mypage/model/MyPageTab.kt
@@ -1,0 +1,5 @@
+package com.example.rentit.presentation.mypage.model
+
+enum class MyPageTab {
+    MY_PRODUCT, MY_RENTAL
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,7 +287,7 @@
     <string name="screen_mypage_text_tab_list_rental_empty">대여 내역이 없어요.</string>
 
     <string name="screen_mypage_my_activity_count_label_post">게시글</string>
-    <string name="screen_mypage_my_activity_count_label_rental">대여 현황</string>
+    <string name="screen_mypage_my_activity_count_label_rental">대여 중</string>
     <string name="screen_mypage_my_activity_count_label_pending">승인/발송 대기</string>
 
     <!-- 내 상품 대여 현황 -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,11 +276,15 @@
     <!-- 마이페이지 -->
     <string name="screen_mypage_btn_my_activity">나의 활동 내역</string>
     <string name="screen_mypage_btn_new">NEW</string>
-    <string name="screen_mypage_info_text_1">내가 대여한</string>
-    <string name="screen_mypage_info_text_2">의 반납일이</string>
-    <string name="screen_mypage_info_text_3">일&#160;</string>
-    <string name="screen_mypage_info_text_4">남았어요!</string>
-    <string name="screen_mypage_check_usage_history">대여 정보 확인하기</string>
+    <string name="screen_mypage_info_text_return_day_1">오늘은</string>
+    <string name="screen_mypage_info_text_return_day_2">의</string>
+    <string name="screen_mypage_info_text_return_day_3">반납일</string>
+    <string name="screen_mypage_info_text_return_day_4">이에요! 반납을 진행해주세요.</string>
+    <string name="screen_mypage_info_text_1">의 반납일이</string>
+    <string name="screen_mypage_info_text_left">남았어요.</string>
+    <string name="screen_mypage_info_text_overdue">지났어요. 즉시 반납해주세요!</string>
+    <string name="screen_mypage_info_button_rental_detail">대여 정보 확인하기</string>
+    <string name="screen_mypage_info_button_return">상품 반납하기</string>
     <string name="screen_mypage_tab_title_my_product">내 물건</string>
     <string name="screen_mypage_tab_title_on_rent">내 대여</string>
     <string name="screen_mypage_text_tab_list_product_empty">게시글이 없어요.</string>


### PR DESCRIPTION
# Pull Request

## Summary  
마이페이지 대여 현황 집계 및 반납 임박 상태 표시 기능, 탭 전환 개선 

## Related Issue  
- Close: #179 

## Changes  
**대여 카운트 및 리스트 정렬 개선**  
- 마이페이지 대여 건수는 `RENTING` 상태의 아이템만 표시하도록 수정  
- 라벨을 **"대여 현황"** → **"대여 중"** 으로 변경  
- 대여 목록을 정렬하여 현재 대여 중인 아이템이 상단에 오도록 개선  
- `myValidRentalCount` → `myRentingCount` 로 네이밍 변경 (도메인 및 프레젠테이션 계층)  

**대여 상태 박스**  
- 가장 가까운 대여 건의 상태를 동적으로 표시 (대여 중 / 반납 당일 / 연체)  
- 상태에 따라 텍스트, 강조 색상, 버튼 문구가 달라짐  
  - **대여 중** → "대여 정보 확인"  
  - **반납 당일 / 연체** → "반납하기"  
- 기존 커스텀 클릭 텍스트를 공용 `ArrowedTextButton` 으로 교체  

- **탭 상태 관리 개선**
  - 기존 불리언 플래그(`isFirstTabSelected`) → 새로운 enum(`MyPageTab`: `MY_PRODUCT`, `MY_RENTAL`)으로 리팩토링
  - 마이페이지 화면의 상태 관리 및 가독성을 향상

- **프로필 카운트 클릭 시 탭 전환**
  - 프로필 영역의 "내 게시글 수" / "대여 중 수" 카운트를 클릭하면 해당 탭으로 이동하도록 개선
  - `MyPageViewModel` 에 `onMyProductCountClicked`, `onMyRentingCountClicked` 추가.
  - 클릭 시 하단 리스트 탭을 자연스럽게 전환

**리팩터링**  
- `ArrowedTextButton` 에 `color` 파라미터를 추가하여 텍스트 및 아이콘 색상을 동적으로 적용  
- `MyRentalListResponseDto` 에 `productId` 필드 추가 및 `NearestDueItemMapper` 수정  
- 파일명 오타 수정: `MyRentalListtResponseDto.kt` → `MyRentalListResponseDto.kt`  
- 데이터 조회에 대한 성공/실패 로그 추가

## Screenshots
- 상태에 따른 Info 섹션 변화
<img width="250" src="https://github.com/user-attachments/assets/2155ec2a-7d27-49fc-9e74-b7f6a0d2cade"/>
<img width="250" src="https://github.com/user-attachments/assets/1afdc67d-1c4a-4915-9f8f-d9b29d239890"/>
<img width="250" src="https://github.com/user-attachments/assets/e712b3b4-0862-4816-a6e7-71c4e373f653"/>
