### PR TITLE
Feat/185 automatic message

### DIFF
--- a/app/src/main/java/com/example/rentit/common/enums/AutoMessageType.kt
+++ b/app/src/main/java/com/example/rentit/common/enums/AutoMessageType.kt
@@ -1,5 +1,5 @@
 package com.example.rentit.common.enums
 
 enum class AutoMessageType(val code: String) {
-    REQUEST_ACCEPT("rq!A19"), COMPLETE_PAY("cp#7x")
+    REQUEST_ACCEPTED("rq!A19"), COMPLETE_PAY("cp#7x")
 }

--- a/app/src/main/java/com/example/rentit/data/chat/websocketImpl/WebSocketManagerImpl.kt
+++ b/app/src/main/java/com/example/rentit/data/chat/websocketImpl/WebSocketManagerImpl.kt
@@ -65,7 +65,7 @@ class WebSocketManagerImpl @Inject constructor(
             })
     }
 
-    override fun connect(chatroomId: String, onMessageReceived: (MessageResponseDto) -> Unit, onError: (Throwable) -> Unit) {
+    override fun connect(chatRoomId: String, onMessageReceived: (MessageResponseDto) -> Unit, onError: (Throwable) -> Unit) {
         val token = getAccessToken()
 
         clearDisposable()
@@ -73,15 +73,15 @@ class WebSocketManagerImpl @Inject constructor(
 
         subscribeLifeCycle(onError)
         stompClient?.connect(listOf(StompHeader("Authorization", "Bearer $token")))
-        subscribeTopic(chatroomId, onMessageReceived, onError)
+        subscribeTopic(chatRoomId, onMessageReceived, onError)
     }
 
-    override fun sendMessage(chatroomId: String, message: String, onSuccess: () -> Unit, onError: (Throwable) -> Unit) {
+    override fun sendMessage(chatRoomId: String, message: String, onSuccess: () -> Unit, onError: (Throwable) -> Unit) {
         val authUserId = getAuthUserId()
-        val dto = MessageRequestDto(chatroomId, authUserId, message)
+        val dto = MessageRequestDto(chatRoomId, authUserId, message)
         val json = Gson().toJson(dto)
 
-        sendDisposable = stompClient?.send("/app/chatroom.$chatroomId", json)
+        sendDisposable = stompClient?.send("/app/chatroom.$chatRoomId", json)
             ?.subscribe({
                 Log.i(TAG, "Message sent")
                 onSuccess()

--- a/app/src/main/java/com/example/rentit/domain/chat/websocket/WebSocketManager.kt
+++ b/app/src/main/java/com/example/rentit/domain/chat/websocket/WebSocketManager.kt
@@ -3,9 +3,9 @@ package com.example.rentit.domain.chat.websocket
 import com.example.rentit.data.chat.dto.MessageResponseDto
 
 interface WebSocketManager {
-    fun connect(chatroomId: String, onMessageReceived: (MessageResponseDto) -> Unit, onError: (Throwable) -> Unit)
+    fun connect(chatRoomId: String, onMessageReceived: (MessageResponseDto) -> Unit, onError: (Throwable) -> Unit)
 
-    fun sendMessage(chatroomId: String, message: String, onSuccess: () -> Unit, onError: (Throwable) -> Unit)
+    fun sendMessage(chatRoomId: String, message: String, onSuccess: () -> Unit, onError: (Throwable) -> Unit)
 
     fun disconnect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/ChatListScreen.kt
@@ -155,7 +155,7 @@ fun ChatListItem(
     val formatLastMsgTime = lastMessageTime?.let { "· " + it.toRelativeDayFormat() } ?: ""
 
     val lastMsg = when (lastMessage) {
-        AutoMessageType.REQUEST_ACCEPT.code -> stringResource(R.string.auto_msg_type_request_accept_title)
+        AutoMessageType.REQUEST_ACCEPTED.code -> stringResource(R.string.auto_msg_type_request_accept_title)
         AutoMessageType.COMPLETE_PAY.code -> stringResource(R.string.auto_msg_type_pay_complete_title)
         "" -> stringResource(R.string.screen_chat_list_empty_chat_message)
         else -> lastMessage

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/components/AutoMessageBubble.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/components/AutoMessageBubble.kt
@@ -39,7 +39,7 @@ fun AutoMessageBubble(isSender: Boolean, type: AutoMessageType, onPayClick: () -
     var content = ""
     var btnText = ""
     when (type) {
-        AutoMessageType.REQUEST_ACCEPT -> {
+        AutoMessageType.REQUEST_ACCEPTED -> {
             title = stringResource(R.string.auto_msg_type_request_accept_title)
             content = stringResource(R.string.auto_msg_type_request_accept_content)
             btnText = stringResource(R.string.auto_msg_type_request_accept_btn_text)
@@ -71,7 +71,7 @@ fun AutoMessageBubble(isSender: Boolean, type: AutoMessageType, onPayClick: () -
                 style = MaterialTheme.typography.bodyMedium.copy(lineBreak = LineBreak.Simple),
                 color = if(isSender) Color.White else AppBlack
             )
-            if(type == AutoMessageType.REQUEST_ACCEPT){
+            if(type == AutoMessageType.REQUEST_ACCEPTED){
                 Button(
                     onClick = onPayClick,
                     enabled = isPayButtonAvailable,

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/components/AutoMessageBubble.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/components/AutoMessageBubble.kt
@@ -54,7 +54,7 @@ fun AutoMessageBubble(isSender: Boolean, type: AutoMessageType, onPayClick: () -
             .widthIn(max = LocalConfiguration.current.screenWidthDp.dp * 0.6f)
             .clip(RoundedCornerShape(20.dp))
             .background(if(isSender) PrimaryBlue500 else Color.White)
-            .padding(vertical = 12.dp, horizontal = 12.dp)
+            .padding(vertical = 16.dp, horizontal = 18.dp)
     ) {
         Column {
             Text(

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/components/ReceivedMessageBubble.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/components/ReceivedMessageBubble.kt
@@ -52,8 +52,8 @@ fun ReceivedMessageBubble(msg: String, sentAt: String, senderNickname: String, o
             )
             Row(verticalAlignment = Alignment.Bottom) {
                 when (msg) {
-                    AutoMessageType.REQUEST_ACCEPT.code -> {
-                        AutoMessageBubble(false, AutoMessageType.REQUEST_ACCEPT, onPayClick = onPayClick)
+                    AutoMessageType.REQUEST_ACCEPTED.code -> {
+                        AutoMessageBubble(false, AutoMessageType.REQUEST_ACCEPTED, onPayClick = onPayClick)
                     }
                     AutoMessageType.COMPLETE_PAY.code -> {
                         AutoMessageBubble(false, AutoMessageType.COMPLETE_PAY)

--- a/app/src/main/java/com/example/rentit/presentation/chat/chatroom/components/SentMessageBubble.kt
+++ b/app/src/main/java/com/example/rentit/presentation/chat/chatroom/components/SentMessageBubble.kt
@@ -47,8 +47,8 @@ fun SentMessageBubble(msg: String, sentAt: String) {
             color = Gray400
         )
         when (msg) {
-            AutoMessageType.REQUEST_ACCEPT.code -> {
-                AutoMessageBubble(true, AutoMessageType.REQUEST_ACCEPT)
+            AutoMessageType.REQUEST_ACCEPTED.code -> {
+                AutoMessageBubble(true, AutoMessageType.REQUEST_ACCEPTED)
             }
             AutoMessageType.COMPLETE_PAY.code -> {
                 AutoMessageBubble(true, AutoMessageType.COMPLETE_PAY)

--- a/app/src/main/java/com/example/rentit/presentation/pay/PayRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/pay/PayRoute.kt
@@ -43,6 +43,9 @@ fun PayRoute(navHostController: NavHostController, productId: Int, reservationId
                     PaySideEffect.ToastPayFailed -> {
                         Toast.makeText(context, context.getString(R.string.toast_pay_result_failed), Toast.LENGTH_SHORT).show()
                     }
+                    PaySideEffect.ToastPaidMessageSendSuccess -> {
+                        Toast.makeText(context, context.getString(R.string.toast_pay_result_paid_message_send_success), Toast.LENGTH_SHORT).show()
+                    }
                     PaySideEffect.NavigateBack -> {
                         navHostController.popBackStack()
                     }

--- a/app/src/main/java/com/example/rentit/presentation/pay/PaySideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/pay/PaySideEffect.kt
@@ -2,6 +2,7 @@ package com.example.rentit.presentation.pay
 
 sealed class PaySideEffect {
     data object ToastPayFailed : PaySideEffect()
+    data object ToastPaidMessageSendSuccess : PaySideEffect()
     data object NavigateBack : PaySideEffect()
     data class CommonError(val throwable: Throwable): PaySideEffect()
 }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailRoute.kt
@@ -104,6 +104,9 @@ fun RentalDetailRoute(navHostController: NavHostController, productId: Int, rese
                     RentalDetailSideEffect.ToastAcceptRentalFailed -> {
                         Toast.makeText(context, R.string.toast_accept_rental_failed, Toast.LENGTH_SHORT).show()
                     }
+                    RentalDetailSideEffect.ToastAcceptedMessageSendSuccess -> {
+                        Toast.makeText(context, R.string.toast_accepted_message_send_success, Toast.LENGTH_SHORT).show()
+                    }
                     RentalDetailSideEffect.ToastChatRoomError -> {
                         Toast.makeText(context, R.string.toast_chat_room_error, Toast.LENGTH_SHORT).show()
                     }

--- a/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/rentaldetail/RentalDetailSideEffect.kt
@@ -19,6 +19,7 @@ sealed class RentalDetailSideEffect {
     data object ToastCancelRentalFailed: RentalDetailSideEffect()
     data object ToastAcceptRentalSuccess: RentalDetailSideEffect()
     data object ToastAcceptRentalFailed: RentalDetailSideEffect()
+    data object ToastAcceptedMessageSendSuccess: RentalDetailSideEffect()
     data object ToastChatRoomError: RentalDetailSideEffect()
     data class CommonError(val throwable: Throwable): RentalDetailSideEffect()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -516,6 +516,7 @@
     <string name="dialog_pay_result_success_title">결제가 정상적으로 완료됐어요</string>
     <string name="dialog_pay_result_btn_confirm">완료</string>
     <string name="toast_pay_result_failed">결제 처리 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.</string>
+    <string name="toast_pay_result_paid_message_send_success">결제 완료되어 안내 메세지가 발송되었어요</string>
 
     <string name="error_mypage_new_chatroom">채팅방 생성에 실패했어요.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="common_dialog_accept_request_btn_accept">수락하기</string>
     <string name="toast_accept_rental_success">대여 요청이 정상적으로 승인되었어요.</string>
     <string name="toast_accept_rental_failed">요청 수락에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
+    <string name="toast_accepted_message_send_success">요청이 수락되어 안내 메세지가 발송되었어요</string>
     <string name="toast_chat_room_error">채팅방을 찾을 수 없어요.</string>
 
     <string name="common_calendar_left_chevron_description">다음달로 이동</string>


### PR DESCRIPTION
# Pull Request

## Summary  
- 요청 수락 시, 결제 완료 시 자동 메세지 전송 구현

## Related Issue  
- Close: #185

## Changes  
- `AutoMessageType.REQUEST_ACCEPT` → `REQUEST_ACCEPTED`로 이름 변경

**결제 완료 자동 메시지 전송**
- 결제 완료 시 해당 채팅방에 자동으로 결제 완료 메시지 전송
- `PayViewModel`에서 `WebSocketManager`를 사용하여 렌탈 상태 업데이트 후 메시지 전송
- 사용자에게 메시지 전송 완료를 확인시키는 토스트 표시
- `WebSocketManager` 인터페이스 및 구현 리팩토링: `chatroomId` → `chatRoomId`로 파라미터명 변경

**렌탈 수락 시 자동 메시지 전송**
- 렌탈 요청이 수락되면 WebSocket을 통해 대여자에게 결제 안내 메시지 자동 전송
- 소유자에게 메시지 전송 완료를 확인시키는 토스트 표시
- `RentalDetailViewModel`에서 요청 수락 시 WebSocket 연결 및 메시지 전송 구현
- 관련 채팅 컴포넌트 업데이트
- `ToastAcceptedMessageSendSuccess` 사이드 이펙트 및 문자열 리소스 추가
 
## Screenshots
<img width="300" src="https://github.com/user-attachments/assets/dd1d2de1-f2e1-4426-b88d-24010d3da320"/>

## Notes  
- 이 자동 메세지는 옵션 기능이므로 별도로 메세지 전송 실패에 대응하지 않았음