### PR TITLE
Bugfix / 207 First Google Login Fail

### DIFF
--- a/app/src/main/java/com/example/rentit/presentation/auth/login/LoginRoute.kt
+++ b/app/src/main/java/com/example/rentit/presentation/auth/login/LoginRoute.kt
@@ -77,6 +77,7 @@ fun launchGoogleSignIn(launcher: ManagedActivityResultLauncher<Intent, ActivityR
     val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
         .requestIdToken(BuildConfig.GOOGLE_CLIENT_ID)
         .requestServerAuthCode(BuildConfig.GOOGLE_CLIENT_ID)
+        .requestEmail()
         .build()
     val googleSignInClient = GoogleSignIn.getClient(context, gso)
     launcher.launch(googleSignInClient.signInIntent)    // Google Login Intent 실행


### PR DESCRIPTION
# Pull Request

## Summary  
최초 구글 로그인 실패 이슈의 원인을 파악(이메일 요청 누락)하고 이메일 요청 옵션을 추가

## Related Issue  
- Closed: #207 

## Changes  
- GoogleSignIn에 `.requestEmail()` 옵션 추가
