### PR TITLE
Fix/191 product detail ui

### DIFF
--- a/app/src/main/java/com/example/rentit/common/component/item/ProductListItem.kt
+++ b/app/src/main/java/com/example/rentit/common/component/item/ProductListItem.kt
@@ -53,7 +53,7 @@ fun ProductListItem(
         if (categories.isNotEmpty()) {
             categories.joinToString(" · ")
         } else {
-            stringResource(R.string.product_list_item_text_empty_category)
+            stringResource(R.string.common_empty_category)
         }
 
     Box(

--- a/app/src/main/java/com/example/rentit/presentation/productdetail/ProductDetailScreen.kt
+++ b/app/src/main/java/com/example/rentit/presentation/productdetail/ProductDetailScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.rentit.R
@@ -213,28 +214,19 @@ fun ImagePager(pagerState: PagerState, imgUrlList: List<String?>, onClick: () ->
 
 
 @Composable
-fun PostHeader(title: String, category: List<String>, creationDate: String, onLikeClick: () -> Unit, onShareClick: () -> Unit) {
+fun PostHeader(title: String, categories: List<String>, creationDate: String, onLikeClick: () -> Unit, onShareClick: () -> Unit) {
     Row(Modifier
         .fillMaxWidth()
         .screenHorizontalPadding()
-        .padding(vertical = 16.dp),
+        .padding(top = 16.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.Bottom
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Column {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
-            ) {
-                Text(text = title, style = MaterialTheme.typography.bodyLarge)
-            }
-            Text(
-                modifier = Modifier.padding(top = 5.dp),
-                text = "${category.joinToString(" · ") }  $creationDate",
-                style = MaterialTheme.typography.labelMedium,
-                color = Gray400
-            )
-        }
+        Text(
+            modifier = Modifier.weight(1f, false),
+            text = title,
+            style = MaterialTheme.typography.bodyLarge
+        )
         Row(modifier = Modifier.offset(x = 10.dp), verticalAlignment = Alignment.CenterVertically) {
             IconButton(onLikeClick) {
                 Image(
@@ -249,6 +241,26 @@ fun PostHeader(title: String, category: List<String>, creationDate: String, onLi
                 )
             }
         }
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth().screenHorizontalPadding().padding(bottom = 20.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Text(
+            modifier = Modifier.weight(1f, false),
+            text = if(categories.isNotEmpty()) categories.joinToString(" · ") else stringResource(R.string.common_empty_category),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.labelMedium,
+            color = Gray400
+        )
+
+        Text(
+            text = creationDate,
+            style = MaterialTheme.typography.labelMedium,
+            color = Gray400
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="common_loadable_uri_img_content_description">사진</string>
     <string name="common_tag_btn_icon_check_description">선택된 태그</string>
     <string name="common_removable_tag_btn_icon_delete_description">태그 지우기</string>
+    <string name="common_empty_category">카테고리 없음</string>
 
     <string name="common_dialog_btn_close">닫기</string>
 
@@ -124,7 +125,6 @@
     <string name="screen_main_btn_create_post_content_description">상품 등록</string>
 
     <!-- 게시글 리스트 아이템 -->
-    <string name="product_list_item_text_empty_category">카테고리 없음</string>
     <string name="product_list_item_period_btn_check_request">요청 확인하기</string>
 
     <!-- 홈 -->


### PR DESCRIPTION
# Pull Request

## Summary  
상품 상세 화면 `PostHeader` 레이아웃을 개선하여 긴 제목과 많은 카테고리에서도 UI가 깨지지 않도록 수정

## Related Issue  
- Close: #191 

## Changes  
**상품 상세 화면 PostHeader 레이아웃 개선**
- `PostHeader` 컴포저블을 리팩토링: 제목/액션 버튼과 카테고리/작성일을 각각 두 줄로 분리
- 긴 제목이나 많은 카테고리에서 발생하는 UI 문제 방지
- 카테고리 텍스트가 너무 길면 말줄임표(...) 처리
- "카테고리 없음" 텍스트를 `common_empty_category` 공통 문자열 리소스로 통합
- `ProductListItem`에서 새로운 공통 문자열 사용 (카테고리 없음)

## Screenshots
- 수정 전-후
<img width="200" src="https://github.com/user-attachments/assets/5f7cc55d-0ed3-40b1-aa44-bf311b30cd6a"/>
<img width="200" src="https://github.com/user-attachments/assets/d40ab00a-af04-43d4-8f83-e539a308bb4d"/>
