### PR TITLE
New branch

### DIFF
--- a/app/src/main/java/com/example/rentit/navigation/productdetail/ProductDetailNavigation.kt
+++ b/app/src/main/java/com/example/rentit/navigation/productdetail/ProductDetailNavigation.kt
@@ -11,7 +11,7 @@ import com.example.rentit.navigation.bottomtab.BottomTabRoute
 import com.example.rentit.presentation.productdetail.ProductDetailRoute
 import com.example.rentit.presentation.productdetail.rentalhistory.RentalHistoryRoute
 import com.example.rentit.presentation.productdetail.reservation.ReservationRoute
-import com.example.rentit.presentation.productdetail.reservation.complete.ReservationCompleteScreen
+import com.example.rentit.presentation.productdetail.reservation.complete.ReservationCompleteRoute
 
 fun NavHostController.navigateToProductDetail(productId: Int) {
     navigate(
@@ -36,15 +36,19 @@ fun NavHostController.navigateToReservation(productId: Int) {
 }
 
 fun NavHostController.navigateToReservationComplete(
+    productId: Int = 0,
+    reservationId: Int = 0,
     rentalStartDate: String = "",
     rentalEndDate: String = "",
-    formattedTotalPrice: String = "0",
+    totalPrice: Int = 0
 ) {
     navigate(
         route = ProductDetailRoute.ReservationComplete(
+            productId,
+            reservationId,
             rentalStartDate,
             rentalEndDate,
-            formattedTotalPrice
+            totalPrice
         )
     )
 }
@@ -67,11 +71,13 @@ fun NavGraphBuilder.productDetailGraph(navHostController: NavHostController) {
     }
     composable<ProductDetailRoute.ReservationComplete> { backStackEntry ->
         val items: ProductDetailRoute.ReservationComplete = backStackEntry.toRoute()
-        ReservationCompleteScreen(
+        ReservationCompleteRoute(
             navHostController,
+            items.productId,
+            items.reservationId,
             items.rentalStartDate,
             items.rentalEndDate,
-            items.formattedTotalPrice
+            items.totalPrice
         )
     }
     composable<ProductDetailRoute.RentalHistory> { backStackEntry ->

--- a/app/src/main/java/com/example/rentit/navigation/productdetail/ProductDetailRoute.kt
+++ b/app/src/main/java/com/example/rentit/navigation/productdetail/ProductDetailRoute.kt
@@ -12,9 +12,11 @@ sealed class ProductDetailRoute {
 
     @Serializable
     data class ReservationComplete(
+        val productId: Int,
+        val reservationId: Int,
         val rentalStartDate: String,
         val rentalEndDate: String,
-        val formattedTotalPrice: String,
+        val totalPrice: Int,
     ) : ProductDetailRoute()
 
     @Serializable

--- a/app/src/main/java/com/example/rentit/navigation/rentaldetail/RentalDetailNavigation.kt
+++ b/app/src/main/java/com/example/rentit/navigation/rentaldetail/RentalDetailNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.example.rentit.navigation.bottomtab.BottomTabRoute
 import com.example.rentit.presentation.rentaldetail.RentalDetailRoute
 import com.example.rentit.presentation.rentaldetail.photobeforerent.PhotoBeforeRentRoute
 import com.example.rentit.presentation.rentaldetail.rentalphotocheck.RentalPhotoCheckRoute
@@ -15,6 +16,16 @@ fun NavHostController.navigateToRentalDetail(productId: Int, reservationId: Int)
     navigate(
         route = RentalDetailRoute.RentalDetail(productId, reservationId)
     )
+}
+
+fun NavHostController.navigateToRentalDetailPopUpToHome(productId: Int, reservationId: Int) {
+    navigate(
+        route = RentalDetailRoute.RentalDetail(productId, reservationId)
+    ) {
+        popUpTo(BottomTabRoute.Home.route) {
+            inclusive = false
+        }
+    }
 }
 
 fun NavHostController.navigateToRentalPhotoCheck(productId: Int, reservationId: Int) {

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationRoute.kt
@@ -17,7 +17,6 @@ import androidx.navigation.NavHostController
 import com.example.rentit.R
 import com.example.rentit.common.component.dialog.BaseDialog
 import com.example.rentit.common.component.layout.LoadingScreen
-import com.example.rentit.common.util.formatPrice
 import com.example.rentit.navigation.productdetail.navigateToReservationComplete
 import com.example.rentit.presentation.main.MainViewModel
 
@@ -44,9 +43,11 @@ fun ReservationRoute(navHostController: NavHostController, productId: Int) {
                 when (it) {
                     is ReservationSideEffect.NavigateToReservationComplete -> {
                         navHostController.navigateToReservationComplete(
+                            productId = productId,
+                            reservationId = it.reservationId,
                             rentalStartDate = it.rentalStartDate,
                             rentalEndDate = it.rentalEndDate,
-                            formattedTotalPrice = formatPrice(it.totalPrice)
+                            totalPrice = it.totalPrice
                         )
                     }
                     ReservationSideEffect.ToastInvalidPeriod -> {

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationRoute.kt
@@ -73,6 +73,7 @@ fun ReservationRoute(navHostController: NavHostController, productId: Int) {
         rentalPrice = uiState.totalRentalPrice,
         totalPrice = uiState.totalPrice,
         deposit = uiState.deposit,
+        isRequestButtonEnabled = uiState.isRequestButtonEnabled,
         onBackClick = navHostController::popBackStack,
         onReservationClick = { viewModel.postResv(productId) },
         onSetRentalStartDate = viewModel::setRentalStartDate,

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationScreen.kt
@@ -51,6 +51,7 @@ fun ReservationScreen(
     rentalPrice: Int = 0,
     totalPrice: Int = 0,
     deposit: Int = 0,
+    isRequestButtonEnabled: Boolean = true,
     onBackClick: () -> Unit,
     onReservationClick: () -> Unit,
     onSetRentalStartDate: (LocalDate?) -> Unit,
@@ -71,6 +72,7 @@ fun ReservationScreen(
                 text = stringResource(id = R.string.screen_resv_request_btn_resv_request),
                 containerColor = PrimaryBlue500,
                 contentColor = Color.White,
+                enabled = isRequestButtonEnabled,
                 onClick = onReservationClick
             )
         }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationSideEffect.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationSideEffect.kt
@@ -2,6 +2,7 @@ package com.example.rentit.presentation.productdetail.reservation
 
 sealed class ReservationSideEffect {
     data class NavigateToReservationComplete(
+        val reservationId: Int,
         val rentalStartDate: String,
         val rentalEndDate: String,
         val totalPrice: Int

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationState.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationState.kt
@@ -15,6 +15,7 @@ data class ReservationState(
     val deposit: Int = 0,
     val reservedDateList: List<String> = emptyList(),
     val isLoading: Boolean = false,
+    val isRequestButtonEnabled: Boolean = true,
     val showAccessNotAllowedDialog: Boolean = false,
     val showResvAlreadyExistDialog: Boolean = false
 ) {

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationViewModel.kt
@@ -90,7 +90,6 @@ class ReservationViewModel @Inject constructor(
         val selectedPeriod = _uiState.value.selectedPeriod
         val minPeriod = _uiState.value.minPeriod
         val maxPeriod = _uiState.value.maxPeriod
-        val totalPrice = _uiState.value.totalPrice
 
         viewModelScope.launch {
             setLoading(true)
@@ -105,9 +104,10 @@ class ReservationViewModel @Inject constructor(
             ).onSuccess {
                 emitSideEffect(
                     ReservationSideEffect.NavigateToReservationComplete(
+                        reservationId = it.data.reservationId,
                         rentalStartDate = startDate,
                         rentalEndDate = endDate,
-                        totalPrice = totalPrice
+                        totalPrice = it.data.totalAmount
                     )
                 )
                 Log.i(TAG, "대여 예약 성공: ${it.data.reservationId}")

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationViewModel.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/ReservationViewModel.kt
@@ -93,6 +93,8 @@ class ReservationViewModel @Inject constructor(
         val totalPrice = _uiState.value.totalPrice
 
         viewModelScope.launch {
+            setLoading(true)
+            setRequestButtonEnable(false)
             postReservationUseCase(
                 productId = productId,
                 minPeriod = minPeriod,
@@ -113,6 +115,8 @@ class ReservationViewModel @Inject constructor(
                 Log.e(TAG, "대여 예약 실패", e)
                 handlePostResvError(e)
             }
+            setRequestButtonEnable(true)
+            setLoading(false)
         }
     }
 
@@ -147,5 +151,9 @@ class ReservationViewModel @Inject constructor(
 
     fun dismissResvAlreadyExistDialog() {
         _uiState.value = _uiState.value.copy(showResvAlreadyExistDialog = false)
+    }
+
+    fun setRequestButtonEnable(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(isRequestButtonEnabled = enabled)
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/complete/ReservationCompleteRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/complete/ReservationCompleteRoute.kt
@@ -1,0 +1,25 @@
+package com.example.rentit.presentation.productdetail.reservation.complete
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import com.example.rentit.navigation.rentaldetail.navigateToRentalDetailPopUpToHome
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun ReservationCompleteRoute(
+    navHostController: NavHostController,
+    productId: Int,
+    reservationId: Int,
+    rentalStartDate: String,
+    rentalEndDate: String,
+    totalPrice: Int
+) {
+    ReservationCompleteScreen(
+        rentalStartDate = rentalStartDate,
+        rentalEndDate = rentalEndDate,
+        totalPrice = totalPrice,
+        onConfirmClick = { navHostController.navigateToRentalDetailPopUpToHome(productId, reservationId) }
+    )
+}

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/complete/ReservationCompleteScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/complete/ReservationCompleteScreen.kt
@@ -14,12 +14,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.example.rentit.R
 import com.example.rentit.common.component.CommonButton
 import com.example.rentit.common.component.CommonDivider
@@ -29,17 +28,17 @@ import com.example.rentit.common.theme.Gray100
 import com.example.rentit.common.theme.Gray800
 import com.example.rentit.common.theme.PrimaryBlue500
 import com.example.rentit.common.theme.RentItTheme
+import com.example.rentit.common.util.formatPrice
 import com.example.rentit.common.util.formatRentalPeriod
-import com.example.rentit.navigation.bottomtab.navigateToHome
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun ReservationCompleteScreen(
-    navHostController: NavHostController,
     rentalStartDate: String,
     rentalEndDate: String,
-    formattedTotalPrice: String,
-    ) {
+    totalPrice: Int,
+    onConfirmClick: () -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -59,7 +58,7 @@ fun ReservationCompleteScreen(
             horizontalArrangement = Arrangement.SpaceBetween) {
             Text(text = stringResource(
                 id = R.string.screen_request_confirm_resv_period), style = MaterialTheme.typography.bodyLarge)
-            Text(text = formatRentalPeriod(navHostController.context, rentalStartDate, rentalEndDate), style = MaterialTheme.typography.bodyMedium, color = Gray800)
+            Text(text = formatRentalPeriod(LocalContext.current, rentalStartDate, rentalEndDate), style = MaterialTheme.typography.bodyMedium, color = Gray800)
         }
         CommonDivider()
         Row(modifier = Modifier
@@ -69,13 +68,17 @@ fun ReservationCompleteScreen(
             horizontalArrangement = Arrangement.SpaceBetween) {
             Text(text = stringResource(
                 id = R.string.screen_request_confirm_total_price), style = MaterialTheme.typography.bodyLarge)
-            Text(text = "$formattedTotalPrice 원",
+            Text(text = "${formatPrice(totalPrice)} 원",
                 style = MaterialTheme.typography.bodyLarge,
                 color = PrimaryBlue500)
         }
-        CommonButton(text = "완료", containerColor = Gray100, contentColor = AppBlack, modifier = Modifier.padding(top = 52.dp)) {
-            navHostController.navigateToHome()
-        }
+        CommonButton(
+            text = "완료",
+            containerColor = Gray100,
+            contentColor = AppBlack,
+            modifier = Modifier.padding(top = 52.dp),
+            onClick = onConfirmClick
+        )
     }
 }
 
@@ -85,10 +88,10 @@ fun ReservationCompleteScreen(
 private fun Preview() {
     RentItTheme {
         ReservationCompleteScreen(
-            rememberNavController(),
             rentalStartDate = "2025-07-12",
             rentalEndDate = "2025-07-16",
-            formattedTotalPrice = "45,000"
+            totalPrice = 45_000,
+            {}
         )
     }
 }

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/components/DateRangePicker.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/reservation/components/DateRangePicker.kt
@@ -117,7 +117,7 @@ fun TotalPeriodText(period: Int) {
 @Composable
 fun DateBox(date: String, isSelectingDate: Boolean, onDateClick: () -> Unit) {
     Box(modifier = Modifier
-        .width(120.dp)
+        .width(110.dp)
         .height(40.dp)
         .basicRoundedGrayBorder(if (isSelectingDate) PrimaryBlue500 else Gray200)
         .clip(RoundedCornerShape(20.dp))


### PR DESCRIPTION
# Pull Request

## Summary  
- 예약 요청 중 버튼을 비활성화하고, 예약 완료 후 홈 대신 렌탈 상세 화면으로 바로 이동하도록 구현. 
- 백스택 정리와 `ReservationCompleteRoute` 적용, 총 금액 API 데이터 사용, 네비게이션 액션 추가

## Related Issue  
- Close: #179

## Changes  
**예약 요청 버튼 비활성화 및 로딩 처리**
- 예약 요청 중에는 "예약 요청" 버튼을 비활성화하여 중복 제출 방지
- `ReservationState`에 `isRequestButtonEnabled` 추가하여 버튼 상태 관리
- `ReservationViewModel`에서 네트워크 요청 전 버튼 비활성화, 요청 완료/실패 시 재활성화

**예약 완료 후 렌탈 상세 화면으로 이동**
- 예약 완료 후 홈 대신 해당 예약의 **렌탈 상세 화면으로 이동**
- 백스택을 홈까지 정리하여 뒤로가면 홈으로 복귀
- `ReservationCompleteRoute` 도입으로 `ReservationCompleteScreen`을 **stateless composable**로 변경
- `productId`와 `reservationId`를 경로에 추가하여 올바른 상세 화면으로 이동 가능
- 완료 화면 총 금액을 **예약 API 응답 데이터**에서 직접 사용
- 새로운 네비게이션 액션 `navigateToRentalDetailPopUpToHome` 추가하여 플로우와 백스택 관리
